### PR TITLE
Plan: monorepo restructure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,86 +1,50 @@
-# zSILENCER
+# Silencer
 
-Multiplayer 2D action game (C++/SDL2) plus a self-hosted Go lobby server
-that replaces the defunct `lobby.zsilencer.com`.
+Multiplayer 2D action game (C++/SDL2) plus a self-hosted Go lobby
+server, an admin web app (Next.js), and an admin API (Bun+TS).
+Rebranded from zSILENCER — use "Silencer" in new content, rename
+old identifiers opportunistically when touching the file.
 
-## Commands
+## Tech stack
 
-```bash
-# Build the client (Linux/macOS)
-cd build && cmake .. && make
-
-# Build the lobby server (stdlib only, no deps)
-cd server && go build       # → ./zsilencer-lobby
-
-# Run a local lobby + game
-sudo ./server/zsilencer-lobby -addr :517 -game-binary ./build/zsilencer
-./build/zsilencer
-```
-
-Windows: open `zSILENCER.sln` in Visual Studio; SDL2 + SDL2_mixer dev
-libs must be on the VS include/lib path.
-
-Runtime deps (client): SDL2, SDL2_mixer, zlib.
+- Game client: C++14 / SDL2 / CMake
+- Lobby server: Go (stdlib only)
+- Admin web + API: Bun + TypeScript + oxfmt
+- Infra: Docker Compose, Terraform (AWS)
 
 ## Layout
 
-- `src/` — C++ client (~159 files, CMake, C++14). Entry: `src/main.cpp`.
-- `server/` — Go lobby server. Entry: `server/main.go`.
-- `data/` — runtime assets (sprites, tiles, sounds, palette).
-- `res/` — app icons.
-- `build/` — out-of-tree CMake build dir (contains `zsilencer` binary).
-- `terraform/` — AWS infra (EC2 + EBS + cloud-init + Tailscale). See
-  `terraform/CLAUDE.md`.
-- `docs/production.md` — production setup guide: stand up your own
-  lobby from scratch, CI wiring, day-2 ops, failure modes.
-- `scripts/fastdeploy.sh` — bypass CI: rsync → build on the box → swap
-  binary → restart `zsilencer-lobby`. Debug-only; prod goes through
-  `.github/workflows/deploy.yml`.
-- `.github/workflows/` — `deploy.yml` (tag `v*` → ARM64 lobby build →
-  scp over Tailscale → symlink swap); `release.yml` (macOS + Windows
-  client zips).
+Each component owns its own `CLAUDE.md` with build/run/test/gotchas:
 
-Protocol constants and lobby wire format are in `src/lobby.cpp`,
-`src/lobbygame.cpp`, and `server/protocol.go`.
+- `clients/silencer/` — C++ game + dedicated server (same binary)
+- `services/lobby/` — Go lobby server
+- `services/admin-api/` — Express → Bun+TS admin backend
+- `web/admin/` — Next.js admin dashboard + level designer
+- `shared/data/` — runtime assets (sprites, tiles, sounds)
+- `infra/terraform/` — AWS infra
 
-## Dedicated-server contract
+> Layout migration in progress. See
+> [docs/plans/2026-04-25-monorepo-restructure.md](docs/plans/2026-04-25-monorepo-restructure.md).
 
-The same `zsilencer` binary runs the client and, when launched with
-`-s`, a headless dedicated server:
+## Universal rules
 
-```
-zsilencer -s <lobbyaddr> <lobbyport> <gameid> <accountid>
-```
+1. **JavaScript = Bun + TypeScript + oxfmt.** No `node`,
+   `npm`/`pnpm`/`yarn`, `.js` source, or alternative formatters.
+   Migrate as you touch.
+2. **Every component dir has a `CLAUDE.md`** with an `AGENTS.md`
+   symlink alongside (one-line stub on Windows). Keep them
+   identical.
+3. **No backwards-compat shims during refactors** unless asked.
+   Update everything to the new design and delete the old.
+4. **Verify end-to-end before claiming done** for cross-service
+   features. Real request through the full stack.
+5. **Ask early when ambiguous.** Cheaper than redoing it.
 
-- Parsed in `src/main.cpp:160` → `src/game.cpp:132`.
-- Spawned by the Go lobby in `server/proc.go` on each `MSG_NEWGAME`.
-- Dedicated mode skips `SDL_Init(VIDEO)` and audio; RSS ~12 MB.
-- Heartbeats UDP to the lobby: `[0x00][gameid u32][port u16][state u8]`.
-  If no heartbeat in 30 s, the lobby aborts the create.
+## More
 
