### PR TITLE
feat: track credits, heals, and preserve early-leave stats

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -2507,6 +2507,10 @@ void Player::Tick(World & world){
 									if(shield < maxshield){
 										shield = maxshield;
 									}
+									Peer * peer = GetPeer(world);
+									if(peer){
+										peer->stats.healsdone++;
+									}
 								}
 							}
 						}
@@ -2527,6 +2531,7 @@ void Player::Tick(World & world){
 								Peer * peer = GetPeer(world);
 								if(peer){
 									peer->stats.filesreturned += files;
+									peer->stats.creditsmade += creditamount;
 								}
 								files = 0;
 								oldfiles = 0;
@@ -3295,6 +3300,8 @@ bool Player::BuyItem(World & world, Uint8 id){
 		if(bought){
 			EmitSound(world, world.resources.soundbank["reload2.wav"], 96);
 			world.BuyItem(id);
+			Peer * peer = GetPeer(world);
+			if(peer) peer->stats.creditsspent += buyableitem->price;
 			credits -= buyableitem->price;
 			return true;
 		}
@@ -3324,6 +3331,8 @@ bool Player::RepairItem(World & world, Uint8 id){
 			team->disabledtech &= ~(buyableitem->techchoice);
 			EmitSound(world, world.resources.soundbank["reload2.wav"], 96);
 			world.RepairItem(id);
+			Peer * peer = GetPeer(world);
+			if(peer) peer->stats.creditsspent += buyableitem->repairprice;
 			credits -= buyableitem->repairprice;
 			return true;
 		}

--- a/src/stats.cpp
+++ b/src/stats.cpp
@@ -35,6 +35,9 @@ Stats::Stats(){
 	virusesused = 0;
 	fileshacked = 0;
 	filesreturned = 0;
+	creditsmade = 0;
+	creditsspent = 0;
+	healsdone = 0;
 }
 
 void Stats::Serialize(bool write, Serializer & data, Serializer * old){
@@ -72,6 +75,9 @@ void Stats::Serialize(bool write, Serializer & data, Serializer * old){
 	data.Serialize(write, virusesused, old);
 	data.Serialize(write, fileshacked, old);
 	data.Serialize(write, filesreturned, old);
+	data.Serialize(write, creditsmade, old);
+	data.Serialize(write, creditsspent, old);
+	data.Serialize(write, healsdone, old);
 }
 
 Uint32 Stats::CalculateExperience(void){

--- a/src/stats.h
+++ b/src/stats.h
@@ -42,6 +42,9 @@ public:
 	Uint32 virusesused;
 	Uint32 fileshacked;
 	Uint32 filesreturned;
+	Uint32 creditsmade;
+	Uint32 creditsspent;
+	Uint32 healsdone;
 };
 
 #endif

--- a/src/world.cpp
+++ b/src/world.cpp
@@ -1155,6 +1155,19 @@ void World::HandleDisconnect(Uint8 peerid){
 		}
 	}else
 	if(mode == AUTHORITY){
+		// If a player disconnects mid-game, record their partial stats immediately
+		// so their progress isn't lost (won=0 since they left before the game ended).
+		if(gameplaystate == INGAME && peerlist[peerid]->accountid != 0){
+			Peer * leavingPeer = peerlist[peerid];
+			User * user = lobby.GetUserInfo(leavingPeer->accountid);
+			Team * team = GetPeerTeam(peerid);
+			if(user && team){
+				user->statscopy = leavingPeer->stats;
+				user->statsagency = team->agency;
+				user->teamnumber = team->number;
+				lobby.RegisterStats(*user, 0, gameinfo.id);
+			}
+		}
 		delete peerlist[peerid];
 		peerlist[peerid] = 0;
 		peercount--;


### PR DESCRIPTION
## Summary

This PR adds three new gameplay statistics and fixes stat loss for players who disconnect mid-game.

### New Stats Tracked

| Stat | Description |
|------|-------------|
| `creditsmade` | Credits earned at the credit machine (files × contacts bonus) |
| `creditsspent` | Credits spent buying items or repairing tech |
| `healsdone` | Heal machine activations (restores health + shield) |

### Early-Leave Stat Preservation (`world.cpp`)

Previously, players who disconnected before a game ended lost all accumulated stats for that match — kills, deaths, objectives, tech usage, etc. The end-of-game loop only registered stats for peers still present.

**Fix:** In `HandleDisconnect` (AUTHORITY mode), before the peer is deleted, if the game is in progress the player's current stats are immediately sent to the lobby server with `won=0`.

### Files Changed
- `src/stats.h` — 3 new fields: `creditsmade`, `creditsspent`, `healsdone`
- `src/stats.cpp` — initialize + serialize new fields (blob: 136 → 148 bytes)
- `src/player.cpp` — increment stats at credit machine, buy/repair, heal machine
- `src/world.cpp` — `HandleDisconnect`: register partial stats on mid-game disconnect