### PR TITLE
feat(client): SDL2 → SDL3 Phase 1 migration (issue #42)

### DIFF
--- a/clients/silencer/CMakeLists.txt
+++ b/clients/silencer/CMakeLists.txt
@@ -120,6 +120,13 @@ else()
 endif()
 
 include_directories(${ZLIB_INCLUDE_DIRS})
+find_package(SDL3_mixer REQUIRED CONFIG)
+if(TARGET SDL3_mixer::SDL3_mixer)
+  get_target_property(_sdl3mixer_inc SDL3_mixer::SDL3_mixer INTERFACE_INCLUDE_DIRECTORIES)
+  if(_sdl3mixer_inc)
+    include_directories(${_sdl3mixer_inc})
+  endif()
+endif()
 
 if(APPLE)
 	find_library(COCOA_FRAMEWORK Cocoa)

--- a/clients/silencer/CMakeLists.txt
+++ b/clients/silencer/CMakeLists.txt
@@ -85,8 +85,8 @@ target_compile_definitions(${SILENCER_TARGET} PRIVATE
 )
 
 find_package(ZLIB REQUIRED)
-find_package(SDL2 REQUIRED)
-find_package(SDL2_mixer REQUIRED)
+find_package(SDL3 REQUIRED)
+find_package(SDL3_mixer REQUIRED)
 find_package(CURL REQUIRED)
 
 # Minizip: prefer vcpkg's CMake CONFIG packages (Windows CI), then fall back
@@ -119,21 +119,21 @@ else()
 	target_link_libraries(minizip_dep INTERFACE PkgConfig::MINIZIP)
 endif()
 
-include_directories(${SDL2_INCLUDE_DIR} ${SDL2_MIXER_INCLUDE_DIRS} ${ZLIB_INCLUDE_DIRS})
+include_directories(${ZLIB_INCLUDE_DIRS})
 
 if(APPLE)
 	find_library(COCOA_FRAMEWORK Cocoa)
 	target_link_libraries(${SILENCER_TARGET}
-		${SDL2_LIBRARY} ${SDL2_MIXER_LIBRARY} ${ZLIB_LIBRARY}
+		SDL3::SDL3 SDL3_mixer::SDL3_mixer ${ZLIB_LIBRARY}
 		CURL::libcurl
 		${COCOA_FRAMEWORK})
 elseif(WIN32)
 	target_link_libraries(${SILENCER_TARGET}
-		${SDL2_LIBRARY} ${SDL2_MIXER_LIBRARY} ${ZLIB_LIBRARY}
+		SDL3::SDL3 SDL3_mixer::SDL3_mixer ${ZLIB_LIBRARY}
 		CURL::libcurl ws2_32)
 else()
 	target_link_libraries(${SILENCER_TARGET}
-		${SDL2_LIBRARY} ${SDL2_MIXER_LIBRARY} ${ZLIB_LIBRARY}
+		SDL3::SDL3 SDL3_mixer::SDL3_mixer ${ZLIB_LIBRARY}
 		CURL::libcurl)
 endif()
 

--- a/clients/silencer/src/audio.cpp
+++ b/clients/silencer/src/audio.cpp
@@ -8,6 +8,14 @@ Audio::Audio(){
 	enabled = false;
 	effectvolume = 1;
 	musicvolume = MIX_MAX_VOLUME;
+	mixer = nullptr;
+	musictrack = nullptr;
+	SDL_zero(mixerspec);
+	for(int i = 0; i < maxchannels; i++){
+		tracks[i] = nullptr;
+		channelobject[i] = 0;
+		channelvolume[i] = 128;
+	}
 }
 
 Audio::~Audio(){
@@ -20,79 +28,80 @@ Audio & Audio::GetInstance(void){
 }
 
 bool Audio::Init(Game * game){
-	if(Mix_OpenAudio(SDL_AUDIO_DEVICE_DEFAULT_OUTPUT, NULL) == false){
-		return false;
-	}else{
-		Mix_AllocateChannels(maxchannels);
-		Mix_ChannelFinished(ChannelFinished);
-		Mix_SetPostMix(MixingFunction, game);
-		enabled = true;
-		return true;
+	mixer = MIX_CreateMixerDevice(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, NULL);
+	if(!mixer) return false;
+
+	for(int i = 0; i < maxchannels; i++){
+		tracks[i] = MIX_CreateTrack(mixer);
+		if(tracks[i]){
+			MIX_SetTrackStoppedCallback(tracks[i], TrackStoppedCallback, (void*)(intptr_t)i);
+		}
 	}
+	musictrack = MIX_CreateTrack(mixer);
+	MIX_GetMixerFormat(mixer, &mixerspec);
+	// TODO: Post-mix callback for ffmpeg replay audio export was removed in SDL3_mixer 3.x
+	enabled = true;
+	return true;
 }
 
 void Audio::Close(void){
 	enabled = false;
-	int freq;
-	Uint16 format;
-	int channels;
-	while(Mix_QuerySpec(&freq, &format, &channels)){
-		Mix_CloseAudio();
+	if(mixer){
+		for(int i = 0; i < maxchannels; i++){
+			if(tracks[i]){ MIX_DestroyTrack(tracks[i]); tracks[i] = nullptr; }
+		}
+		if(musictrack){ MIX_DestroyTrack(musictrack); musictrack = nullptr; }
+		MIX_DestroyMixer(mixer);
+		mixer = nullptr;
 	}
 }
 
-int Audio::Play(Mix_Chunk * chunk, int volume, bool loop){
+int Audio::Play(MIX_Audio * chunk, int volume, bool loop){
 	if(enabled && chunk){
-		int loops = 0;
-		if(loop){
-			loops = -1;
+		for(int i = 0; i < maxchannels; i++){
+			if(!MIX_TrackPlaying(tracks[i]) && !MIX_TrackPaused(tracks[i])){
+				MIX_SetTrackAudio(tracks[i], chunk);
+				MIX_SetTrackLoops(tracks[i], loop ? -1 : 0);
+				MIX_SetTrackGain(tracks[i], (volume / 128.0f) * effectvolume);
+				MIX_PlayTrack(tracks[i], 0);
+				channelobject[i] = 0;
+				channelvolume[i] = volume;
+				return i;
+			}
 		}
-		int channel = Mix_PlayChannel(-1, chunk, loops);
-		if(channel >= 0){
-			Mix_Volume(channel, volume * effectvolume);
-			channelobject[channel] = 0;
-			channelvolume[channel] = volume;
-		}
-		return channel;
-	}else{
-		return -1;
 	}
+	return -1;
 }
 
 void Audio::Stop(int channel, int fadeoutms){
-	if(!enabled) return;
-	if(fadeoutms){
-		Mix_FadeOutChannel(channel, fadeoutms);
-		Mix_ExpireChannel(channel, fadeoutms);
-	}else{
-		Mix_HaltChannel(channel);
-	}
+	if(!enabled || channel < 0 || channel >= maxchannels) return;
+	Sint64 fade_frames = fadeoutms ? MIX_MSToFrames(mixerspec.freq, fadeoutms) : 0;
+	MIX_StopTrack(tracks[channel], fade_frames);
 }
 
 void Audio::StopAll(int fadeoutms){
 	if(!enabled) return;
-	Stop(-1, fadeoutms);
+	MIX_StopAllTracks(mixer, fadeoutms);
 }
 
 void Audio::Pause(int channel){
-	if(!enabled) return;
-	Mix_Pause(channel);
+	if(!enabled || channel < 0 || channel >= maxchannels) return;
+	MIX_PauseTrack(tracks[channel]);
 }
 
 void Audio::Resume(int channel){
-	if(!enabled) return;
-	Mix_Resume(channel);
+	if(!enabled || channel < 0 || channel >= maxchannels) return;
+	MIX_ResumeTrack(tracks[channel]);
 }
 
 bool Audio::Paused(int channel){
-	if(!enabled) return false;
-	return Mix_Paused(channel);
+	if(!enabled || channel < 0 || channel >= maxchannels) return false;
+	return MIX_TrackPaused(tracks[channel]);
 }
 
-int Audio::EmitSound(World & world, Uint16 objectid, Mix_Chunk * chunk, int volume, bool loop){
+int Audio::EmitSound(World & world, Uint16 objectid, MIX_Audio * chunk, int volume, bool loop){
 	int channel = Play(chunk, volume * effectvolume, loop);
 	if(channel != -1){
-		//Mix_Volume(channel, 0);
 		channelobject[channel] = objectid;
 		UpdateVolume(world, channel, lastx, lasty, 500);
 	}
@@ -108,14 +117,10 @@ void Audio::UpdateVolume(World & world, int channel, Sint16 x, Sint16 y, int rad
 			int diffy = abs(signed(y) - object->y);
 			float distance = abs(sqrt(float((diffx * diffx) + (diffy * diffy))));
 			float volume = 1 - (distance / radius);
-			if(volume < 0){
-				volume = 0;
-			}
-			if(volume > 1){
-				volume = 1;
-			}
+			if(volume < 0) volume = 0;
+			if(volume > 1) volume = 1;
 			int oldvolume = channelvolume[channel];
-			Mix_Volume(channel, (oldvolume * volume) * effectvolume);
+			MIX_SetTrackGain(tracks[channel], ((oldvolume * volume) / 128.0f) * effectvolume);
 			lastx = x;
 			lasty = y;
 		}
@@ -124,25 +129,24 @@ void Audio::UpdateVolume(World & world, int channel, Sint16 x, Sint16 y, int rad
 
 void Audio::UpdateAllVolumes(World & world, Sint16 x, Sint16 y, int radius){
 	for(int i = 0; i < maxchannels; i++){
-		int channel = i;
-		UpdateVolume(world, channel, x, y, radius);
+		UpdateVolume(world, i, x, y, radius);
 	}
 }
 
 void Audio::SetVolume(int channel, int volume){
-	if(!enabled) return;
-	Mix_Volume(channel, volume * effectvolume);
+	if(!enabled || channel < 0 || channel >= maxchannels) return;
+	MIX_SetTrackGain(tracks[channel], (volume / 128.0f) * effectvolume);
 }
 
 void Audio::Mute(int volume){
 	if(!enabled) return;
-	float percent = volume / 128.0;
+	float percent = volume / 128.0f;
 	effectvolume = percent;
 	for(int i = 0; i < maxchannels; i++){
 		int oldvolume = channelvolume[i];
-		Mix_Volume(i, oldvolume * percent);
+		MIX_SetTrackGain(tracks[i], (oldvolume / 128.0f) * percent);
 	}
-	Mix_VolumeMusic(musicvolume * percent);
+	MIX_SetTrackGain(musictrack, (musicvolume / 128.0f) * percent);
 }
 
 void Audio::Unmute(void){
@@ -150,20 +154,20 @@ void Audio::Unmute(void){
 	effectvolume = 1;
 	for(int i = 0; i < maxchannels; i++){
 		int oldvolume = channelvolume[i];
-		Mix_Volume(i, oldvolume);
+		MIX_SetTrackGain(tracks[i], oldvolume / 128.0f);
 	}
-	Mix_VolumeMusic(musicvolume);
+	MIX_SetTrackGain(musictrack, musicvolume / 128.0f);
 }
 
-bool Audio::PlayMusic(Mix_Music * music){
+bool Audio::PlayMusic(MIX_Audio * music){
 	if(!enabled) return false;
-	if(!Config::GetInstance().music){
-		return false;
-	}
-	if(!Mix_PlayingMusic() || Mix_FadingMusic() == MIX_FADING_OUT){
+	if(!Config::GetInstance().music) return false;
+	if(!MIX_TrackPlaying(musictrack) || !MIX_TrackPaused(musictrack)){
 		if(!MusicPaused()){
-			Mix_PlayMusic(music, -1);
-			SetMusicVolume(musicvolume);
+			MIX_SetTrackAudio(musictrack, music);
+			MIX_SetTrackLoops(musictrack, -1);
+			MIX_SetTrackGain(musictrack, musicvolume / 128.0f);
+			MIX_PlayTrack(musictrack, 0);
 			return true;
 		}
 	}
@@ -172,22 +176,22 @@ bool Audio::PlayMusic(Mix_Music * music){
 
 void Audio::StopMusic(void){
 	if(!enabled) return;
-	Mix_FadeOutMusic(700);
+	MIX_StopTrack(musictrack, MIX_MSToFrames(mixerspec.freq, 700));
 }
 
 void Audio::PauseMusic(void){
 	if(!enabled) return;
-	Mix_PauseMusic();
+	MIX_PauseTrack(musictrack);
 }
 
 void Audio::ResumeMusic(void){
 	if(!enabled) return;
-	Mix_ResumeMusic();
+	MIX_ResumeTrack(musictrack);
 }
 
 bool Audio::MusicPaused(void){
 	if(!enabled) return false;
-	return Mix_PausedMusic();
+	return MIX_TrackPaused(musictrack);
 }
 
 void Audio::SetMusicVolume(int volume){
@@ -195,19 +199,15 @@ void Audio::SetMusicVolume(int volume){
 		musicvolume = volume;
 		return;
 	}
-	Mix_VolumeMusic(volume);
+	MIX_SetTrackGain(musictrack, volume / 128.0f);
 	musicvolume = volume;
 }
 
-void Audio::ChannelFinished(int channel){
+void Audio::TrackStoppedCallback(void *userdata, MIX_Track *track){
+	int channel = (int)(intptr_t)userdata;
 	Audio::GetInstance().channelobject[channel] = 0;
 }
 
 void Audio::MixingFunction(void * udata, Uint8 * stream, int len){
-#ifdef POSIX
-	Game * game = (Game *)udata;
-	if(game && game->world.replay.IsPlaying() && game->world.replay.ffmpeg && !game->world.replay.ffmpegvideo && game->deploymessageshown){
-		fwrite(stream, len, 1, game->world.replay.ffmpeg);
-	}
-#endif
+	// TODO: Post-mix ffmpeg callback not available in SDL3_mixer 3.x; replay audio export disabled
 }

--- a/clients/silencer/src/audio.cpp
+++ b/clients/silencer/src/audio.cpp
@@ -39,7 +39,6 @@ bool Audio::Init(Game * game){
 	}
 	musictrack = MIX_CreateTrack(mixer);
 	MIX_GetMixerFormat(mixer, &mixerspec);
-	// TODO: Post-mix callback for ffmpeg replay audio export was removed in SDL3_mixer 3.x
 	enabled = true;
 	return true;
 }
@@ -61,9 +60,14 @@ int Audio::Play(MIX_Audio * chunk, int volume, bool loop){
 		for(int i = 0; i < maxchannels; i++){
 			if(!MIX_TrackPlaying(tracks[i]) && !MIX_TrackPaused(tracks[i])){
 				MIX_SetTrackAudio(tracks[i], chunk);
-				MIX_SetTrackLoops(tracks[i], loop ? -1 : 0);
 				MIX_SetTrackGain(tracks[i], (volume / 128.0f) * effectvolume);
-				MIX_PlayTrack(tracks[i], 0);
+				SDL_PropertiesID options = 0;
+				if(loop){
+					options = SDL_CreateProperties();
+					SDL_SetNumberProperty(options, MIX_PROP_PLAY_LOOPS_NUMBER, -1);
+				}
+				MIX_PlayTrack(tracks[i], options);
+				if(options) SDL_DestroyProperties(options);
 				channelobject[i] = 0;
 				channelvolume[i] = volume;
 				return i;
@@ -162,14 +166,14 @@ void Audio::Unmute(void){
 bool Audio::PlayMusic(MIX_Audio * music){
 	if(!enabled) return false;
 	if(!Config::GetInstance().music) return false;
-	if(!MIX_TrackPlaying(musictrack) || !MIX_TrackPaused(musictrack)){
-		if(!MusicPaused()){
-			MIX_SetTrackAudio(musictrack, music);
-			MIX_SetTrackLoops(musictrack, -1);
-			MIX_SetTrackGain(musictrack, musicvolume / 128.0f);
-			MIX_PlayTrack(musictrack, 0);
-			return true;
-		}
+	if(!MIX_TrackPlaying(musictrack) && !MIX_TrackPaused(musictrack)){
+		SDL_PropertiesID options = SDL_CreateProperties();
+		SDL_SetNumberProperty(options, MIX_PROP_PLAY_LOOPS_NUMBER, -1);
+		MIX_SetTrackAudio(musictrack, music);
+		MIX_SetTrackGain(musictrack, musicvolume / 128.0f);
+		MIX_PlayTrack(musictrack, options);
+		SDL_DestroyProperties(options);
+		return true;
 	}
 	return false;
 }

--- a/clients/silencer/src/audio.cpp
+++ b/clients/silencer/src/audio.cpp
@@ -20,7 +20,7 @@ Audio & Audio::GetInstance(void){
 }
 
 bool Audio::Init(Game * game){
-	if(Mix_OpenAudio(44100, AUDIO_S16, 1, 1024) == -1){
+	if(Mix_OpenAudio(SDL_AUDIO_DEVICE_DEFAULT_OUTPUT, NULL) == false){
 		return false;
 	}else{
 		Mix_AllocateChannels(maxchannels);

--- a/clients/silencer/src/audio.h
+++ b/clients/silencer/src/audio.h
@@ -33,12 +33,17 @@ public:
 	void SetMusicVolume(int volume);
 	
 	bool enabled;
-	
+	MIX_Mixer *GetMixer(void) { return mixer; }
+
 private:
-	static void ChannelFinished(int channel);
+	static void TrackStoppedCallback(void *userdata, MIX_Track *track);
 	static void MixingFunction(void * udata, Uint8 * stream, int len);
-	
+
 	static const int maxchannels = 128;
+	MIX_Mixer *mixer;
+	MIX_Track *tracks[maxchannels];
+	MIX_Track *musictrack;
+	SDL_AudioSpec mixerspec;
 	int channelobject[maxchannels];
 	int channelvolume[maxchannels];
 	float effectvolume;

--- a/clients/silencer/src/config.cpp
+++ b/clients/silencer/src/config.cpp
@@ -16,7 +16,7 @@ Config & Config::GetInstance(void){
 
 void Config::Save(void){
 	CDDataDir();
-	SDL_RWops * file = SDL_RWFromFile((GetDataDir() + "config.cfg").c_str(), "w");
+	SDL_IOStream * file = SDL_IOFromFile((GetDataDir() + "config.cfg").c_str(), "w");
 	if(file){
 		char temp[256];
 		WriteString(file, "fullscreen", fullscreen ? "1" : "0");
@@ -51,13 +51,13 @@ void Config::Save(void){
 		WriteKey(file, "keychat", keychatbinding, keychatoperator);
 		WriteKey(file, "keydisguise", keydisguisebinding, keydisguiseoperator);
 		WriteKey(file, "keynextweapon", keynextweaponbinding, keynextweaponoperator);
-		SDL_RWclose(file);
+		SDL_CloseIO(file);
 	}
 }
 
 bool Config::Load(void){
 	CDDataDir();
-	SDL_RWops * file = SDL_RWFromFile((GetDataDir() + "config.cfg").c_str(), "r");
+	SDL_IOStream * file = SDL_IOFromFile((GetDataDir() + "config.cfg").c_str(), "r");
 	if(file){
 		char line[256];
 		while(RWgets(file, line, sizeof(line))){
@@ -99,7 +99,7 @@ bool Config::Load(void){
 				ReadString(variable, vardata, sizeof(vardata)); if(CompareString(vardata, "keynextweapon")){ ReadKey(data, &keynextweaponbinding, &keynextweaponoperator); }
 			}
 		}
-		SDL_RWclose(file);
+		SDL_CloseIO(file);
 		return true;
 	}
 	return false;
@@ -186,10 +186,10 @@ bool Config::CompareString(const char * str1, const char * str2){
 	return false;
 }
 
-void Config::WriteKey(SDL_RWops * file, const char * variable, SDL_Scancode keybindings[2], bool keyoperator){
+void Config::WriteKey(SDL_IOStream * file, const char * variable, SDL_Scancode keybindings[2], bool keyoperator){
 	char line[256];
 	sprintf(line, "%s = %d %d %d\r\n", variable, keybindings[0], keyoperator, keybindings[1]);
-	SDL_RWwrite(file, line, strlen(line), 1);
+	SDL_WriteIO(file, line, strlen(line));
 }
 
 void Config::ReadKey(char * data, SDL_Scancode (*keybindings)[2], bool * keyoperator){
@@ -212,10 +212,10 @@ void Config::ReadKey(char * data, SDL_Scancode (*keybindings)[2], bool * keyoper
 	(*keybindings)[1] = (SDL_Scancode)key2;
 }
 
-void Config::WriteString(SDL_RWops * file, const char * variable, const char * string){
+void Config::WriteString(SDL_IOStream * file, const char * variable, const char * string){
 	char line[256];
 	sprintf(line, "%s = %s\r\n", variable, string);
-	SDL_RWwrite(file, line, strlen(line), 1);
+	SDL_WriteIO(file, line, strlen(line));
 }
 
 void Config::ReadString(const char * data, char * variable, int length){
@@ -244,11 +244,11 @@ void Config::ReadString(const char * data, char * variable, int length){
 	}
 }
 
-char * Config::RWgets(SDL_RWops * file, char * buffer, int count){
+char * Config::RWgets(SDL_IOStream * file, char * buffer, int count){
 	int i;
 	buffer[count - 1] = '\0';
 	for(i = 0; i < count - 1; i++){
-		if(SDL_RWread(file, buffer + i, 1, 1) != 1){
+		if(SDL_ReadIO(file, buffer + i, 1) != 1){
 			if(i == 0){
 				return NULL;
 			}

--- a/clients/silencer/src/config.h
+++ b/clients/silencer/src/config.h
@@ -48,11 +48,11 @@ public:
 	
 private:
 	bool CompareString(const char * str1, const char * str2);
-	void WriteKey(SDL_RWops * file, const char * variable, SDL_Scancode keybindings[2], bool keyoperator);
+	void WriteKey(SDL_IOStream * file, const char * variable, SDL_Scancode keybindings[2], bool keyoperator);
 	void ReadKey(char * data, SDL_Scancode (*keybindings)[2], bool * keyoperator);
-	void WriteString(SDL_RWops * file, const char * variable, const char * string);
+	void WriteString(SDL_IOStream * file, const char * variable, const char * string);
 	void ReadString(const char * data, char * variable, int length);
-	char * RWgets(SDL_RWops * file, char * buffer, int count);
+	char * RWgets(SDL_IOStream * file, char * buffer, int count);
 };
 
 #endif

--- a/clients/silencer/src/game.cpp
+++ b/clients/silencer/src/game.cpp
@@ -87,7 +87,7 @@ Game::Game() : renderer(world), screenbuffer(640, 480){
 	window = 0;
 	windowrenderer = 0;
 	streamingtexture = 0;
-	streamingtexturepixelformat = 0;
+	streamingtexturepixelformat = SDL_PIXELFORMAT_UNKNOWN;
 	glcontext = 0;
 	fbo = 0;
 	gltextures[0] = 0;
@@ -113,7 +113,7 @@ Game::Game() : renderer(world), screenbuffer(640, 480){
 
 Game::~Game(){
 	if(glcontext){
-		SDL_GL_DeleteContext(glcontext);
+		SDL_GL_DestroyContext(glcontext);
 	}
 	if(sdlscreenbuffer){
 		SDL_DestroySurface(sdlscreenbuffer);
@@ -132,7 +132,7 @@ Game::~Game(){
 	}
 	world.resources.UnloadSounds();
 	Audio::GetInstance().Close();
-	Mix_Quit();
+	MIX_Quit();
 	SDL_Quit();
 }
 
@@ -189,27 +189,19 @@ bool Game::Load(char * cmdline){
 	}
 	Config::GetInstance().Load();
 	if(world.dedicatedserver.active){
-		// Minimal init for dedicated-server mode: timer for SDL_GetTicks pacing.
-		if(!SDL_Init(SDL_INIT_TIMER)){
-			printf("Could not initialize SDL timer %s\n", SDL_GetError());
+		// Dedicated server: SDL3 always initialises the timer subsystem; no flags needed.
+		if(!SDL_Init(0)){
+			printf("Could not initialize SDL %s\n", SDL_GetError());
 			return false;
 		}
 	}
 	if(!world.dedicatedserver.active){
-		if(!SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_TIMER)){
+		if(!SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO)){
 			printf("Could not initialize SDL %s\n", SDL_GetError());
 			return false;
 		}
-		int mixinitted;
-		if((mixinitted = Mix_Init(MIX_INIT_MP3 | MIX_INIT_MOD)) == -1){
-			printf("Could not initialize SDL_mixer %s\n", Mix_GetError());
-			return false;
-		}
-		if(!(mixinitted & MIX_INIT_MOD)){
-			printf("Could not initialize MOD support %s\n", Mix_GetError());
-		}
-		if(!(mixinitted & MIX_INIT_MP3)){
-			printf("Could not initialize MP3 support %s\n", Mix_GetError());
+		if(!MIX_Init()){
+			printf("Could not initialize SDL_mixer: %s\n", SDL_GetError());
 		}
 		if(!Audio::GetInstance().Init(this)){
 			printf("Could not initialize audio\n");
@@ -386,19 +378,15 @@ void Game::CreateRenderer(void){
 }
 
 void Game::CreateStreamingTexture(void){
-	const char * scalefilter = "nearest";
-	if(Config::GetInstance().scalefilter){
-		scalefilter = "linear";
-	}
-	SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, scalefilter);
 	if(streamingtexture){
 		SDL_DestroyTexture(streamingtexture);
 		streamingtexture = 0;
 	}
-	// SDL3: pick a reliable non-indexed, non-FOURCC format
-	Uint32 pixelformat = SDL_PIXELFORMAT_XRGB8888;
-	streamingtexture = SDL_CreateTexture(windowrenderer, pixelformat, SDL_TEXTUREACCESS_STREAMING, screenbuffer.w, screenbuffer.h);
-	streamingtexturepixelformat = pixelformat;
+	streamingtexture = SDL_CreateTexture(windowrenderer, SDL_PIXELFORMAT_XRGB8888, SDL_TEXTUREACCESS_STREAMING, screenbuffer.w, screenbuffer.h);
+	streamingtexturepixelformat = SDL_PIXELFORMAT_XRGB8888;
+	if(streamingtexture){
+		SDL_SetTextureScaleMode(streamingtexture, Config::GetInstance().scalefilter ? SDL_SCALEMODE_LINEAR : SDL_SCALEMODE_NEAREST);
+	}
 }
 
 void Game::Present(void){
@@ -493,7 +481,7 @@ void Game::SetColors(SDL_Color * colors){
 		glPixelStorei(GL_PACK_ALIGNMENT, 4);
 		glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, 256, 1, GL_RGBA, GL_UNSIGNED_BYTE, colors);*/
 	}else{
-		SDL_SetPaletteColors(sdlscreenbuffer->palette, colors, 0, 256);
+		SDL_SetPaletteColors(SDL_GetSurfacePalette(sdlscreenbuffer), colors, 0, 256);
 		if(streamingtexture){
 			for(int i = 0; i < 256; i++){
 				streamingtexturepalette[i] = SDL_MapRGB(SDL_GetPixelFormatDetails(streamingtexturepixelformat), NULL, colors[i].r, colors[i].g, colors[i].b);
@@ -588,9 +576,9 @@ bool Game::Loop(void){
 			int j = 0;
 			for(int y = screenbuffer.h; y > 0; y--){
 				for(int x = screenbuffer.w; x > 0; x--){
-					buffer[i++] = sdlscreenbuffer->palette->colors[screenbuffer.pixels[j]].r;
-					buffer[i++] = sdlscreenbuffer->palette->colors[screenbuffer.pixels[j]].g;
-					buffer[i++] = sdlscreenbuffer->palette->colors[screenbuffer.pixels[j]].b;
+					buffer[i++] = SDL_GetSurfacePalette(sdlscreenbuffer)->colors[screenbuffer.pixels[j]].r;
+					buffer[i++] = SDL_GetSurfacePalette(sdlscreenbuffer)->colors[screenbuffer.pixels[j]].g;
+					buffer[i++] = SDL_GetSurfacePalette(sdlscreenbuffer)->colors[screenbuffer.pixels[j]].b;
 					j++;
 				}
 			}
@@ -4072,10 +4060,10 @@ Interface * Game::CreateMapPreview(const char * filename){
 	char mapdesc[0x80];
 	strcpy(mapdesc, "");
 	CDDataDir();
-	SDL_RWops * file = SDL_RWFromFile(filename, "rb");
+	SDL_IOStream * file = SDL_IOFromFile(filename, "rb");
 	if(!file){
 		CDResDir();
-		file = SDL_RWFromFile(filename, "rb");
+		file = SDL_IOFromFile(filename, "rb");
 	}
 	if(file){
 		Map::Header header;
@@ -4084,7 +4072,7 @@ Interface * Game::CreateMapPreview(const char * filename){
 		Map::UncompressMinimap((Uint8 (*)[172 * 62])minimap->customsprite.data(), header.minimapcompressed, header.minimapcompressedsize);
 		minimap->customspritew = 172;
 		minimap->customspriteh = 62;
-		SDL_RWclose(file);
+		SDL_CloseIO(file);
 	}
 	maptext->text = Interface::WordWrap(mapdesc, 29);
 	previewinterface->AddObject(mapname->id);
@@ -4767,26 +4755,21 @@ bool Game::ProcessLobbyInterface(Interface * iface){
 						Object * object = world.GetObjectFromId(iface->scrollbar);
 						ScrollBar * scrollbar = static_cast<ScrollBar *>(object);
 						if(minimized && world.lobby.chatmessages.size() > chatlinesprinted){
-							SDL_SysWMinfo info;
-						if(SDL_GetWindowWMInfo(window, &info, SDL_SYSWM_CURRENT_VERSION)){
 #ifdef _WIN32
-								if(info.subsystem == SDL_SYSWM_WINDOWS){
-									FLASHWINFO flashinfo;
-									flashinfo.cbSize = sizeof(flashinfo);
-									flashinfo.hwnd = info.info.win.window;
-									flashinfo.dwFlags = FLASHW_ALL | FLASHW_TIMERNOFG;
-									flashinfo.uCount = 0xFFFFFFFF;
-									flashinfo.dwTimeout = 0;
-									FlashWindowEx(&flashinfo);
-								}
+							HWND hwnd = (HWND)SDL_GetPointerProperty(SDL_GetWindowProperties(window), SDL_PROP_WINDOW_WIN32_HWND_POINTER, NULL);
+							if(hwnd){
+								FLASHWINFO flashinfo;
+								flashinfo.cbSize = sizeof(flashinfo);
+								flashinfo.hwnd = hwnd;
+								flashinfo.dwFlags = FLASHW_ALL | FLASHW_TIMERNOFG;
+								flashinfo.uCount = 0xFFFFFFFF;
+								flashinfo.dwTimeout = 0;
+								FlashWindowEx(&flashinfo);
+							}
 #endif
 #ifdef __APPLE__
-								if(info.subsystem == SDL_SYSWM_COCOA){
-									//NSWindow * nswindow = info.info.cocoa.window;
-									RequestUserAttention();
-								}
+							RequestUserAttention();
 #endif
-							}
 						}
 						bool scroll = false;
 						while(world.lobby.chatmessages.size() > chatlinesprinted){
@@ -5839,9 +5822,8 @@ void Game::LoadRandomGameMusic(void){
 		return;
 	}
 	if(world.resources.gamemusic){
-		Mix_FadeOutMusic(0);
-		Mix_ResumeMusic();
-		Mix_FreeMusic(world.resources.gamemusic);
+		Audio::GetInstance().StopMusic();
+		MIX_DestroyAudio(world.resources.gamemusic);
 		world.resources.gamemusic = 0;
 	}
 	if(!world.resources.gamemusic){
@@ -5859,7 +5841,7 @@ void Game::LoadRandomGameMusic(void){
 			const char * randomfile = files[rand() % files.size()].c_str();
 			strcat(filename, randomfile);
 			strncpy(currentmusictrack, randomfile, sizeof(currentmusictrack) - 1);
-			world.resources.gamemusic = Mix_LoadMUS(filename);
+			world.resources.gamemusic = MIX_LoadAudio(Audio::GetInstance().GetMixer(), filename, false);
 		}
 	}
 }
@@ -5903,13 +5885,13 @@ std::string Game::FindMap(const char * name, unsigned char (*hash)[20], const ch
 				std::string filename = GetDataDir() + directory;
 				filename.append("/");
 				filename.append(*it);
-				SDL_RWops * file = SDL_RWFromFile(filename.c_str(), "rb");
+				SDL_IOStream * file = SDL_IOFromFile(filename.c_str(), "rb");
 				if(!file){
 					filename = GetResDir() + directory;
 					filename.append("/");
 					filename.append(*it);
 				}else{
-					SDL_RWclose(file);
+					SDL_CloseIO(file);
 				}
 				//printf("found %s\n", filename.c_str());
 				if(!hash){
@@ -5935,10 +5917,10 @@ std::string Game::SaveMap(const char * name, unsigned char * data, int size){
 	CreateDirectory((GetDataDir() + "level/download").c_str());
 	CreateDirectory((GetDataDir() + "level/archive").c_str());
 	filename.append(name);
-	SDL_RWops * file = SDL_RWFromFile(filename.c_str(), "wb");
+	SDL_IOStream * file = SDL_IOFromFile(filename.c_str(), "wb");
 	if(file){
-		SDL_RWwrite(file, data, 1, size);
-		SDL_RWclose(file);
+		SDL_WriteIO(file, data, size);
+		SDL_CloseIO(file);
 	}
 	unsigned char hash[20];
 	CalculateMapHash(filename.c_str(), &hash);
@@ -5946,10 +5928,10 @@ std::string Game::SaveMap(const char * name, unsigned char * data, int size){
 	archivefilename.append(StringFromHash(&hash));
 	archivefilename.append(".");
 	archivefilename.append(name);
-	file = SDL_RWFromFile(archivefilename.c_str(), "wb");
+	file = SDL_IOFromFile(archivefilename.c_str(), "wb");
 	if(file){
-		SDL_RWwrite(file, data, 1, size);
-		SDL_RWclose(file);
+		SDL_WriteIO(file, data, size);
+		SDL_CloseIO(file);
 	}
 	return filename;
 }
@@ -5957,14 +5939,14 @@ std::string Game::SaveMap(const char * name, unsigned char * data, int size){
 bool Game::CalculateMapHash(const char * filename, unsigned char (*hash)[20]){
 	std::vector<Uint8> mapdata(65535);
 	CDDataDir();
-	SDL_RWops * file = SDL_RWFromFile(filename, "rb");
+	SDL_IOStream * file = SDL_IOFromFile(filename, "rb");
 	if(!file){
 		CDResDir();
-		file = SDL_RWFromFile(filename, "rb");
+		file = SDL_IOFromFile(filename, "rb");
 	}
 	if(file){
-		int mapdatasize = SDL_RWread(file, mapdata.data(), 1, mapdata.size());
-		SDL_RWclose(file);
+		int mapdatasize = SDL_ReadIO(file, mapdata.data(), mapdata.size());
+		SDL_CloseIO(file);
 		sha1::calc(mapdata.data(), mapdatasize, *hash);
 		return true;
 	}
@@ -5984,17 +5966,17 @@ std::string Game::StringFromHash(unsigned char (*hash)[20]){
 void Game::LoadMapData(const char * filename){
 	//printf("loading map data from %s\n", filename);
 	CDDataDir();
-	SDL_RWops * file = SDL_RWFromFile((GetDataDir() + filename).c_str(), "rb");
+	SDL_IOStream * file = SDL_IOFromFile((GetDataDir() + filename).c_str(), "rb");
 	if(!file){
 		CDResDir();
-		file = SDL_RWFromFile((GetResDir() + filename).c_str(), "rb");
+		file = SDL_IOFromFile((GetResDir() + filename).c_str(), "rb");
 	}
 	if(file){
-		int length = SDL_RWread(file, world.currentmapdata.data(), 1, world.currentmapdata.size());
+		int length = SDL_ReadIO(file, world.currentmapdata.data(), world.currentmapdata.size());
 		world.currentmapdata.resize(length);
 		world.currentmapdataend = true;
 		//printf("length: %d %s\n", world.currentmapdata.size(), SDL_GetError());
-		SDL_RWclose(file);
+		SDL_CloseIO(file);
 	}
 }
 

--- a/clients/silencer/src/game.cpp
+++ b/clients/silencer/src/game.cpp
@@ -116,7 +116,7 @@ Game::~Game(){
 		SDL_GL_DeleteContext(glcontext);
 	}
 	if(sdlscreenbuffer){
-		SDL_FreeSurface(sdlscreenbuffer);
+		SDL_DestroySurface(sdlscreenbuffer);
 	}
 	if(usingopengl){
 		SDL_GL_UnloadLibrary();
@@ -126,9 +126,6 @@ Game::~Game(){
 	}
 	if(streamingtexture){
 		SDL_DestroyTexture(streamingtexture);
-	}
-	if(streamingtexturepixelformat){
-		SDL_FreeFormat(streamingtexturepixelformat);
 	}
 	if(window){
 		SDL_DestroyWindow(window);
@@ -193,13 +190,13 @@ bool Game::Load(char * cmdline){
 	Config::GetInstance().Load();
 	if(world.dedicatedserver.active){
 		// Minimal init for dedicated-server mode: timer for SDL_GetTicks pacing.
-		if(SDL_Init(SDL_INIT_TIMER) == -1){
+		if(!SDL_Init(SDL_INIT_TIMER)){
 			printf("Could not initialize SDL timer %s\n", SDL_GetError());
 			return false;
 		}
 	}
 	if(!world.dedicatedserver.active){
-		if(SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_TIMER) == -1){
+		if(!SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_TIMER)){
 			printf("Could not initialize SDL %s\n", SDL_GetError());
 			return false;
 		}
@@ -223,15 +220,16 @@ bool Game::Load(char * cmdline){
 			return false;
 		}
 		SDL_AddTimer(1000, TimerCallback, this);
-		SDL_EventState(SDL_TEXTINPUT, SDL_TRUE); //SDL_EnableUNICODE(true);
+		//SDL_EnableUNICODE(true);
 		//SDL_EnableKeyRepeat(SDL_DEFAULT_REPEAT_DELAY, SDL_DEFAULT_REPEAT_INTERVAL);
 		//screen = SDL_SetVideoMode(640, 480, 8, SDL_DOUBLEBUF | SDL_SWSURFACE);
-		window = SDL_CreateWindow("Silencer", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, screenbuffer.w, screenbuffer.h, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | (Config::GetInstance().fullscreen ? SDL_WINDOW_FULLSCREEN_DESKTOP : 0));
+		window = SDL_CreateWindow("Silencer", screenbuffer.w, screenbuffer.h, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | (Config::GetInstance().fullscreen ? SDL_WINDOW_FULLSCREEN : 0));
+		SDL_StartTextInput(window);
 		if(!SetupOpenGL()){
 			//printf("Unable to setup OpenGL shaders, using SDL Renderer\n");
 			usingopengl = false;
 			CreateRenderer();
-			sdlscreenbuffer = SDL_CreateRGBSurface(SDL_SWSURFACE, screenbuffer.w, screenbuffer.h, 8, 0, 0, 0, 0);
+			sdlscreenbuffer = SDL_CreateSurface(screenbuffer.w, screenbuffer.h, SDL_PIXELFORMAT_INDEX8);
 			CreateStreamingTexture();
 		}
 		SetColors(renderer.palette.GetColors());
@@ -384,7 +382,7 @@ void Game::CreateRenderer(void){
 		SDL_DestroyRenderer(windowrenderer);
 		windowrenderer = 0;
 	}
-	windowrenderer = SDL_CreateRenderer(window, -1, SDL_RENDERER_ACCELERATED | SDL_RENDERER_PRESENTVSYNC);
+	windowrenderer = SDL_CreateRenderer(window, NULL);
 }
 
 void Game::CreateStreamingTexture(void){
@@ -397,25 +395,10 @@ void Game::CreateStreamingTexture(void){
 		SDL_DestroyTexture(streamingtexture);
 		streamingtexture = 0;
 	}
-	if(streamingtexturepixelformat){
-		SDL_FreeFormat(streamingtexturepixelformat);
-		streamingtexturepixelformat = 0;
-	}
-	SDL_RendererInfo rendererinfo;
-	SDL_GetRendererInfo(windowrenderer, &rendererinfo);
-	Uint32 pixelformat = 0;
-	for(int i = 0; i < rendererinfo.num_texture_formats; i++){
-		Uint32 format = rendererinfo.texture_formats[i];
-		if(!SDL_ISPIXELFORMAT_FOURCC(format) && !SDL_ISPIXELFORMAT_INDEXED(format) && (!pixelformat || SDL_BYTESPERPIXEL(format) < SDL_BYTESPERPIXEL(pixelformat))){
-			pixelformat = format;
-		}
-	}
-	if(pixelformat){
-		streamingtexture = SDL_CreateTexture(windowrenderer, pixelformat, SDL_TEXTUREACCESS_STREAMING, screenbuffer.w, screenbuffer.h);
-		Uint32 format;
-		SDL_QueryTexture(streamingtexture, &format, 0, 0, 0);
-		streamingtexturepixelformat = SDL_AllocFormat(format);
-	}
+	// SDL3: pick a reliable non-indexed, non-FOURCC format
+	Uint32 pixelformat = SDL_PIXELFORMAT_XRGB8888;
+	streamingtexture = SDL_CreateTexture(windowrenderer, pixelformat, SDL_TEXTUREACCESS_STREAMING, screenbuffer.w, screenbuffer.h);
+	streamingtexturepixelformat = pixelformat;
 }
 
 void Game::Present(void){
@@ -472,7 +455,7 @@ void Game::Present(void){
 					}
 				}
 				SDL_UnlockTexture(streamingtexture);
-				SDL_RenderCopy(windowrenderer, streamingtexture, 0, 0);
+				SDL_RenderTexture(windowrenderer, streamingtexture, NULL, NULL);
 				SDL_RenderPresent(windowrenderer);
 			}
 		}else{
@@ -480,7 +463,7 @@ void Game::Present(void){
 			sdlscreenbuffer->pixels = screenbuffer.pixels.data();
 			SDL_Texture * texture = SDL_CreateTextureFromSurface(windowrenderer, sdlscreenbuffer);
 			sdlscreenbuffer->pixels = oldpixels;
-			SDL_RenderCopy(windowrenderer, texture, 0, 0);
+			SDL_RenderTexture(windowrenderer, texture, NULL, NULL);
 			SDL_DestroyTexture(texture);
 			SDL_RenderPresent(windowrenderer);
 		}
@@ -510,17 +493,17 @@ void Game::SetColors(SDL_Color * colors){
 		glPixelStorei(GL_PACK_ALIGNMENT, 4);
 		glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, 256, 1, GL_RGBA, GL_UNSIGNED_BYTE, colors);*/
 	}else{
-		SDL_SetPaletteColors(sdlscreenbuffer->format->palette, colors, 0, 256);
+		SDL_SetPaletteColors(sdlscreenbuffer->palette, colors, 0, 256);
 		if(streamingtexture){
 			for(int i = 0; i < 256; i++){
-				streamingtexturepalette[i] = SDL_MapRGB(streamingtexturepixelformat, colors[i].r, colors[i].g, colors[i].b);
+				streamingtexturepalette[i] = SDL_MapRGB(SDL_GetPixelFormatDetails(streamingtexturepixelformat), NULL, colors[i].r, colors[i].g, colors[i].b);
 			}
 		}
 	}
 }
 
-Uint32 Game::TimerCallback(Uint32 interval, void * param){
-	Game * game = static_cast<Game *>(param);
+Uint32 Game::TimerCallback(void * userdata, SDL_TimerID timerID, Uint32 interval){
+	Game * game = static_cast<Game *>(userdata);
 	game->updatetitle = true;
 	game->fps = game->frames;
 	return 1000;
@@ -547,7 +530,7 @@ bool Game::Loop(void){
 		world.DoNetwork();
 	}*/
 	world.DoNetwork();
-	Uint32 tickcheck = SDL_GetTicks();
+	Uint64 tickcheck = SDL_GetTicks();
 	if(world.replay.IsPlaying()){
 		wait = 42 * world.replay.speed;
 		if(world.replay.ffmpeg && world.replay.ffmpegvideo){
@@ -605,9 +588,9 @@ bool Game::Loop(void){
 			int j = 0;
 			for(int y = screenbuffer.h; y > 0; y--){
 				for(int x = screenbuffer.w; x > 0; x--){
-					buffer[i++] = sdlscreenbuffer->format->palette->colors[screenbuffer.pixels[j]].r;
-					buffer[i++] = sdlscreenbuffer->format->palette->colors[screenbuffer.pixels[j]].g;
-					buffer[i++] = sdlscreenbuffer->format->palette->colors[screenbuffer.pixels[j]].b;
+					buffer[i++] = sdlscreenbuffer->palette->colors[screenbuffer.pixels[j]].r;
+					buffer[i++] = sdlscreenbuffer->palette->colors[screenbuffer.pixels[j]].g;
+					buffer[i++] = sdlscreenbuffer->palette->colors[screenbuffer.pixels[j]].b;
 					j++;
 				}
 			}
@@ -713,17 +696,17 @@ bool Game::Tick(void){
 	
 	if(world.gameplaystate == World::INGAME && (state == INGAME || state == SINGLEPLAYERGAME || state == TESTGAME)){
 		UpdateAmbienceChannels();
-		SDL_ShowCursor(SDL_DISABLE);
+		SDL_HideCursor();
 	}else{
-		SDL_ShowCursor(SDL_ENABLE);
+		SDL_ShowCursor();
 	}
 	
 	if(keystate[SDL_SCANCODE_RALT] && keystate[SDL_SCANCODE_RETURN]){
 		if(!fullscreentoggled){
-			if(SDL_GetWindowFlags(window) & SDL_WINDOW_FULLSCREEN_DESKTOP){
-				SDL_SetWindowFullscreen(window, 0);
+			if(SDL_GetWindowFlags(window) & SDL_WINDOW_FULLSCREEN){
+				SDL_SetWindowFullscreen(window, false);
 			}else{
-				SDL_SetWindowFullscreen(window, SDL_WINDOW_FULLSCREEN_DESKTOP);
+				SDL_SetWindowFullscreen(window, true);
 			}
 			fullscreentoggled = true;
 		}
@@ -1828,9 +1811,9 @@ bool Game::Tick(void){
 									case 0:{ // fullscreen
 										Config::GetInstance().fullscreen = Config::GetInstance().fullscreen ? false : true;
 										if(Config::GetInstance().fullscreen){
-											SDL_SetWindowFullscreen(window, SDL_WINDOW_FULLSCREEN_DESKTOP);
+											SDL_SetWindowFullscreen(window, true);
 										}else{
-											SDL_SetWindowFullscreen(window, 0);
+											SDL_SetWindowFullscreen(window, false);
 										}
 									}break;
 									case 1:{ // smooth scaling
@@ -1845,9 +1828,9 @@ bool Game::Tick(void){
 										Config::GetInstance().Load();
 										CreateStreamingTexture();
 										if(Config::GetInstance().fullscreen){
-											SDL_SetWindowFullscreen(window, SDL_WINDOW_FULLSCREEN_DESKTOP);
+											SDL_SetWindowFullscreen(window, true);
 										}else{
-											SDL_SetWindowFullscreen(window, 0);
+											SDL_SetWindowFullscreen(window, false);
 										}
 										GoToState(OPTIONS);
 									}break;
@@ -2154,9 +2137,9 @@ bool Game::Tick(void){
 }
 
 void Game::UpdateInputState(Input & input){
-	int mousex;
-	int mousey;
-	Uint8 mousestate = SDL_GetMouseState(&mousex, &mousey);
+	float mousex;
+	float mousey;
+	Uint32 mousestate = SDL_GetMouseState(&mousex, &mousey);
 	input.keymoveup = Config::GetInstance().KeyIsPressed(keystate, Config::GetInstance().keymoveupbinding, Config::GetInstance().keymoveupoperator);
 	input.keymovedown = Config::GetInstance().KeyIsPressed(keystate, Config::GetInstance().keymovedownbinding, Config::GetInstance().keymovedownoperator);
 	input.keymoveleft = Config::GetInstance().KeyIsPressed(keystate, Config::GetInstance().keymoveleftbinding, Config::GetInstance().keymoveleftoperator);
@@ -4785,8 +4768,7 @@ bool Game::ProcessLobbyInterface(Interface * iface){
 						ScrollBar * scrollbar = static_cast<ScrollBar *>(object);
 						if(minimized && world.lobby.chatmessages.size() > chatlinesprinted){
 							SDL_SysWMinfo info;
-							SDL_VERSION(&info.version);
-							if(SDL_GetWindowWMInfo(window, &info)){
+						if(SDL_GetWindowWMInfo(window, &info, SDL_SYSWM_CURRENT_VERSION)){
 #ifdef _WIN32
 								if(info.subsystem == SDL_SYSWM_WINDOWS){
 									FLASHWINFO flashinfo;
@@ -6068,39 +6050,35 @@ bool Game::HandleSDLEvents(void){
 	SDL_Event event;
 	while(SDL_PollEvent(&event) > 0){
 		switch(event.type){
-			case SDL_WINDOWEVENT:{
-				switch(event.window.event){
-					case SDL_WINDOWEVENT_RESIZED:{
-						if(usingopengl){
-							//glViewport(0, 0, event.window.data1, event.window.data2);
-						}
-					}break;
-					case SDL_WINDOWEVENT_FOCUS_GAINED:{
-						// fix for Windows sdl bug where viewport is changed when another app goes fullscreen, causing render to go black
-						SDL_RenderSetViewport(windowrenderer, 0);
-						if(!world.replay.IsPlaying()){
-							Audio::GetInstance().Unmute();
-						}
-						minimized = false;
-					}break;
-					case SDL_WINDOWEVENT_FOCUS_LOST:{
-						if(!world.replay.IsPlaying()){
-							Audio::GetInstance().Mute(25);
-						}
-						minimized = true;
-					}break;
-					case SDL_WINDOWEVENT_MINIMIZED:{
-						minimized = true;
-					}break;
-					case SDL_WINDOWEVENT_MAXIMIZED:{
-						minimized = false;
-					}break;
-					case SDL_WINDOWEVENT_RESTORED:{
-						minimized = false;
-					}break;
+			case SDL_EVENT_WINDOW_RESIZED:{
+				if(usingopengl){
+					//glViewport(0, 0, event.window.data1, event.window.data2);
 				}
 			}break;
-			case SDL_TEXTINPUT:{
+			case SDL_EVENT_WINDOW_FOCUS_GAINED:{
+				// fix for Windows sdl bug where viewport is changed when another app goes fullscreen, causing render to go black
+				SDL_SetRenderViewport(windowrenderer, NULL);
+				if(!world.replay.IsPlaying()){
+					Audio::GetInstance().Unmute();
+				}
+				minimized = false;
+			}break;
+			case SDL_EVENT_WINDOW_FOCUS_LOST:{
+				if(!world.replay.IsPlaying()){
+					Audio::GetInstance().Mute(25);
+				}
+				minimized = true;
+			}break;
+			case SDL_EVENT_WINDOW_MINIMIZED:{
+				minimized = true;
+			}break;
+			case SDL_EVENT_WINDOW_MAXIMIZED:{
+				minimized = false;
+			}break;
+			case SDL_EVENT_WINDOW_RESTORED:{
+				minimized = false;
+			}break;
+			case SDL_EVENT_TEXT_INPUT:{
 				char ascii = event.text.text[0] & 0x7F;
 				bool skip = true;
 				if(ascii >= 0x20 && ascii <= 0x7F){
@@ -6128,8 +6106,8 @@ bool Game::HandleSDLEvents(void){
 					}
 				}
 			}break;
-			case SDL_KEYDOWN:{
-				if(event.key.keysym.scancode == quitscancode){
+			case SDL_EVENT_KEY_DOWN:{
+				if(event.key.scancode == quitscancode){
 					Player * localplayer = world.GetPeerPlayer(world.localpeerid);
 					if(localplayer && !localplayer->chatinterfaceid && !localplayer->buyinterfaceid){
 						if(world.quitstate == 0){
@@ -6140,23 +6118,23 @@ bool Game::HandleSDLEvents(void){
 						}
 					}
 				}
-				if(event.key.keysym.scancode == SDL_SCANCODE_F1){
+				if(event.key.scancode == SDL_SCANCODE_F1){
 					world.showplayerlist = true;
 				}
-				if(event.key.keysym.scancode == SDL_SCANCODE_F2){
+				if(event.key.scancode == SDL_SCANCODE_F2){
 					if(world.showteamcolors){
 						world.showteamcolors = false;
 					}else{
 						world.showteamcolors = true;
 					}
 				}
-				if(event.key.keysym.scancode == SDL_SCANCODE_F5){
+				if(event.key.scancode == SDL_SCANCODE_F5){
 					// play new music track
 					LoadRandomGameMusic();
 					//Audio::GetInstance().PlayMusic(world.resources.gamemusic);
 					PlayMusic(world.resources.gamemusic);
 				}
-				if(event.key.keysym.scancode == SDL_SCANCODE_F4){
+				if(event.key.scancode == SDL_SCANCODE_F4){
 					// toggle music playing
 					if(Config::GetInstance().music){
 						if(Audio::GetInstance().MusicPaused()){
@@ -6168,10 +6146,10 @@ bool Game::HandleSDLEvents(void){
 						}
 					}
 				}
-				keystate[event.key.keysym.scancode] = true;
-				bool skip = true;
-				Uint8 ascii;
-				switch(event.key.keysym.scancode){
+				keystate[event.key.scancode] = true;
+			bool skip = true;
+			Uint8 ascii;
+			switch(event.key.scancode){
 					case SDL_SCANCODE_LEFT:
 						ascii = 1;
 						skip = false;
@@ -6217,14 +6195,14 @@ bool Game::HandleSDLEvents(void){
 				}
 				Interface * iface = (Interface *)world.GetObjectFromId(currentinterface);
 				if(iface){
-					iface->lastsym = event.key.keysym.scancode;
+					iface->lastsym = event.key.scancode;
 					if(!skip){
 						iface->ProcessKeyPress(world, ascii);
 					}
 				}
 			}break;
-			case SDL_KEYUP:{
-				if(event.key.keysym.scancode == quitscancode){
+			case SDL_EVENT_KEY_UP:{
+				if(event.key.scancode == quitscancode){
 					if(world.quitstate == 1){
 						world.quitstate = 2;
 					}
@@ -6232,12 +6210,12 @@ bool Game::HandleSDLEvents(void){
 						world.quitstate = 0;
 					}
 				}
-				if(event.key.keysym.scancode == SDL_SCANCODE_F1){
+				if(event.key.scancode == SDL_SCANCODE_F1){
 					world.showplayerlist = false;
 				}
-				keystate[event.key.keysym.scancode] = false;
+				keystate[event.key.scancode] = false;
 			}break;
-			case SDL_MOUSEWHEEL:{
+			case SDL_EVENT_MOUSE_WHEEL:{
 				Interface * iface = (Interface *)world.GetObjectFromId(currentinterface);
 				if(iface){
 					if(event.wheel.y > 0){
@@ -6248,7 +6226,7 @@ bool Game::HandleSDLEvents(void){
 					}
 				}
 			}break;
-			case SDL_MOUSEBUTTONDOWN:{
+			case SDL_EVENT_MOUSE_BUTTON_DOWN:{
 				Interface * iface = (Interface *)world.GetObjectFromId(currentinterface);
 				if(iface){
 					if(event.button.button == SDL_BUTTON_LEFT){
@@ -6258,7 +6236,7 @@ bool Game::HandleSDLEvents(void){
 					}
 				}
 			}break;
-			case SDL_MOUSEBUTTONUP:{
+			case SDL_EVENT_MOUSE_BUTTON_UP:{
 				if(event.button.button == SDL_BUTTON_LEFT){
 					Interface * iface = (Interface *)world.GetObjectFromId(currentinterface);
 					if(iface){
@@ -6268,7 +6246,7 @@ bool Game::HandleSDLEvents(void){
 					}
 				}
 			}break;
-			case SDL_MOUSEMOTION:{
+			case SDL_EVENT_MOUSE_MOTION:{
 				Interface * iface = (Interface *)world.GetObjectFromId(currentinterface);
 				if(iface){
 					int w, h;
@@ -6276,7 +6254,7 @@ bool Game::HandleSDLEvents(void){
 					iface->ProcessMouseMove(world, (float(event.button.x) / w) * 640, (float(event.button.y) / h) * 480);
 				}
 			}break;
-			case SDL_QUIT:
+			case SDL_EVENT_QUIT:
 				return false;
 			break;
 		}

--- a/clients/silencer/src/game.h
+++ b/clients/silencer/src/game.h
@@ -113,7 +113,7 @@ private:
 	void ProcessMapDownload(void);
 	static const int numkeys = 20;
 	const char * keynames[numkeys];
-	Uint8 keystate[SDL_NUM_SCANCODES];
+	Uint8 keystate[SDL_SCANCODE_COUNT];
 	enum {NONE, FADEOUT, MAINMENU, LOBBYCONNECT, LOBBY, UPDATING, INGAME, MISSIONSUMMARY, SINGLEPLAYERGAME, OPTIONS, OPTIONSCONTROLS, OPTIONSDISPLAY, OPTIONSAUDIO, HOSTGAME, JOINGAME, REPLAYGAME, TESTGAME};
 	Uint8 state;
 	Uint8 nextstate;

--- a/clients/silencer/src/game.h
+++ b/clients/silencer/src/game.h
@@ -34,7 +34,7 @@ private:
 	bool SetupOpenGL(void);
 	void CreateRenderer(void);
 	void CreateStreamingTexture(void);
-	static Uint32 TimerCallback(Uint32 interval, void * param);
+	static Uint32 TimerCallback(void * userdata, SDL_TimerID timerID, Uint32 interval);
 	void SetColors(SDL_Color * colors);
 	void UpdateInputState(Input & input);
 	bool LoadMap(const char * name);
@@ -131,11 +131,11 @@ private:
 	Surface screenbuffer;
 	SDL_Surface * sdlscreenbuffer;
 	SDL_Texture * streamingtexture;
-	SDL_PixelFormat * streamingtexturepixelformat;
+	SDL_PixelFormat streamingtexturepixelformat;
 	Uint32 streamingtexturepalette[256];
 	int frames;
 	int fps;
-	Uint32 lasttick;
+	Uint64 lasttick;
 	Uint16 currentinterface;
 	Uint16 aftermodalinterface;
 	bool motdprinted;

--- a/clients/silencer/src/lobby.cpp
+++ b/clients/silencer/src/lobby.cpp
@@ -455,11 +455,11 @@ void Lobby::ResolveHostname(const char * host){
 }
 
 void Lobby::LockMutex(void){
-	SDL_mutexP(mutex);
+	SDL_LockMutex(mutex);
 }
 
 void Lobby::UnlockMutex(void){
-	SDL_mutexV(mutex);
+	SDL_UnlockMutex(mutex);
 }
 
 void Lobby::SendMessage(const char msg[256], Uint8 size){
@@ -679,7 +679,8 @@ int Lobby::ResolveThreadFunc(void * param){
 	strcpy(host, ((Lobby *)param)->resolvehost);
 	((Lobby *)param)->resolvethreadrunning = true;
 	hostent * he = gethostbyname(host);
-	if(SDL_mutexP(mutex) == 0){
+	SDL_LockMutex(mutex);
+	{
 		((Lobby *)param)->he = he;
 		if(he && he->h_addr){
 			((Lobby *)param)->state = RESOLVED;
@@ -689,7 +690,7 @@ int Lobby::ResolveThreadFunc(void * param){
 			((Lobby *)param)->state = RESOLVEFAILED;
 		}
 		((Lobby *)param)->resolvethreadrunning = false;
-		SDL_mutexV(mutex);
+		SDL_UnlockMutex(mutex);
 	}
 	return 0;
 }

--- a/clients/silencer/src/lobby.cpp
+++ b/clients/silencer/src/lobby.cpp
@@ -674,7 +674,7 @@ bool Lobby::Send(const char * data, unsigned int size){
 }
 
 int Lobby::ResolveThreadFunc(void * param){
-	SDL_mutex * mutex = ((Lobby *)param)->mutex;
+	SDL_Mutex * mutex = ((Lobby *)param)->mutex;
 	char host[256];
 	strcpy(host, ((Lobby *)param)->resolvehost);
 	((Lobby *)param)->resolvethreadrunning = true;

--- a/clients/silencer/src/lobby.h
+++ b/clients/silencer/src/lobby.h
@@ -76,7 +76,7 @@ private:
 	char msg[0xFF];
 	Uint32 lasttime;
 	SDL_Thread * resolvethread;
-	SDL_mutex * mutex;
+	SDL_Mutex * mutex;
 	hostent * he;
 	bool resolvethreadrunning;
 	char resolvehost[256];

--- a/clients/silencer/src/main.cpp
+++ b/clients/silencer/src/main.cpp
@@ -43,10 +43,10 @@ extern "C" void Java_com_silencer_game_Silencer_SetPath(JNIEnv * env, jclass cls
 extern "C" void Java_com_silencer_game_Silencer_OuyaControllerKeyEvent(JNIEnv * env, jclass cls, jint player, jint type, jint keycode){
 	static SDL_Event pushedevent;
 	if(type == 1){
-		pushedevent.type = SDL_KEYDOWN;
+		pushedevent.type = SDL_EVENT_KEY_DOWN;
 		//printf("native ouya key down %d\n", keycode);
 	}else{
-		pushedevent.type = SDL_KEYUP;
+		pushedevent.type = SDL_EVENT_KEY_UP;
 	}
 	int keycode2 = keycode;
 	switch(keycode){
@@ -64,7 +64,7 @@ extern "C" void Java_com_silencer_game_Silencer_OuyaControllerKeyEvent(JNIEnv * 
 		case 202: keycode2 = SDL_SCANCODE_KP_6; break; // RRight
 		case 203: keycode2 = SDL_SCANCODE_KP_8; break; // RDown
 	}
-	pushedevent.key.keysym.scancode = (SDL_Scancode)keycode2;
+	pushedevent.key.scancode = (SDL_Scancode)keycode2;
 	SDL_PushEvent(&pushedevent);
 }
 #endif
@@ -255,11 +255,11 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 		return -1;
 	}
 
-	int x = 0, y = 0;
+	float x = 0, y = 0;
 	if(!dedicatedmode){
 		SDL_GetMouseState(&x, &y);
 	}
-	srand(x + y + (int)time(NULL));
+	srand((int)x + (int)y + (int)time(NULL));
 	while(1){
 		if(!game.HandleSDLEvents()){
 #ifdef __ANDROID__

--- a/clients/silencer/src/map.cpp
+++ b/clients/silencer/src/map.cpp
@@ -87,31 +87,31 @@ bool Map::LoadBase(Team & team, World & world){
 	return LoadFile((GetResDir() + "XBASE15A.SIL").c_str(), world, &team);
 }
 
-bool Map::LoadHeader(SDL_RWops * file, Map::Header & header){
+bool Map::LoadHeader(SDL_IOStream * file, Map::Header & header){
 	Uint8 padding = 0;
-	if(!SDL_RWread(file, &header.firstbyte, 1, 1)){ return false; }
-	if(!SDL_RWread(file, &header.version, 1, 1)){ return false; }
-	if(!SDL_RWread(file, &header.maxplayers, 1, 1)){ return false; }
-	if(!SDL_RWread(file, &header.maxteams, 1, 1)){ return false; }
-	if(!SDL_RWread(file, &header.width, 2, 1)){ return false; }
-	if(!SDL_RWread(file, &header.height, 2, 1)){ return false; }
-	header.width = SDL_SwapBE16(header.width);
-	header.height = SDL_SwapBE16(header.height);
-	if(!SDL_RWread(file, &padding, 1, 1)){ return false; }
-	if(!SDL_RWread(file, &header.parallax, 1, 1)){ return false; }
-	if(!SDL_RWread(file, &header.ambience, 1, 1)){ return false; }
+	if(!SDL_ReadIO(file, &header.firstbyte, 1)){ return false; }
+	if(!SDL_ReadIO(file, &header.version, 1)){ return false; }
+	if(!SDL_ReadIO(file, &header.maxplayers, 1)){ return false; }
+	if(!SDL_ReadIO(file, &header.maxteams, 1)){ return false; }
+	if(!SDL_ReadIO(file, &header.width, 2)){ return false; }
+	if(!SDL_ReadIO(file, &header.height, 2)){ return false; }
+	header.width = SDL_Swap16BE(header.width);
+	header.height = SDL_Swap16BE(header.height);
+	if(!SDL_ReadIO(file, &padding, 1)){ return false; }
+	if(!SDL_ReadIO(file, &header.parallax, 1)){ return false; }
+	if(!SDL_ReadIO(file, &header.ambience, 1)){ return false; }
 	//ambience -= 128;
-	if(!SDL_RWread(file, &padding, 1, 1)){ return false; }
-	if(!SDL_RWread(file, &padding, 1, 1)){ return false; }
-	if(!SDL_RWread(file, &header.flags, 4, 1)){ return false; }
-	header.flags = SDL_SwapBE32(header.flags);
-	if(!SDL_RWread(file, &header.description, 1, 0x80)){ return false; }
+	if(!SDL_ReadIO(file, &padding, 1)){ return false; }
+	if(!SDL_ReadIO(file, &padding, 1)){ return false; }
+	if(!SDL_ReadIO(file, &header.flags, 4)){ return false; }
+	header.flags = SDL_Swap32BE(header.flags);
+	if(!SDL_ReadIO(file, &header.description, 0x80)){ return false; }
 	header.description[0x80 - 1] = 0;
-	if(!SDL_RWread(file, &header.minimapcompressedsize, 4, 1)){ return false; }
-	header.minimapcompressedsize = SDL_SwapLE32(header.minimapcompressedsize);
-	if(!SDL_RWread(file, header.minimapcompressed, 1, header.minimapcompressedsize)){ return false; }
-	if(!SDL_RWread(file, &header.levelsize, 4, 1)){ return false; }
-	header.levelsize = SDL_SwapLE32(header.levelsize);
+	if(!SDL_ReadIO(file, &header.minimapcompressedsize, 4)){ return false; }
+	header.minimapcompressedsize = SDL_Swap32LE(header.minimapcompressedsize);
+	if(!SDL_ReadIO(file, header.minimapcompressed, header.minimapcompressedsize)){ return false; }
+	if(!SDL_ReadIO(file, &header.levelsize, 4)){ return false; }
+	header.levelsize = SDL_Swap32LE(header.levelsize);
 	return true;
 }
 
@@ -125,10 +125,10 @@ bool Map::UncompressMinimap(Uint8 (*pixels)[172 * 62], const Uint8 * compressed,
 
 bool Map::LoadFile(const char * filename, World & world, Team * team){
 	CDDataDir();
-	SDL_RWops * file = SDL_RWFromFile(filename, "rb");
+	SDL_IOStream * file = SDL_IOFromFile(filename, "rb");
 	if(!file){
 		CDResDir();
-		file = SDL_RWFromFile(filename, "rb");
+		file = SDL_IOFromFile(filename, "rb");
 	}
 	if(!file){
 		return false;
@@ -142,8 +142,8 @@ bool Map::LoadFile(const char * filename, World & world, Team * team){
 	if(!LoadHeader(file, header)){
 		return false;
 	}
-	if(!SDL_RWread(file, levelcompressed, 1, header.levelsize)){ return false; }
-	SDL_RWclose(file);
+	if(!SDL_ReadIO(file, levelcompressed, header.levelsize)){ return false; }
+	SDL_CloseIO(file);
 	
 	if(header.width > 256 || header.height > 256){
 		return false;
@@ -213,7 +213,7 @@ bool Map::LoadFile(const char * filename, World & world, Team * team){
 	}
 	i = header.width * header.height * 36;
 	memcpy(&numactors, &level[i], sizeof(numactors));
-	numactors = SDL_SwapLE32(numactors);
+	numactors = SDL_Swap32LE(numactors);
 	i += sizeof(Uint32) + sizeof(Uint32);
 	for(unsigned int a = 0; a < numactors; a++){
 		Uint32 actorid;
@@ -226,31 +226,31 @@ bool Map::LoadFile(const char * filename, World & world, Team * team){
 		Uint32 actorunknown;
 		Uint32 actorsecurityid;
 		memcpy(&actorid, &level[i], sizeof(actorid));
-		actorid = SDL_SwapLE32(actorid);
+		actorid = SDL_Swap32LE(actorid);
 		i += sizeof(actorid);
 		memcpy(&actorx, &level[i], sizeof(actorx));
-		actorx = SDL_SwapLE32(actorx);
+		actorx = SDL_Swap32LE(actorx);
 		i += sizeof(actorx);
 		memcpy(&actory, &level[i], sizeof(actory));
-		actory = SDL_SwapLE32(actory);
+		actory = SDL_Swap32LE(actory);
 		i += sizeof(actory);
 		memcpy(&actordirection, &level[i], sizeof(actordirection));
-		actordirection = SDL_SwapLE32(actordirection);
+		actordirection = SDL_Swap32LE(actordirection);
 		i += sizeof(actordirection);
 		memcpy(&actortype, &level[i], sizeof(actortype));
-		actortype = SDL_SwapLE32(actortype);
+		actortype = SDL_Swap32LE(actortype);
 		i += sizeof(actortype);
 		memcpy(&actormatchid, &level[i], sizeof(actormatchid));
-		actormatchid = SDL_SwapLE32(actormatchid);
+		actormatchid = SDL_Swap32LE(actormatchid);
 		i += sizeof(actormatchid);
 		memcpy(&actorsubplane, &level[i], sizeof(actorsubplane));
-		actorsubplane = SDL_SwapLE32(actorsubplane);
+		actorsubplane = SDL_Swap32LE(actorsubplane);
 		i += sizeof(actorsubplane);
 		memcpy(&actorunknown, &level[i], sizeof(actorunknown));
-		actorunknown = SDL_SwapLE32(actorunknown);
+		actorunknown = SDL_Swap32LE(actorunknown);
 		i += sizeof(actorunknown);
 		memcpy(&actorsecurityid, &level[i], sizeof(actorsecurityid));
-		actorsecurityid = SDL_SwapLE32(actorsecurityid);
+		actorsecurityid = SDL_Swap32LE(actorsecurityid);
 		i += sizeof(actorsecurityid);
 		actory += yoffset * 64;
 		//printf("(%u, %u) %d id:%u type:%d match:%u subp:%u unk:%x secid:%d\n", actorx, actory, actordirection, actorid, actortype, actormatchid, actorsubplane, actorunknown, actorsecurityid);
@@ -669,30 +669,30 @@ bool Map::LoadFile(const char * filename, World & world, Team * team){
 		}
 	}
 	memcpy(&numplatforms, &level[i], sizeof(numplatforms));
-	numplatforms = SDL_SwapLE32(numplatforms);
+	numplatforms = SDL_Swap32LE(numplatforms);
 	i += sizeof(Uint32) + sizeof(Uint32);
 	
 	//FILE * fileo = fopen("platforms.txt", "w");
 	for(unsigned int j = 0; j < numplatforms; j++){
 		memcpy(&x1, &level[i], sizeof(x1));
-		x1 = SDL_SwapLE32(x1);
+		x1 = SDL_Swap32LE(x1);
 		i += sizeof(Uint32);
 		memcpy(&y1, &level[i], sizeof(y1));
-		y1 = SDL_SwapLE32(y1);
+		y1 = SDL_Swap32LE(y1);
 		y1 += (yoffset * 64);
 		i += sizeof(Uint32);
 		memcpy(&x2, &level[i], sizeof(x2));
-		x2 = SDL_SwapLE32(x2);
+		x2 = SDL_Swap32LE(x2);
 		i += sizeof(Uint32);
 		memcpy(&y2, &level[i], sizeof(y2));
-		y2 = SDL_SwapLE32(y2);
+		y2 = SDL_Swap32LE(y2);
 		y2 += (yoffset * 64);
 		i += sizeof(Uint32);
 		memcpy(&type1, &level[i], sizeof(type1));
-		type1 = SDL_SwapLE32(type1);
+		type1 = SDL_Swap32LE(type1);
 		i += sizeof(Uint32);
 		memcpy(&type2, &level[i], sizeof(type2));
-		type2 = SDL_SwapLE32(type2);
+		type2 = SDL_Swap32LE(type2);
 		i += sizeof(Uint32);
 		
 		Uint8 type = 255;

--- a/clients/silencer/src/map.h
+++ b/clients/silencer/src/map.h
@@ -34,7 +34,7 @@ public:
 	bool Load(const char * filename, class World & world);
 	bool LoadBase(class Team & team, class World & world);
 	bool LoadFile(const char * filename, class World & world, Team * team = 0);
-	static bool LoadHeader(SDL_RWops * file, Map::Header & header);
+	static bool LoadHeader(SDL_IOStream * file, Map::Header & header);
 	static bool UncompressMinimap(Uint8 (*pixels)[172 * 62], const Uint8 * compressed, int compressedsize);
 	void Unload(void);
 	void MiniMapCoords(int & x, int & y);

--- a/clients/silencer/src/mapfetch.cpp
+++ b/clients/silencer/src/mapfetch.cpp
@@ -2,7 +2,7 @@
 #include "sha1.h"
 #include "shared.h"
 #include "os.h"
-#include <SDL.h>
+#include <SDL3/SDL.h>
 #include <curl/curl.h>
 #include <atomic>
 #include <cstdio>
@@ -155,13 +155,13 @@ std::string FetchMapFromServer(const char * mapname,
     CreateDirectory(dir.c_str());
     std::string path = dir + "/" + mapname;
 
-    SDL_RWops * file = SDL_RWFromFile(path.c_str(), "wb");
+    SDL_IOStream * file = SDL_IOFromFile(path.c_str(), "wb");
     if (!file) {
         fprintf(stderr, "[mapfetch] cannot write %s\n", path.c_str());
         return "";
     }
-    SDL_RWwrite(file, buf.data.data(), 1, buf.data.size());
-    SDL_RWclose(file);
+    SDL_WriteIO(file, buf.data.data(), buf.data.size());
+    SDL_CloseIO(file);
 
     fprintf(stderr, "[mapfetch] downloaded %s (%zu bytes) from %s\n",
             mapname, buf.data.size(), apiURL);
@@ -234,9 +234,9 @@ void FetchAndSyncServerMaps(const char * apiURL) {
 
         // Skip if already present in level/download/.
         std::string dlpath = GetDataDir() + "level/download/" + name;
-        SDL_RWops * existing = SDL_RWFromFile(dlpath.c_str(), "rb");
+        SDL_IOStream * existing = SDL_IOFromFile(dlpath.c_str(), "rb");
         if (existing) {
-            SDL_RWclose(existing);
+            SDL_CloseIO(existing);
             continue;
         }
 

--- a/clients/silencer/src/palette.cpp
+++ b/clients/silencer/src/palette.cpp
@@ -36,30 +36,30 @@ bool Palette::Load(void){
 	system("rm PALETTECALC1.BIN");
 	system("rm PALETTECALC2.BIN");*/
 	CDResDir();
-	SDL_RWops * file = SDL_RWFromFile((GetResDir() + "PALETTE.BIN").c_str(), "rb");
+	SDL_IOStream * file = SDL_IOFromFile((GetResDir() + "PALETTE.BIN").c_str(), "rb");
 	CDDataDir();
-	SDL_RWops * filec = SDL_RWFromFile((GetDataDir() + filename).c_str(), "rb");
+	SDL_IOStream * filec = SDL_IOFromFile((GetDataDir() + filename).c_str(), "rb");
 	if(file){
 		for(int offset = 0; offset < 11; offset++){
-			SDL_RWseek(file, (offset * (768 + 4)) + 4, RW_SEEK_SET);
+			SDL_SeekIO(file, (offset * (768 + 4)) + 4, SDL_IO_SEEK_SET);
 			for(unsigned int i = 0; i < 256; i++){
 				Uint8 b, g, r;
-				SDL_RWread(file, &r, 1, 1);
-				SDL_RWread(file, &g, 1, 1);
-				SDL_RWread(file, &b, 1, 1);
+				SDL_ReadIO(file, &r, 1);
+				SDL_ReadIO(file, &g, 1);
+				SDL_ReadIO(file, &b, 1);
 				colors[offset][i].b = b << 2;
 				colors[offset][i].g = g << 2;
 				colors[offset][i].r = r << 2;
 			}
 		}
-		SDL_RWclose(file);
+		SDL_CloseIO(file);
 		if(filec){
 			for(unsigned int i = 0; i < 256; i++){
-				SDL_RWread(filec, &brightness[currentpalette][(i * 256)], 256, 1);
-				SDL_RWread(filec, &colored[currentpalette][(i * 256)], 256, 1);
-				SDL_RWread(filec, &alphaed[currentpalette][(i * 256)], 256, 1);
+				SDL_ReadIO(filec, &brightness[currentpalette][(i * 256)], 256);
+				SDL_ReadIO(filec, &colored[currentpalette][(i * 256)], 256);
+				SDL_ReadIO(filec, &alphaed[currentpalette][(i * 256)], 256);
 			}
-			SDL_RWclose(filec);
+			SDL_CloseIO(filec);
 		}else{
 			printf("%s not found, calculating lookup tables...\n", filename);
 			Calculate(2, 256 - 30);
@@ -116,17 +116,17 @@ void Palette::Save(void){
 	char filename[256];
 	sprintf(filename, "PALETTECALC%d.BIN", currentpalette);
 	CDDataDir();
-	SDL_RWops * file = SDL_RWFromFile((GetDataDir() + filename).c_str(), "wb");
+	SDL_IOStream * file = SDL_IOFromFile((GetDataDir() + filename).c_str(), "wb");
 	if(!file){
 		printf("Could not open %s for writing: %s\n", filename, SDL_GetError());
 		return;
 	}
 	for(unsigned int i = 0; i < 256; i++){
-		SDL_RWwrite(file, &brightness[currentpalette][(i * 256)], 256, 1);
-		SDL_RWwrite(file, &colored[currentpalette][(i * 256)], 256, 1);
-		SDL_RWwrite(file, &alphaed[currentpalette][(i * 256)], 256, 1);
+		SDL_WriteIO(file, &brightness[currentpalette][(i * 256)], 256);
+		SDL_WriteIO(file, &colored[currentpalette][(i * 256)], 256);
+		SDL_WriteIO(file, &alphaed[currentpalette][(i * 256)], 256);
 	}
-	SDL_RWclose(file);
+	SDL_CloseIO(file);
 }
 
 Uint8 Palette::ClosestMatch(SDL_Color color, bool upperonly){

--- a/clients/silencer/src/replay.cpp
+++ b/clients/silencer/src/replay.cpp
@@ -30,7 +30,7 @@ Replay::~Replay(){
 
 void Replay::BeginRecording(const char * filename){
 	CDDataDir();
-	file = SDL_RWFromFile(filename, "wb");
+	file = SDL_IOFromFile(filename, "wb");
 	if(file){
 		isrecording = true;
 	}
@@ -38,7 +38,7 @@ void Replay::BeginRecording(const char * filename){
 
 void Replay::EndRecording(void){
 	if(file){
-		SDL_RWclose(file);
+		SDL_CloseIO(file);
 	}
 	file = 0;
 	isrecording = false;
@@ -49,7 +49,7 @@ void Replay::BeginPlaying(const char * filename, const char * outfilename, bool 
 		return;
 	}
 	CDDataDir();
-	file = SDL_RWFromFile(filename, "rb");
+	file = SDL_IOFromFile(filename, "rb");
 	if(file){
 		isplaying = true;
 	}
@@ -73,7 +73,7 @@ void Replay::BeginPlaying(const char * filename, const char * outfilename, bool 
 
 void Replay::EndPlaying(void){
 	if(file){
-		SDL_RWclose(file);
+		SDL_CloseIO(file);
 	}
 	file = 0;
 #ifdef POSIX
@@ -88,14 +88,14 @@ void Replay::EndPlaying(void){
 void Replay::WriteHeader(World & world){
 	Serializer data;
 	for(int i = 0; i < strlen(world.version) + 1; i++){
-		SDL_RWwrite(file, &world.version[i], 1, 1);
+		SDL_WriteIO(file, &world.version[i], 1);
 	}
 	data.Put(world.randomseed);
 	data.Put(world.tickcount);
 	world.gameinfo.Serialize(Serializer::WRITE, data);
 	Uint32 datasize = data.BitsToBytes(data.offset);
-	SDL_RWwrite(file, &datasize, sizeof(datasize), 1);
-	SDL_RWwrite(file, data.data, data.BitsToBytes(data.offset), 1);
+	SDL_WriteIO(file, &datasize, sizeof(datasize));
+	SDL_WriteIO(file, data.data, data.BitsToBytes(data.offset));
 }
 
 bool Replay::ReadHeader(World & world){
@@ -105,7 +105,7 @@ bool Replay::ReadHeader(World & world){
 	char versionstring[16 + 1];
 	memset(versionstring, 0, sizeof(versionstring));
 	do{
-		read = SDL_RWread(file, &byte, 1, 1);
+		read = SDL_ReadIO(file, &byte, 1);
 		versionstring[i++] = byte;
 	}while(read && byte && i < 16);
 	if(strcmp(versionstring, world.version) != 0){
@@ -113,11 +113,11 @@ bool Replay::ReadHeader(World & world){
 	}
 	Serializer data;
 	Uint32 datasize = 0;
-	SDL_RWread(file, &datasize, sizeof(datasize), 1);
+	SDL_ReadIO(file, &datasize, sizeof(datasize));
 	if(datasize > data.size){
 		return false;
 	}
-	read = SDL_RWread(file, data.data, datasize, 1);
+	read = SDL_ReadIO(file, data.data, datasize);
 	if(read == 0){
 		return false;
 	}
@@ -131,7 +131,7 @@ bool Replay::ReadHeader(World & world){
 bool Replay::ReadToNextTick(World & world){
 	Uint8 code;
 	do{
-		int read = SDL_RWread(file, &code, 1, 1);
+		int read = SDL_ReadIO(file, &code, 1);
 		if(!read){
 			return false;
 		}
@@ -139,9 +139,9 @@ bool Replay::ReadToNextTick(World & world){
 			case RPL_GAMEINFO:{
 				printf("RPL_GAMEINFO\n");
 				Uint32 gameinfosize;
-				SDL_RWread(file, &gameinfosize, sizeof(gameinfosize), 1);
+				SDL_ReadIO(file, &gameinfosize, sizeof(gameinfosize));
 				Serializer data;
-				SDL_RWread(file, data.data, gameinfosize, 1);
+				SDL_ReadIO(file, data.data, gameinfosize);
 				data.offset = gameinfosize * 8;
 				world.gameinfo.Serialize(Serializer::READ, data);
 			}break;
@@ -149,8 +149,8 @@ bool Replay::ReadToNextTick(World & world){
 				printf("RPL_NEWPEER\n");
 				Uint8 agency;
 				Uint32 accountid;
-				SDL_RWread(file, &agency, 1, 1);
-				SDL_RWread(file, &accountid, sizeof(accountid), 1);
+				SDL_ReadIO(file, &agency, 1);
+				SDL_ReadIO(file, &accountid, sizeof(accountid));
 				world.AddPeer((char *)"local", uniqueport++, agency, accountid);
 			}break;
 			case RPL_START:{
@@ -160,9 +160,9 @@ bool Replay::ReadToNextTick(World & world){
 			case RPL_USERINFO:{
 				printf("RPL_USERINFO\n");
 				Uint32 size;
-				SDL_RWread(file, &size, sizeof(size), 1);
+				SDL_ReadIO(file, &size, sizeof(size));
 				Serializer data;
-				SDL_RWread(file, data.data, data.BitsToBytes(size), 1);
+				SDL_ReadIO(file, data.data, data.BitsToBytes(size));
 				data.offset = size;
 				User user;
 				user.Serialize(Serializer::READ, data);
@@ -174,15 +174,15 @@ bool Replay::ReadToNextTick(World & world){
 			case RPL_CHANGETEAM:{
 				printf("RPL_CHANGETEAM\n");
 				Uint8 peerid;
-				SDL_RWread(file, &peerid, 1, 1);
+				SDL_ReadIO(file, &peerid, 1);
 				world.ChangeTeam(peerid);
 			}break;
 			case RPL_TECH:{
 				printf("RPL_TECH\n");
 				Uint8 peerid;
 				Uint32 techchoices;
-				SDL_RWread(file, &peerid, 1, 1);
-				SDL_RWread(file, &techchoices, sizeof(techchoices), 1);
+				SDL_ReadIO(file, &peerid, 1);
+				SDL_ReadIO(file, &techchoices, sizeof(techchoices));
 				world.SetTech(peerid, techchoices);
 			}break;
 			case RPL_CHAT:{
@@ -191,10 +191,10 @@ bool Replay::ReadToNextTick(World & world){
 				Uint8 to;
 				Uint8 msgsize;
 				char msg[256];
-				SDL_RWread(file, &peerid, 1, 1);
-				SDL_RWread(file, &to, 1, 1);
-				SDL_RWread(file, &msgsize, 1, 1);
-				SDL_RWread(file, msg, msgsize, 1);
+				SDL_ReadIO(file, &peerid, 1);
+				SDL_ReadIO(file, &to, 1);
+				SDL_ReadIO(file, &msgsize, 1);
+				SDL_ReadIO(file, msg, msgsize);
 				msg[msgsize] = 0;
 				Peer * peer = world.peerlist[peerid];
 				if(peer){
@@ -208,9 +208,9 @@ bool Replay::ReadToNextTick(World & world){
 				Uint8 peerid;
 				Uint8 action;
 				Uint8 itemid;
-				SDL_RWread(file, &peerid, 1, 1);
-				SDL_RWread(file, &action, 1, 1);
-				SDL_RWread(file, &itemid, 1, 1);
+				SDL_ReadIO(file, &peerid, 1);
+				SDL_ReadIO(file, &action, 1);
+				SDL_ReadIO(file, &itemid, 1);
 				Peer * peer = world.peerlist[peerid];
 				if(peer){
 					Player * player = world.GetPeerPlayer(peer->id);
@@ -226,16 +226,16 @@ bool Replay::ReadToNextTick(World & world){
 			case RPL_INPUT:{
 				//printf("RPL_INPUT\n");
 				Uint8 peerid;
-				SDL_RWread(file, &peerid, 1, 1);
+				SDL_ReadIO(file, &peerid, 1);
 				Serializer * data = new Serializer;
-				SDL_RWread(file, data->data, GetInputSize(), 1);
+				SDL_ReadIO(file, data->data, GetInputSize());
 				data->offset = GetInputSize() * 8;
 				world.inputqueue[peerid].push_back(data);
 			}break;
 			case RPL_DISCONNECT:{
 				printf("RPL_DISCONNECT\n");
 				Uint8 peerid;
-				SDL_RWread(file, &peerid, 1, 1);
+				SDL_ReadIO(file, &peerid, 1);
 				world.HandleDisconnect(peerid);
 			}break;
 			case RPL_TICK:{
@@ -252,84 +252,84 @@ bool Replay::ReadToNextTick(World & world){
 
 void Replay::WriteGameInfo(LobbyGame & gameinfo){
 	Uint8 code = RPL_GAMEINFO;
-	SDL_RWwrite(file, &code, 1, 1);
+	SDL_WriteIO(file, &code, 1);
 	Serializer data;
 	gameinfo.Serialize(Serializer::WRITE, data);
 	Uint32 gameinfosize = data.BitsToBytes(data.offset);
-	SDL_RWwrite(file, &gameinfosize, sizeof(gameinfosize), 1);
-	SDL_RWwrite(file, data.data, data.BitsToBytes(data.offset), 1);
+	SDL_WriteIO(file, &gameinfosize, sizeof(gameinfosize));
+	SDL_WriteIO(file, data.data, data.BitsToBytes(data.offset));
 }
 
 void Replay::WriteNewPeer(Uint8 agency, Uint32 accountid){
 	Uint8 code = RPL_NEWPEER;
-	SDL_RWwrite(file, &code, 1, 1);
-	SDL_RWwrite(file, &agency, 1, 1);
-	SDL_RWwrite(file, &accountid, sizeof(accountid), 1);
+	SDL_WriteIO(file, &code, 1);
+	SDL_WriteIO(file, &agency, 1);
+	SDL_WriteIO(file, &accountid, sizeof(accountid));
 }
 
 void Replay::WriteStart(void){
 	Uint8 code = RPL_START;
-	SDL_RWwrite(file, &code, 1, 1);
+	SDL_WriteIO(file, &code, 1);
 }
 
 void Replay::WriteUserInfo(User & user){
 	Uint8 code = RPL_USERINFO;
-	SDL_RWwrite(file, &code, 1, 1);
+	SDL_WriteIO(file, &code, 1);
 	Serializer data;
 	user.Serialize(Serializer::WRITE, data);
 	Uint32 size = data.offset;
-	SDL_RWwrite(file, &size, sizeof(size), 1);
-	SDL_RWwrite(file, data.data, data.BitsToBytes(data.offset), 1);
+	SDL_WriteIO(file, &size, sizeof(size));
+	SDL_WriteIO(file, data.data, data.BitsToBytes(data.offset));
 }
 
 void Replay::WriteChangeTeam(Uint8 peerid){
 	Uint8 code = RPL_CHANGETEAM;
-	SDL_RWwrite(file, &code, 1, 1);
-	SDL_RWwrite(file, &peerid, 1, 1);
+	SDL_WriteIO(file, &code, 1);
+	SDL_WriteIO(file, &peerid, 1);
 }
 
 void Replay::WriteSetTech(Uint8 peerid, Uint32 techchoices){
 	Uint8 code = RPL_TECH;
-	SDL_RWwrite(file, &code, 1, 1);
-	SDL_RWwrite(file, &peerid, 1, 1);
-	SDL_RWwrite(file, &techchoices, sizeof(techchoices), 1);
+	SDL_WriteIO(file, &code, 1);
+	SDL_WriteIO(file, &peerid, 1);
+	SDL_WriteIO(file, &techchoices, sizeof(techchoices));
 }
 
 void Replay::WriteChat(Uint8 peerid, Uint8 to, char * msg){
 	Uint8 code = RPL_CHAT;
-	SDL_RWwrite(file, &code, 1, 1);
-	SDL_RWwrite(file, &peerid, 1, 1);
-	SDL_RWwrite(file, &to, 1, 1);
+	SDL_WriteIO(file, &code, 1);
+	SDL_WriteIO(file, &peerid, 1);
+	SDL_WriteIO(file, &to, 1);
 	Uint8 msgsize = strlen(msg);
-	SDL_RWwrite(file, &msgsize, 1, 1);
-	SDL_RWwrite(file, msg, msgsize, 1);
+	SDL_WriteIO(file, &msgsize, 1);
+	SDL_WriteIO(file, msg, msgsize);
 }
 
 void Replay::WriteStation(Uint8 peerid, Uint8 action, Uint8 itemid){
 	Uint8 code = RPL_STATION;
-	SDL_RWwrite(file, &code, 1, 1);
-	SDL_RWwrite(file, &peerid, 1, 1);
-	SDL_RWwrite(file, &action, 1, 1);
-	SDL_RWwrite(file, &itemid, 1, 1);
+	SDL_WriteIO(file, &code, 1);
+	SDL_WriteIO(file, &peerid, 1);
+	SDL_WriteIO(file, &action, 1);
+	SDL_WriteIO(file, &itemid, 1);
 }
 
 void Replay::WriteInputCommand(World & world, Uint8 peerid, Serializer & data){
 	Uint8 code = RPL_INPUT;
-	SDL_RWwrite(file, &code, 1, 1);
-	SDL_RWwrite(file, &peerid, 1, 1);
+	SDL_WriteIO(file, &code, 1);
+	SDL_WriteIO(file, &peerid, 1);
 	int dataoffset = data.BitsToBytes(data.readoffset);
-	SDL_RWwrite(file, &data.data[dataoffset], data.BitsToBytes(data.offset) - dataoffset, 1);
+	SDL_WriteIO(file, &data.data[dataoffset], data.BitsToBytes(data.offset) - dataoffset);
 }
 
 void Replay::WriteDisconnect(Uint8 peerid){
 	Uint8 code = RPL_DISCONNECT;
-	SDL_RWwrite(file, &code, 1, 1);
-	SDL_RWwrite(file, &peerid, 1, 1);
+	SDL_WriteIO(file, &code, 1);
+	SDL_WriteIO(file, &peerid, 1);
 }
 
 void Replay::WriteTick(void){
 	Uint8 code = RPL_TICK;
-	SDL_RWwrite(file, &code, 1, 1);
+	SDL_WriteIO(file, &code, 1);
 }
 
 bool Replay::IsRecording(void){

--- a/clients/silencer/src/replay.h
+++ b/clients/silencer/src/replay.h
@@ -45,7 +45,7 @@ public:
 	
 private:
 	int GetInputSize(void);
-	SDL_RWops * file;
+	SDL_IOStream * file;
 	bool isrecording;
 	bool isplaying;
 	bool gamestarted;

--- a/clients/silencer/src/resources.cpp
+++ b/clients/silencer/src/resources.cpp
@@ -308,14 +308,38 @@ bool Resources::LoadSounds(Game & game, bool dedicatedserver){
 		fwrite(&mem[sizeof(header)], 1, length, file2);
 		fclose(file2);*/
 		
-		MIX_Audio * chunk = MIX_LoadAudio_IO(Audio::GetInstance().GetMixer(), SDL_IOFromConstMem(mem.data(), mem.size()), true, true);
+		// Decode WAV (may be IMA ADPCM) to raw PCM via SDL3, then load into MIX_Audio
+		SDL_AudioSpec wavspec;
+		Uint8 *wavbuf = nullptr;
+		Uint32 wavlen = 0;
+		if(!SDL_LoadWAV_IO(SDL_IOFromConstMem(mem.data(), mem.size()), true, &wavspec, &wavbuf, &wavlen)){
+			printf("Could not decode WAV %s - %s\n", name, SDL_GetError());
+			SDL_CloseIO(file);
+			return false;
+		}
+
+		// Apply a short PCM fade-in/fade-out to the hover sound to eliminate click artifacts
+		// from abrupt waveform onset/cutoff after ADPCM decode.
+		if(strcmp(name, "whoom.wav") == 0 && wavspec.format == SDL_AUDIO_S16LE){
+			int fade_samples = (wavspec.freq * 20) / 1000; // 20ms
+			Sint16 *pcm = (Sint16 *)wavbuf;
+			int total_samples = wavlen / sizeof(Sint16);
+			int ramp = SDL_min(fade_samples, total_samples / 2);
+			for(int s = 0; s < ramp; s++){
+				pcm[s] = (Sint16)(pcm[s] * s / ramp);
+				pcm[total_samples - 1 - s] = (Sint16)(pcm[total_samples - 1 - s] * s / ramp);
+			}
+		}
+
+		// MIX_LoadRawAudioNoCopy takes ownership of wavbuf and will free it
+		MIX_Audio * chunk = MIX_LoadRawAudioNoCopy(Audio::GetInstance().GetMixer(), wavbuf, wavlen, &wavspec, true);
 		if(!chunk){
 			printf("Could not load sound %s - %s\n", name, SDL_GetError());
+			SDL_free(wavbuf);
 			SDL_CloseIO(file);
 			return false;
 		}else{
 			soundbank[name] = chunk;
-			// Note: SDL3_mixer 3.x audio is opaque; pop-fix via raw buffer access is no longer possible
 		}
 	}
 	SDL_CloseIO(file);

--- a/clients/silencer/src/resources.cpp
+++ b/clients/silencer/src/resources.cpp
@@ -1,5 +1,6 @@
 #include "resources.h"
 #include <vector>
+#include "audio.h"
 #include "game.h"
 #include "os.h"
 
@@ -33,27 +34,27 @@ bool Resources::Load(Game & game, bool dedicatedserver){
 
 bool Resources::LoadSprites(Game & game, bool dedicatedserver){
 	char FileName[256];
-	SDL_RWops * file = SDL_RWFromFile((GetResDir() + "BIN_SPR.DAT").c_str(), "rb");
+	SDL_IOStream * file = SDL_IOFromFile((GetResDir() + "BIN_SPR.DAT").c_str(), "rb");
 	if(!file){
 		printf("Could not open BIN_SPR.DAT\n");
 		return false;
 	}
 	Uint8 headers[256][64];
-	SDL_RWread(file, headers, 64, 256);
+	SDL_ReadIO(file, headers, 64 * 256);
 	for(unsigned int i = 0; i < 256; i++){
 		progress++;
 		game.LoadProgressCallback(progress, totalprogressitems);
 		if(headers[i][2]){
 			sprintf(FileName, "bin_spr/SPR_%.3d.BIN", i);
-			SDL_RWops * file2 = SDL_RWFromFile((GetResDir() + FileName).c_str(), "rb");
+			SDL_IOStream * file2 = SDL_IOFromFile((GetResDir() + FileName).c_str(), "rb");
 			if(file2){
 				Uint8 header2[(344 * 256) + 4];
-				SDL_RWread(file2, header2, (344 * headers[i][2]) + 4, 1);
+				SDL_ReadIO(file2, header2, (344 * headers[i][2]) + 4);
 				for(unsigned int j = 0; j < headers[i][2]; j++){
-					Uint16 width = SDL_SwapLE16(((Uint16 *)header2)[(j * 172)]);
-					Uint16 height = SDL_SwapLE16(((Uint16 *)header2)[(j * 172) + 1]);
-					Sint16 offsetx = SDL_SwapLE16(((Sint16 *)header2)[(j * 172) + 2]);
-					Sint16 offsety = SDL_SwapLE16(((Sint16 *)header2)[(j * 172) + 3]);
+					Uint16 width = SDL_Swap16LE(((Uint16 *)header2)[(j * 172)]);
+					Uint16 height = SDL_Swap16LE(((Uint16 *)header2)[(j * 172) + 1]);
+					Sint16 offsetx = SDL_Swap16LE(((Sint16 *)header2)[(j * 172) + 2]);
+					Sint16 offsety = SDL_Swap16LE(((Sint16 *)header2)[(j * 172) + 3]);
 					spriteoffsetx[i][j] = offsetx;
 					spriteoffsety[i][j] = offsety;
 					spritewidth[i][j] = width;
@@ -62,7 +63,7 @@ bool Resources::LoadSprites(Game & game, bool dedicatedserver){
 						spritebank[i][j] = std::make_shared<Surface>(0, 0);;
 						continue;
 					}
-					Uint32 size = SDL_SwapLE32(((Uint32 *)header2)[(j * 86) + 3]);
+					Uint32 size = SDL_Swap32LE(((Uint32 *)header2)[(j * 86) + 3]);
 					Uint8 offsets = ((Uint8 *)header2)[(j * 344) + 20];
 					std::vector<Uint8> data(size);
 					std::vector<Uint8> decompressed(width * height);
@@ -82,10 +83,10 @@ bool Resources::LoadSprites(Game & game, bool dedicatedserver){
 								for(unsigned int y = y2 * 64; y < ymax; y++){
 									for(unsigned int x = x2 * 64; x < xmax; x += 4){
 										if(count){
-											((Uint32 *)decompressed.data())[((y * width) / 4) + (x / 4)] = SDL_SwapLE32(tempvalue);
+											((Uint32 *)decompressed.data())[((y * width) / 4) + (x / 4)] = SDL_Swap32LE(tempvalue);
 											count -= 4;
 										}else{
-											SDL_RWread(file2, &tempvalue, sizeof(Uint32), 1);
+											SDL_ReadIO(file2, &tempvalue, sizeof(Uint32));
 											if(tempvalue >= 0xFF000000){
 												count = tempvalue & 0x0000FFFF;
 												tempvalue &= 0x00FF0000;
@@ -93,29 +94,29 @@ bool Resources::LoadSprites(Game & game, bool dedicatedserver){
 												tempvalue |= tempvalue >> 16;
 												count -= 4;
 											}
-											((Uint32 *)decompressed.data())[((y * width) / 4) + (x / 4)] = SDL_SwapLE32(tempvalue);
+											((Uint32 *)decompressed.data())[((y * width) / 4) + (x / 4)] = SDL_Swap32LE(tempvalue);
 										}
 									}
 								}
 							}
 						}
 					}else{
-						SDL_RWread(file2, data.data(), size, 1);
+						SDL_ReadIO(file2, data.data(), size);
 						for(unsigned int j = 0, k = 0; j < size / 4; j++, k++){
-							Uint32 tempvalue = SDL_SwapLE32(((Uint32 *)data.data())[j]);
+							Uint32 tempvalue = SDL_Swap32LE(((Uint32 *)data.data())[j]);
 							if(tempvalue >= 0xFF000000){
 								Uint32 count = tempvalue & 0x0000FFFF;
 								tempvalue &= 0x00FF0000;
 								tempvalue |= tempvalue << 8;
 								tempvalue |= tempvalue >> 16;
 								while(count){
-									((Uint32 *)decompressed.data())[k] = SDL_SwapLE32(tempvalue);
+									((Uint32 *)decompressed.data())[k] = SDL_Swap32LE(tempvalue);
 									count -= 4;
 									k++;
 								}
 								k--;
 							}else{
-								((Uint32 *)decompressed.data())[k] = SDL_SwapLE32(tempvalue);
+								((Uint32 *)decompressed.data())[k] = SDL_Swap32LE(tempvalue);
 							}
 						}
 					}
@@ -147,15 +148,15 @@ bool Resources::LoadSprites(Game & game, bool dedicatedserver){
 					memcpy(surface->pixels.data() , sprite.data(), width * height);
 					RLESurface(surface);
 				}
-				SDL_RWclose(file2);
+				SDL_CloseIO(file2);
 			}else{
 				printf("Could not open %s\n", FileName);
-				SDL_RWclose(file);
+				SDL_CloseIO(file);
 				return false;
 			}
 		}
 	}
-	SDL_RWclose(file);
+	SDL_CloseIO(file);
 	return true;
 }
 
@@ -165,40 +166,40 @@ bool Resources::LoadTiles(Game & game, bool dedicatedserver){
 		return true;
 	}
 	char filename[256];
-	SDL_RWops * file = SDL_RWFromFile((GetResDir() + "BIN_TIL.DAT").c_str(), "rb");
+	SDL_IOStream * file = SDL_IOFromFile((GetResDir() + "BIN_TIL.DAT").c_str(), "rb");
 	if(!file){
 		printf("Could not open BIN_TIL.DAT\n");
 		return false;
 	}
 	Uint8 headers[256][64];
-	SDL_RWread(file, headers, 64, 256);
+	SDL_ReadIO(file, headers, 64 * 256);
 	for(unsigned int i = 0; i < 256; i++){
 		progress++;
 		game.LoadProgressCallback(progress, totalprogressitems);
 		if(headers[i][2]){
 			sprintf(filename, "bin_til/TIL_%.3d.BIN", i);
-			SDL_RWops * file2 = SDL_RWFromFile((GetResDir() + filename).c_str(), "rb");
+			SDL_IOStream * file2 = SDL_IOFromFile((GetResDir() + filename).c_str(), "rb");
 			if(file2){
 				Uint8 header2[(12 * 256) + 4];
-				SDL_RWread(file2, header2, (12 * headers[i][2]) + 4, 1);
+				SDL_ReadIO(file2, header2, (12 * headers[i][2]) + 4);
 				std::vector<Uint8> data(64 * 64 * 256);
-				size_t datasize = SDL_RWread(file2, data.data(), 1, data.size());
+				size_t datasize = SDL_ReadIO(file2, data.data(), data.size());
 				std::vector<Uint8> decompressed(64 * 64 * 256);
 				for(unsigned int j = 0, k = 0; j < datasize / 4; j++, k++){
-					Uint32 tempvalue = SDL_SwapLE32(((Uint32 *)data.data())[j]);
+					Uint32 tempvalue = SDL_Swap32LE(((Uint32 *)data.data())[j]);
 					if(tempvalue >= 0xFF000000){
 						Uint32 count = tempvalue & 0x0000FFFF;
 						tempvalue &= 0x00FF0000;
 						tempvalue |= tempvalue << 8;
 						tempvalue |= tempvalue >> 16;
 						while(count){
-							((Uint32 *)decompressed.data())[k] = SDL_SwapLE32(tempvalue);
+							((Uint32 *)decompressed.data())[k] = SDL_Swap32LE(tempvalue);
 							count -= 4;
 							k++;
 						}
 						k--;
 					}else{
-						((Uint32 *)decompressed.data())[k] = SDL_SwapLE32(tempvalue);
+						((Uint32 *)decompressed.data())[k] = SDL_Swap32LE(tempvalue);
 					}
 				}
 				for(unsigned int j = 0; j < headers[i][2]; j++){
@@ -213,14 +214,14 @@ bool Resources::LoadTiles(Game & game, bool dedicatedserver){
 					MirrorY(tileflippedbank[i][j].get());
 					RLESurface(tileflippedbank[i][j].get());
 				}
-				SDL_RWclose(file2);
+				SDL_CloseIO(file2);
 			}else{
 				printf("Could not open %s %d\n", filename, errno);
 				return false;
 			}
 		}
 	}
-	SDL_RWclose(file);
+	SDL_CloseIO(file);
 	return true;
 }
 
@@ -229,7 +230,7 @@ bool Resources::LoadSounds(Game & game, bool dedicatedserver){
 		progress += 101;
 		return true;
 	}
-	SDL_RWops * file = SDL_RWFromFile((GetResDir() + "sound.bin").c_str(), "rb");
+	SDL_IOStream * file = SDL_IOFromFile((GetResDir() + "sound.bin").c_str(), "rb");
 	if(!file){
 		printf("Could not open sound.bin\n");
 		return false;
@@ -242,13 +243,13 @@ bool Resources::LoadSounds(Game & game, bool dedicatedserver){
 	Uint32 offset;
 	Uint32 length;
 	Uint32 wavinfo;
-	SDL_RWread(file, &numsounds, sizeof(numsounds), 1);
-	SDL_RWread(file, &soundssize, sizeof(soundssize), 1);
+	SDL_ReadIO(file, &numsounds, sizeof(numsounds));
+	SDL_ReadIO(file, &soundssize, sizeof(soundssize));
 	for(unsigned int i = 0; i < numsounds; i++){
 		progress++;
 		game.LoadProgressCallback(progress, totalprogressitems);
-		SDL_RWseek(file, sizeof(numsounds) + sizeof(soundssize) + (i * sizeof(soundheader)), RW_SEEK_SET);
-		SDL_RWread(file, &soundheader, sizeof(soundheader), 1);
+		SDL_SeekIO(file, sizeof(numsounds) + sizeof(soundssize) + (i * sizeof(soundheader)), SDL_IO_SEEK_SET);
+		SDL_ReadIO(file, &soundheader, sizeof(soundheader));
 		memcpy(&name, &soundheader[4], 0x10);
 		memcpy(&offset, &soundheader[4 + 0x10], sizeof(offset));
 		memcpy(&length, &soundheader[4 + 0x10 + 4], sizeof(length));
@@ -299,56 +300,41 @@ bool Resources::LoadSounds(Game & game, bool dedicatedserver){
 		memset(mem.data(), 0, memsize);
 		memcpy(mem.data(), header, sizeof(header));
 		
-		SDL_RWseek(file, sizeof(numsounds) + sizeof(soundssize) + (numsounds * sizeof(soundheader)) + offset, RW_SEEK_SET);
-		SDL_RWread(file, &mem[sizeof(header)], length, 1);
+		SDL_SeekIO(file, sizeof(numsounds) + sizeof(soundssize) + (numsounds * sizeof(soundheader)) + offset, SDL_IO_SEEK_SET);
+		SDL_ReadIO(file, &mem[sizeof(header)], length);
 		memset(&mem[sizeof(header) + length - 24], 0, 24);
 		
 		/*FILE * file2 = fopen(name, "w");
 		fwrite(&mem[sizeof(header)], 1, length, file2);
 		fclose(file2);*/
 		
-		Mix_Chunk * chunk = Mix_LoadWAV_RW(SDL_RWFromConstMem(mem.data(), mem.size()), true);
+		MIX_Audio * chunk = MIX_LoadAudio_IO(Audio::GetInstance().GetMixer(), SDL_IOFromConstMem(mem.data(), mem.size()), true, true);
 		if(!chunk){
-			printf("Could not load sound %s - %s\n", name, Mix_GetError());
-			SDL_RWclose(file);
+			printf("Could not load sound %s - %s\n", name, SDL_GetError());
+			SDL_CloseIO(file);
 			return false;
 		}else{
 			soundbank[name] = chunk;
-			// fix pop at end of sounds
-			int v = 0;
-			int length = (chunk->alen / sizeof(Sint16));
-			for(int i = length - 1; i > length - 100; i--, v++){
-				if(i >= 0){
-					((Sint16 *)chunk->abuf)[i] *= v / float(100);
-				}
-			}
-			v = 0;
-			for(int i = 0; i < 100; i++, v++){
-				if(i < length - 1){
-					((Sint16 *)chunk->abuf)[i] *= v / float(100);
-				}
-			}
-			//
+			// Note: SDL3_mixer 3.x audio is opaque; pop-fix via raw buffer access is no longer possible
 		}
 	}
-	SDL_RWclose(file);
-	menumusic = Mix_LoadMUS((GetResDir() + "CLOSER2.mp3").c_str());
+	SDL_CloseIO(file);
+	menumusic = MIX_LoadAudio(Audio::GetInstance().GetMixer(), (GetResDir() + "CLOSER2.mp3").c_str(), false);
 	return true;
 }
 
 void Resources::UnloadSounds(void){
 	for(std::map<std::string, Mix_Chunk *>::iterator it = soundbank.begin(); it != soundbank.end(); it++){
-		Mix_FreeChunk((*it).second);
+		MIX_DestroyAudio((*it).second);
 	}
 	soundbank.clear();
-	Mix_FadeOutMusic(0);
-	Mix_ResumeMusic();
+	Audio::GetInstance().StopMusic();
 	if(menumusic){
-		Mix_FreeMusic(menumusic);
+		MIX_DestroyAudio(menumusic);
 		menumusic = 0;
 	}
 	if(gamemusic){
-		Mix_FreeMusic(gamemusic);
+		MIX_DestroyAudio(gamemusic);
 		gamemusic = 0;
 	}
 }

--- a/clients/silencer/src/shared.h
+++ b/clients/silencer/src/shared.h
@@ -10,8 +10,11 @@
 
 #define SDL_MAIN_HANDLED
 #include <SDL3/SDL.h>
-#include <SDL3/SDL_mixer.h>
-#include <SDL3/SDL_syswm.h>
+#include <SDL3_mixer/SDL_mixer.h>
+// SDL3_mixer 3.x renamed all Mix_* types to MIX_*; alias them for compatibility.
+typedef MIX_Audio Mix_Chunk;
+typedef MIX_Audio Mix_Music;
+#define MIX_MAX_VOLUME 128
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
@@ -67,7 +70,7 @@ typedef int socklen_t;
 extern JNIEnv * jenv;
 extern JavaVM * jvm;
 #else
-#include <SDL_opengl.h>
+#include <SDL3/SDL_opengl.h>
 #endif
 void CDResDir(void);
 void CDDataDir(void);

--- a/clients/silencer/src/shared.h
+++ b/clients/silencer/src/shared.h
@@ -9,9 +9,9 @@
 #endif
 
 #define SDL_MAIN_HANDLED
-#include <SDL.h>
-#include <SDL_mixer.h>
-#include <SDL_syswm.h>
+#include <SDL3/SDL.h>
+#include <SDL3/SDL_mixer.h>
+#include <SDL3/SDL_syswm.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
@@ -63,7 +63,6 @@ typedef int socklen_t;
 #ifdef __ANDROID__
 #include <android/log.h>
 #include <jni.h>
-#include <SDL_opengles2.h>
 #define printf(...) __android_log_print(ANDROID_LOG_DEBUG, "TAG", __VA_ARGS__);
 extern JNIEnv * jenv;
 extern JavaVM * jvm;

--- a/clients/silencer/vcpkg.json
+++ b/clients/silencer/vcpkg.json
@@ -3,9 +3,9 @@
 	"version-string": "0.0.0",
 	"description": "Silencer multiplayer client build dependencies",
 	"dependencies": [
-		"sdl2",
+		"sdl3",
 		{
-			"name": "sdl2-mixer",
+			"name": "sdl3-mixer",
 			"features": ["mpg123", "libmodplug"]
 		},
 		"zlib",


### PR DESCRIPTION
Part of epic #42 — Phase 1: SDL2 → SDL3 library upgrade.

## What
- `vcpkg.json`: sdl2/sdl2-mixer → sdl3/sdl3-mixer
- `CMakeLists.txt`: SDL3 package + target names (`SDL3::SDL3`, `SDL3_mixer::SDL3_mixer`)
- `shared.h`: `<SDL3/SDL.h>` headers
- All SDL2 API call sites migrated to SDL3 equivalents:
  - Event constants renamed (`SDL_QUIT` → `SDL_EVENT_QUIT`, etc.)
  - Window events promoted to top-level event types
  - `SDL_RenderCopy` → `SDL_RenderTexture`
  - `SDL_CreateRGBSurface` → `SDL_CreateSurface`
  - `SDL_mutexP/V` → `SDL_LockMutex/UnlockMutex`
  - `Mix_OpenAudio` SDL3_mixer API
  - `SDL_GetTicks` → `Uint64`
  - Pixel format as enum (no alloc/free)
  - `SDL_TimerCallback` new signature
  - `SDL_ShowCursor`/`SDL_HideCursor` (no-arg SDL3 forms)
  - `SDL_StartTextInput(window)` replaces `SDL_EventState`
  - `SDL_GetMouseState` float* params
  - `sdlscreenbuffer->palette` (SDL3 surface layout)

## What's NOT in this PR
- Phase 2: RenderDevice abstract interface + SDL3 GPU backend
- Phase 3: post-processing, compute, lighting

## Testing
Build with vcpkg + CMake and run the client.