-## Gotchas
-
-- **Lobby host is a compile-time constant.** Baked in via
-  `-DZSILENCER_LOBBY_HOST=<host> -DZSILENCER_LOBBY_PORT=<port>` (see
-  `CMakeLists.txt:48`, used at `src/game.cpp:4018`/`:4032`). Default is
-  `127.0.0.1:517`. CI sets it to `silencer.hventura.com`; rebuild the
-  client to point at a different lobby.
-- **Version string must match.** Client sets it at `src/game.cpp:31`
-  (`world.SetVersion("00024")`); the lobby's `-version` flag defaults
-  to the same. Bump both together, or pass `-version ""` on the server
-  to accept any client. `CMakeLists.txt` `CPACK_PACKAGE_VERSION` is
-  installer metadata only — unrelated to the wire handshake.
-- **Port 517 needs root on macOS/Linux.** For local dev, rebuild with
-  `-DZSILENCER_LOBBY_PORT=15170` and run the lobby on `:15170`.
-- **Data dir on macOS.** Client `chdir`s to
-  `~/Library/Application Support/zSILENCER` at startup
-  (`src/main.cpp` `CDDataDir`) — copy `data/` there or run from the
-  repo with the binary in place.
-- **Android/Ouya code paths exist** in `src/main.cpp` but are not
-  actively maintained; don't rely on them.
-
-## Lobby storage
-
-Users and per-agency stats live in `lobby.json` (flat file, atomic
-writes, SHA-1 hashed passwords). Swap for SQLite/Postgres in
-`server/store.go` if traffic grows.
+- Writing CLAUDE.md well: [docs/writing-a-good-claude-md.md](docs/writing-a-good-claude-md.md)
+- Production setup: `docs/production.md`
+- UI design system + asset formats: `docs/design-system.md`
+- Intent docs: `docs/plans/`
+- TDD execution plans: `docs/superpowers/plans/`
+- Specs: `docs/superpowers/specs/`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,8 @@ Each component owns its own `CLAUDE.md` with build/run/test/gotchas:
 - `services/lobby/` — Go lobby server
 - `services/admin-api/` — Express → Bun+TS admin backend
 - `web/admin/` — Next.js admin dashboard + level designer
-- `shared/data/` — runtime assets (sprites, tiles, sounds)
+- `shared/assets/` — runtime game assets (sprites, tiles, sounds, levels)
+- `shared/icons/` — app icons used by `clients/silencer` build
 - `infra/terraform/` — AWS infra
 
 > Layout migration in progress. See

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ old identifiers opportunistically when touching the file.
 ## Tech stack
 
 - Game client: C++14 / SDL2 / CMake
-- Lobby server: Go (stdlib only)
+- Lobby server: Go (stdlib + `mongo-driver`/`amqp091-go`, both optional)
 - Admin web + API: Bun + TypeScript + oxfmt
 - Infra: Docker Compose, Terraform (AWS)
 

--- a/clients/cli/AGENTS.md
+++ b/clients/cli/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/clients/cli/CLAUDE.md
+++ b/clients/cli/CLAUDE.md
@@ -1,0 +1,7 @@
+# clients/cli — placeholder
+
+Reserved slot for a hypothetical headless CLI client used by coding
+agents to drive E2E tests of the game without SDL video/audio. Nothing
+here yet.
+
+See [../../docs/plans/2026-04-25-monorepo-restructure.md](../../docs/plans/2026-04-25-monorepo-restructure.md).

--- a/clients/silencer/AGENTS.md
+++ b/clients/silencer/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/clients/silencer/CLAUDE.md
+++ b/clients/silencer/CLAUDE.md
@@ -1,0 +1,7 @@
+# clients/silencer — placeholder
+
+Will house the C++ game client (same binary runs as dedicated server
+when invoked with `-s`) after the monorepo restructure. Code currently
+lives at `/src` with build files at `/CMakeLists.txt` and `/cmake`.
+
+See [../../docs/plans/2026-04-25-monorepo-restructure.md](../../docs/plans/2026-04-25-monorepo-restructure.md).

--- a/data/AGENTS.md
+++ b/data/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/docs/plans/2026-04-25-monorepo-restructure.md
+++ b/docs/plans/2026-04-25-monorepo-restructure.md
@@ -3,6 +3,13 @@
 **Status:** Proposed
 **Date:** 2026-04-25
 
+> **Naming note:** The product is being rebranded from **zSILENCER** to
+> **Silencer**. This plan uses the new name throughout. Renaming the
+> binary, the Windows solution (`zSILENCER.sln`), the macOS plist, the
+> CMake project, and the on-disk data directory
+> (`~/Library/Application Support/zSILENCER`) is a separate concern from
+> the directory restructure and is tracked in its own follow-up.
+
 ## Goal
 
 Reorganize the repository so its top-level layout reflects what each
@@ -30,7 +37,8 @@ left to the implementation PR.
 ## Desired End State
 
 ```
-zSilencer/
+silencer/                      # repo root (currently named zSilencer/
+                               #   on disk; rename tracked separately)
 ├── web/                       # Browser-shipped frontends
 │   ├── admin/                 # Next.js admin dashboard (now includes
 │   │                          #   the level designer route — designer
@@ -82,7 +90,9 @@ zSilencer/
 - Root-level `CMakeLists.txt`, `cmake/`, `resources.rc`,
   `vcpkg.json`, `.vcpkg/`, `zSILENCER.xcodeproj`, `zSILENCER-Info.plist`
   — these belong with the C++ client, so they move into
-  `clients/silencer/`.
+  `clients/silencer/`. (The `zSILENCER`-prefixed filenames are
+  rebranded to `Silencer` as part of the separate naming follow-up,
+  not this restructure.)
 
 ## Top-Level CLAUDE.md Rules to Add
 

--- a/docs/plans/2026-04-25-monorepo-restructure.md
+++ b/docs/plans/2026-04-25-monorepo-restructure.md
@@ -35,6 +35,9 @@ left to the implementation PR.
   coding agents; today there is nowhere obvious to put it.
 - Shared runtime assets (`data/`, `res/`) are consumed by multiple
   components but live at the root with no signal that they're shared.
+  They're also misnamed — `data/` is game assets (sprites/tiles/sounds/
+  levels), `res/` is just app icons. Renaming them as we move:
+  `data/` → `shared/assets/`, `res/` → `shared/icons/`.
 
 ## Desired End State
 
@@ -60,9 +63,9 @@ silencer/                      # repo root (currently named zSilencer/
 │                              #   driven E2E testing of the game
 │
 ├── shared/                    # Consumed by 2+ of the above
-│   ├── data/                  # Runtime assets — sprite/tile/sound
-│   │                          #   banks, levels (was data/)
-│   └── res/                   # App icons used by clients/silencer
+│   ├── assets/                # Runtime game assets — sprite/tile/sound
+│   │                          #   banks, levels, palette (was data/)
+│   └── icons/                 # App icons used by clients/silencer
 │                              #   build (was res/)
 │
 ├── infra/                     # How we build, package, and deploy
@@ -104,7 +107,7 @@ The top-level `CLAUDE.md` will gain three repository-wide conventions:
 
 Every directory that represents a distinct component
 (`web/admin/`, `web/website/`, `services/lobby/`, `services/admin-api/`,
-`clients/silencer/`, `clients/cli/`, `shared/data/`, `infra/terraform/`,
+`clients/silencer/`, `clients/cli/`, `shared/assets/`, `infra/terraform/`,
 etc.) gets its own `CLAUDE.md` describing:
 
 - What this component is and what consumes it

--- a/docs/plans/2026-04-25-monorepo-restructure.md
+++ b/docs/plans/2026-04-25-monorepo-restructure.md
@@ -1,0 +1,170 @@
+# Monorepo Restructure
+
+**Status:** Proposed
+**Date:** 2026-04-25
+
+## Goal
+
+Reorganize the repository so its top-level layout reflects what each
+directory actually *is* — a frontend, a backend service, a client-machine
+executable, or shared assets — rather than the current ad-hoc mix.
+
+This is an intent + end-state document. Concrete migration mechanics
+(updating `CMakeLists.txt` paths, `docker-compose.yml` build contexts,
+GitHub Actions workflows, deploy scripts, Xcode/VS project files) are
+left to the implementation PR.
+
+## Why
+
+- New contributors can't tell at a glance that `src/` is the C++ game
+  client, `server/` is the Go lobby, or that `admin/` contains both a
+  frontend and a backend.
+- The designer is being folded into the admin app, so the standalone
+  `designer/` directory will outlive its purpose.
+- A `website/` slot is wanted for a future public landing page.
+- We may add a CLI client for headless E2E testing of the game by
+  coding agents; today there is nowhere obvious to put it.
+- Shared runtime assets (`data/`, `res/`) are consumed by multiple
+  components but live at the root with no signal that they're shared.
+
+## Desired End State
+
+```
+zSilencer/
+├── web/                       # Browser-shipped frontends
+│   ├── admin/                 # Next.js admin dashboard (now includes
+│   │                          #   the level designer route — designer
+│   │                          #   is being merged into admin)
+│   └── website/               # Public landing page (placeholder slot)
+│
+├── services/                  # Backend services (deployed to a host)
+│   ├── lobby/                 # Go lobby server (was server/)
+│   └── admin-api/             # Express REST + WebSocket API
+│                              #   (was admin/api/)
+│
+├── clients/                   # Executables that run on a user's machine
+│   ├── silencer/              # C++ game client (was src/ + CMake bits).
+│   │                          #   Same binary runs as dedicated server
+│   │                          #   when invoked with -s.
+│   └── cli/                   # Hypothetical headless client for agent-
+│                              #   driven E2E testing of the game
+│
+├── shared/                    # Consumed by 2+ of the above
+│   ├── data/                  # Runtime assets — sprite/tile/sound
+│   │                          #   banks, levels (was data/)
+│   └── res/                   # App icons used by clients/silencer
+│                              #   build (was res/)
+│
+├── infra/                     # How we build, package, and deploy
+│   ├── terraform/             # AWS infra (was terraform/)
+│   ├── docker-compose.yml     # Service composition
+│   └── scripts/               # install-linux-server.sh, fastdeploy.sh,
+│                              #   test-updater.*, build-mac-local.sh
+│
+├── docs/                      # Unchanged
+├── tests/                     # Cross-cutting integration tests only;
+│                              #   per-component tests move into the
+│                              #   component
+├── .github/                   # Workflows live at root by GH convention
+├── CLAUDE.md                  # Top-level (see rules below)
+├── AGENTS.md                  # Symlink to CLAUDE.md
+├── README.md
+└── CHANGELOG.md
+```
+
+## What's Going Away
+
+- `designer/` — folded into `web/admin/` (admin already has an
+  `app/designer/` route). The standalone `Designer.exe` and
+  `web-designer.html` are deprecated.
+- `build/`, `build-new/`, `build-old/`, `test-update-host/` —
+  build artifacts that shouldn't be tracked. Remove and `.gitignore`.
+- Root-level `CMakeLists.txt`, `cmake/`, `resources.rc`,
+  `vcpkg.json`, `.vcpkg/`, `zSILENCER.xcodeproj`, `zSILENCER-Info.plist`
+  — these belong with the C++ client, so they move into
+  `clients/silencer/`.
+
+## Top-Level CLAUDE.md Rules to Add
+
+The top-level `CLAUDE.md` will gain three repository-wide conventions:
+
+### 1. Per-directory CLAUDE.md / AGENTS.md
+
+Every directory that represents a distinct component
+(`web/admin/`, `web/website/`, `services/lobby/`, `services/admin-api/`,
+`clients/silencer/`, `clients/cli/`, `shared/data/`, `infra/terraform/`,
+etc.) gets its own `CLAUDE.md` describing:
+
+- What this component is and what consumes it
+- How to build/run/test it locally
+- Component-specific gotchas
+- Pointers to anything in `shared/` it depends on
+
+The existing component-level CLAUDE.md files
+(`server/CLAUDE.md`, `terraform/CLAUDE.md`, `data/CLAUDE.md`,
+`src/CLAUDE.md`) move with their directories.
+
+### 2. CLAUDE.md ↔ AGENTS.md symlinks
+
+In every directory that has a `CLAUDE.md`, an `AGENTS.md` symlink
+points to it (or vice versa — whichever the host filesystem handles
+more gracefully on Windows). The two files must always have identical
+contents so Codex/Cursor/other agent tooling and Claude Code see the
+same instructions.
+
+The rule in top-level `CLAUDE.md`:
+
+> When creating or editing `CLAUDE.md` in any directory, ensure an
+> `AGENTS.md` symlink exists alongside it pointing to the same file.
+> Never let the two diverge.
+
+(On Windows where symlinks need admin or developer mode, fall back to
+keeping `AGENTS.md` as a one-line file that says
+`See CLAUDE.md in this directory.` — the symlink is the preferred
+form.)
+
+### 3. Bun + TypeScript for all JavaScript
+
+Anything in this repo that runs JavaScript uses **Bun** as the
+runtime/package manager and **TypeScript** as the language. This
+applies to:
+
+- `web/admin/` (currently Next.js + JS — migrate to TS)
+- `web/website/` (new — TS from the start)
+- `services/admin-api/` (currently Express + JS ESM — migrate to TS,
+  run under Bun)
+- Any future tooling, scripts, or codegen written in JS
+
+`npm`/`pnpm`/`yarn` lockfiles are removed in favor of `bun.lockb`.
+`node` invocations in Dockerfiles and scripts become `bun`.
+
+The rule in top-level `CLAUDE.md`:
+
+> All JavaScript in this repository uses Bun as the runtime and
+> package manager, and TypeScript as the language. Do not introduce
+> plain `.js` source files, `package-lock.json`, or `node` invocations.
+
+## Out of Scope for This Plan
+
+These are deliberate non-goals; each gets its own follow-up if pursued:
+
+- The actual `git mv` operations and ref updates to make this layout
+  real. That's the implementation PR.
+- Migrating `admin/web` and `admin/api` from JS to TS — a separate
+  effort tracked under the Bun+TS rule.
+- Building the `website/` content. The directory exists; the site
+  doesn't.
+- Building `clients/cli/`. Slot only.
+- Splitting tests into per-component vs cross-cutting buckets.
+
+## Open Questions
+
+- **Symlinks on Windows:** confirm whether the maintainer's dev
+  environment supports `mklink` symlinks for `AGENTS.md`, or whether
+  we standardize on the one-line stub fallback.
+- **`docs/superpowers/plans/` vs `docs/plans/`:** this document lives
+  at `docs/plans/` (intent doc); execution-style TDD plans continue
+  to live at `docs/superpowers/plans/`. Confirm that split is wanted.
+- **Designer .exe deprecation timing:** is `designer/Designer.exe`
+  removed immediately when the admin route reaches parity, or kept
+  as a fallback for offline level editing?

--- a/docs/plans/2026-04-25-monorepo-restructure.md
+++ b/docs/plans/2026-04-25-monorepo-restructure.md
@@ -4,11 +4,13 @@
 **Date:** 2026-04-25
 
 > **Naming note:** The product is being rebranded from **zSILENCER** to
-> **Silencer**. This plan uses the new name throughout. Renaming the
-> binary, the Windows solution (`zSILENCER.sln`), the macOS plist, the
-> CMake project, and the on-disk data directory
-> (`~/Library/Application Support/zSILENCER`) is a separate concern from
-> the directory restructure and is tracked in its own follow-up.
+> **Silencer**. This plan uses the new name throughout. Identifier
+> renames (binary, `zSILENCER.sln`, `zSILENCER.xcodeproj`,
+> `zSILENCER-Info.plist`, `CPACK_PACKAGE_NAME`, the macOS data dir
+> `~/Library/Application Support/zSILENCER`, etc.) happen
+> **opportunistically as files are touched** — there is no dedicated
+> rename PR. If a restructure step modifies a file that still says
+> `zSILENCER`, update it in the same change.
 
 ## Goal
 
@@ -90,9 +92,9 @@ silencer/                      # repo root (currently named zSilencer/
 - Root-level `CMakeLists.txt`, `cmake/`, `resources.rc`,
   `vcpkg.json`, `.vcpkg/`, `zSILENCER.xcodeproj`, `zSILENCER-Info.plist`
   — these belong with the C++ client, so they move into
-  `clients/silencer/`. (The `zSILENCER`-prefixed filenames are
-  rebranded to `Silencer` as part of the separate naming follow-up,
-  not this restructure.)
+  `clients/silencer/`. The `zSILENCER`-prefixed filenames get
+  rebranded to `Silencer` as part of the same move, since we're
+  already touching them.
 
 ## Top-Level CLAUDE.md Rules to Add
 

--- a/docs/writing-a-good-claude-md.md
+++ b/docs/writing-a-good-claude-md.md
@@ -1,0 +1,47 @@
+# Writing a Good CLAUDE.md
+
+Source: https://www.humanlayer.dev/blog/writing-a-good-claude-md
+
+## Core Insight
+
+LLMs are stateless — every agent session starts with zero codebase knowledge. CLAUDE.md is the primary mechanism for reintroducing essential context. It enters every conversation, so every line has weight.
+
+## Principles
+
+### Less Is More
+
+Claude Code's system prompt already contains ~50 instructions. LLMs can follow ~150-200 instructions with reasonable consistency; beyond that, adherence degrades. Keep CLAUDE.md as short as possible — ideally under 60 lines. Only include universally applicable rules.
+
+### Cover WHY / WHAT / HOW
+
+- **WHY**: Purpose of the project
+- **WHAT**: Tech stack, architecture, project structure
+- **HOW**: Build, test, verify — the commands and workflows needed to contribute
+
+### Progressive Disclosure
+
+Don't put everything in the root file. Create separate docs for task-specific guidance:
+
+```
+docs/database_schema.md
+docs/testing.md
+docs/service_architecture.md
+```
+
+List them briefly in CLAUDE.md with one-line descriptions so the agent reads them on-demand. Use `file:line` references instead of inline code snippets (snippets go stale).
+
+### Don't Use Claude as a Linter
+
+Style rules bloat context and degrade performance. Use actual linters/formatters (Biome, ESLint, Prettier) with auto-fix. Reserve CLAUDE.md for things only a human can judge.
+
+### Hand-Craft It
+
+CLAUDE.md is the highest leverage point of the agent harness — bad lines cascade into bad plans and bad code. Every line should be deliberate. Don't auto-generate it.
+
+## Anti-Patterns
+
+- Instructions that only apply to specific tasks (move to separate docs)
+- Code examples that will drift out of date (use file:line refs)
+- Style/formatting rules (use linters)
+- Verbose examples when a one-liner suffices
+- Auto-generated content nobody has reviewed line-by-line

--- a/infra/scripts/AGENTS.md
+++ b/infra/scripts/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/infra/scripts/CLAUDE.md
+++ b/infra/scripts/CLAUDE.md
@@ -1,0 +1,7 @@
+# infra/scripts — placeholder
+
+Will house deploy/install scripts (`install-linux-server.sh`,
+`fastdeploy.sh`, `build-mac-local.sh`, `test-updater.*`) after the
+monorepo restructure. Currently at `/scripts`.
+
+See [../../docs/plans/2026-04-25-monorepo-restructure.md](../../docs/plans/2026-04-25-monorepo-restructure.md).

--- a/infra/terraform/AGENTS.md
+++ b/infra/terraform/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/infra/terraform/CLAUDE.md
+++ b/infra/terraform/CLAUDE.md
@@ -1,0 +1,7 @@
+# infra/terraform — placeholder
+
+Will house the AWS infra (EC2 + EBS + cloud-init + Tailscale) after
+the monorepo restructure. Code currently at `/terraform` (with its
+own CLAUDE.md).
+
+See [../../docs/plans/2026-04-25-monorepo-restructure.md](../../docs/plans/2026-04-25-monorepo-restructure.md).

--- a/server/AGENTS.md
+++ b/server/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/server/CLAUDE.md
+++ b/server/CLAUDE.md
@@ -32,3 +32,17 @@ storage notes) are in `README.md`; this file is for editing the code.
   not create game" dialog (`src/game.cpp:824`). Don't reuse.
 - **Don't hold `h.mu` across network I/O.** Copy state under lock,
   send outside.
+
+## Storage
+
+`lobby.json` is source of truth — flat file, atomic writes
+(temp + rename), SHA-1 password hashes. When `MONGO_URL` is set,
+`mongosync.go` async-mirrors every mutation to MongoDB so the admin
+dashboard sees up-to-date data. Password hashes are never synced.
+Mongo is a mirror, not a backup — if it diverges, `lobby.json` wins.
+
+## Gotchas
+
+- **Port 517 needs root on macOS/Linux.** For local dev, run on
+  `:15170` and rebuild the client with
+  `-DZSILENCER_LOBBY_PORT=15170` (see `src/CLAUDE.md` gotchas).

--- a/server/CLAUDE.md
+++ b/server/CLAUDE.md
@@ -1,7 +1,9 @@
 # server/ — Go lobby
 
-Stdlib-only Go. Deployment docs (flags, how-it-works narrative,
-storage notes) are in `README.md`; this file is for editing the code.
+Go: stdlib + `mongo-driver` (used only when `MONGO_URL` set) + `amqp091-go`
+(used only when `RABBITMQ_URL` set). Build/run instructions, flags, and
+the how-it-works narrative are in `README.md`; this file is for editing
+the code.
 
 ## Per-file
 
@@ -21,6 +23,19 @@ storage notes) are in `README.md`; this file is for editing the code.
   → `hub.OnHeartbeat`.
 - `store.go` — `lobby.json` atomic writes (temp + rename), SHA-1
   password hashes, per-agency stats keyed by user.
+- `mongosync.go` — async-mirrors store mutations to MongoDB when
+  `MONGO_URL` is set (see Storage). Password hashes never synced.
+- `events.go` — fire-and-forget RabbitMQ event publisher (`zsilencer.events`
+  exchange) for the admin dashboard's live feed. No-op when
+  `RABBITMQ_URL`/`-rabbitmqURL` unset.
+- `playerauth.go` — internal HTTP server (`-player-auth-addr`, default
+  `:15171`) the admin-api calls to validate player credentials. Not
+  exposed outside the Docker network.
+- `maps.go` — uploaded user maps: SHA-1-keyed storage on disk + JSON
+  metadata. Filename whitelist + 64 KiB cap mirrors the engine's
+  `world.cpp AllocateMapData` buffer.
+- `update.go` — loads/serves the auto-update manifest (per-platform
+  download URL + SHA-256) the client polls on launch.
 
 ## Invariants
 

--- a/services/admin-api/AGENTS.md
+++ b/services/admin-api/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/services/admin-api/CLAUDE.md
+++ b/services/admin-api/CLAUDE.md
@@ -1,0 +1,7 @@
+# services/admin-api — placeholder
+
+Will house the admin REST + WebSocket API after the monorepo
+restructure. Currently Express + JS at `/admin/api`; migrating to
+Bun + TypeScript + oxfmt as it moves.
+
+See [../../docs/plans/2026-04-25-monorepo-restructure.md](../../docs/plans/2026-04-25-monorepo-restructure.md).

--- a/services/lobby/AGENTS.md
+++ b/services/lobby/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/services/lobby/CLAUDE.md
+++ b/services/lobby/CLAUDE.md
@@ -1,0 +1,6 @@
+# services/lobby — placeholder
+
+Will house the Go lobby server after the monorepo restructure. Code
+currently lives at `/server` (with its own CLAUDE.md).
+
+See [../../docs/plans/2026-04-25-monorepo-restructure.md](../../docs/plans/2026-04-25-monorepo-restructure.md).

--- a/shared/assets/AGENTS.md
+++ b/shared/assets/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/shared/assets/CLAUDE.md
+++ b/shared/assets/CLAUDE.md
@@ -1,0 +1,8 @@
+# shared/assets — placeholder
+
+Will house runtime assets (sprite/tile/sound banks, levels) consumed
+by `clients/silencer` and the dedicated server after the monorepo
+restructure. Code currently at `/data` (with its own CLAUDE.md
+covering binary formats).
+
+See [../../docs/plans/2026-04-25-monorepo-restructure.md](../../docs/plans/2026-04-25-monorepo-restructure.md).

--- a/shared/icons/AGENTS.md
+++ b/shared/icons/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/shared/icons/CLAUDE.md
+++ b/shared/icons/CLAUDE.md
@@ -1,0 +1,6 @@
+# shared/icons — placeholder
+
+Will house app icons used by the `clients/silencer` build after the
+monorepo restructure. Currently at `/res`.
+
+See [../../docs/plans/2026-04-25-monorepo-restructure.md](../../docs/plans/2026-04-25-monorepo-restructure.md).

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -1,6 +1,9 @@
 # src/ — C++ client
 
 Flat layout: ~158 files, `.cpp` paired with `.h`, no subdirectories.
+Build with the root `CMakeLists.txt` (`mkdir build && cd build && cmake ..
+&& make`) — see top-level `README.md` for platform notes and the
+`-DZSILENCER_LOBBY_*` knobs in *Gotchas* below.
 
 ## Object hierarchy
 

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -1,9 +1,6 @@
 # src/ — C++ client
 
 Flat layout: ~158 files, `.cpp` paired with `.h`, no subdirectories.
-General context (build, dedicated-server contract, data-dir + lobby
-hardcoding gotchas, version string) lives in the root `CLAUDE.md`
-and is not repeated here.
 
 ## Object hierarchy
 
@@ -23,6 +20,21 @@ in `oldsnapshots` / `totalsnapshots`. TCP lobby client is
 `lobby.cpp` + `lobbygame.cpp`; wire format is mirrored in
 `server/protocol.go` — changes must land on both sides.
 
+## Dedicated-server contract
+
+The same binary runs the client and, when launched with `-s`, a
+headless dedicated server:
+
+```
+zsilencer -s <lobbyaddr> <lobbyport> <gameid> <accountid>
+```
+
+- Parsed in `main.cpp:160` → `game.cpp:132`.
+- Spawned by the Go lobby in `server/proc.go` on each `MSG_NEWGAME`.
+- Skips `SDL_Init(VIDEO)` and audio; RSS ~12 MB.
+- Heartbeats UDP to the lobby: `[0x00][gameid u32][port u16][state u8]`.
+  No heartbeat in 30 s → lobby aborts the create.
+
 ## Where to look
 
 - Top-level state machine (menus, lobby, in-game): `game.cpp` (5800+ lines).
@@ -35,3 +47,21 @@ in `oldsnapshots` / `totalsnapshots`. TCP lobby client is
 - Projectiles: `*projectile.cpp` + `shrapnel.cpp`.
 - Stations: `healmachine`, `creditmachine`, `inventorystation`,
   `techstation`, `walldefense`, `fixedcannon`, `terminal`.
+
+## Gotchas
+
+- **Lobby host is a compile-time constant.** Baked in via
+  `-DZSILENCER_LOBBY_HOST=<host> -DZSILENCER_LOBBY_PORT=<port>`
+  (`CMakeLists.txt:48`, used at `game.cpp:4018`/`:4032`). Default is
+  `127.0.0.1:517`. CI sets it to `silencer.hventura.com`. Rebuild
+  the client to point at a different lobby.
+- **Version string must match the lobby.** Set at `game.cpp:31`
+  (`world.SetVersion("00024")`); the lobby's `-version` flag
+  defaults to the same. Bump both together. `CPACK_PACKAGE_VERSION`
+  is installer metadata only — unrelated to the wire handshake.
+- **macOS data dir.** Client `chdir`s to
+  `~/Library/Application Support/zSILENCER` at startup
+  (`main.cpp` `CDDataDir`) — copy `data/` there or run from the
+  repo with the binary in place.
+- **Android/Ouya code paths exist** in `main.cpp` but are not
+  actively maintained; don't rely on them.

--- a/terraform/AGENTS.md
+++ b/terraform/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/web/admin/AGENTS.md
+++ b/web/admin/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/web/admin/CLAUDE.md
+++ b/web/admin/CLAUDE.md
@@ -1,0 +1,6 @@
+# web/admin — placeholder
+
+Will house the Next.js admin dashboard + level designer route after
+the monorepo restructure. Code currently lives at `/admin/web`.
+
+See [../../docs/plans/2026-04-25-monorepo-restructure.md](../../docs/plans/2026-04-25-monorepo-restructure.md).

--- a/web/website/AGENTS.md
+++ b/web/website/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/web/website/CLAUDE.md
+++ b/web/website/CLAUDE.md
@@ -1,0 +1,5 @@
+# web/website — placeholder
+
+Reserved slot for the public Silencer landing page. Nothing here yet.
+
+See [../../docs/plans/2026-04-25-monorepo-restructure.md](../../docs/plans/2026-04-25-monorepo-restructure.md).


### PR DESCRIPTION
## Summary

Intent + end-state plan for reorganizing the repo into `web/`,
`services/`, `clients/`, `shared/`, and `infra/`. Captures the
designer→admin merge and three repo-wide rules to add to CLAUDE.md
(per-dir CLAUDE.md, CLAUDE.md↔AGENTS.md symlinks, Bun+TypeScript for
all JS).

Implementation mechanics (CMake/compose/CI updates) are deferred to a
follow-up PR.

## Test plan

- [ ] Maintainer reviews proposed end-state layout
- [ ] Confirms designer→admin merge is the right call
- [ ] Confirms Windows symlink approach for AGENTS.md
- [ ] Resolves open questions at the bottom of the doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/arsia-mons/silencer/pull/8" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
