### PR TITLE
feat(client): Phases 2+3 — RenderDevice + SDL3 GPU backend + offscreen RT + GPU lights + particle compute (issue #42)

### DIFF
--- a/clients/silencer/src/game.cpp
+++ b/clients/silencer/src/game.cpp
@@ -1,4 +1,5 @@
 #include "game.h"
+#include "sdl3gpubackend.h"
 #include <math.h>
 #include "overlay.h"
 #include "interface.h"
@@ -85,16 +86,8 @@ Game::Game() : renderer(world), screenbuffer(640, 480){
 	minimized = false;
 	modaldialoghasok = false;
 	window = 0;
-	windowrenderer = 0;
-	streamingtexture = 0;
-	streamingtexturepixelformat = SDL_PIXELFORMAT_UNKNOWN;
-	glcontext = 0;
-	fbo = 0;
-	gltextures[0] = 0;
-	gltextures[1] = 0;
-	lasttick = 0;
-	usingopengl = true;
-	sdlscreenbuffer = 0;
+	renderdevice = nullptr;
+	memset(palettecolors, 0, sizeof(palettecolors));
 	oldambiencelevel = 0;
 	nextstateprocessed = false;
 	lastmapchunkrequest = 0;
@@ -112,20 +105,10 @@ Game::Game() : renderer(world), screenbuffer(640, 480){
 }
 
 Game::~Game(){
-	if(glcontext){
-		SDL_GL_DestroyContext(glcontext);
-	}
-	if(sdlscreenbuffer){
-		SDL_DestroySurface(sdlscreenbuffer);
-	}
-	if(usingopengl){
-		SDL_GL_UnloadLibrary();
-	}
-	if(windowrenderer){
-		SDL_DestroyRenderer(windowrenderer);
-	}
-	if(streamingtexture){
-		SDL_DestroyTexture(streamingtexture);
+	if(renderdevice){
+		renderdevice->Shutdown();
+		delete renderdevice;
+		renderdevice = nullptr;
 	}
 	if(window){
 		SDL_DestroyWindow(window);
@@ -215,14 +198,11 @@ bool Game::Load(char * cmdline){
 		//SDL_EnableUNICODE(true);
 		//SDL_EnableKeyRepeat(SDL_DEFAULT_REPEAT_DELAY, SDL_DEFAULT_REPEAT_INTERVAL);
 		//screen = SDL_SetVideoMode(640, 480, 8, SDL_DOUBLEBUF | SDL_SWSURFACE);
-		window = SDL_CreateWindow("Silencer", screenbuffer.w, screenbuffer.h, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | (Config::GetInstance().fullscreen ? SDL_WINDOW_FULLSCREEN : 0));
+		window = SDL_CreateWindow("Silencer", screenbuffer.w, screenbuffer.h, SDL_WINDOW_RESIZABLE | (Config::GetInstance().fullscreen ? SDL_WINDOW_FULLSCREEN : 0));
 		SDL_StartTextInput(window);
-		if(!SetupOpenGL()){
-			//printf("Unable to setup OpenGL shaders, using SDL Renderer\n");
-			usingopengl = false;
-			CreateRenderer();
-			sdlscreenbuffer = SDL_CreateSurface(screenbuffer.w, screenbuffer.h, SDL_PIXELFORMAT_INDEX8);
-			CreateStreamingTexture();
+		if(!SetupRenderDevice()){
+			printf("Could not initialize GPU render device\n");
+			return false;
 		}
 		SetColors(renderer.palette.GetColors());
 		//SDL_Flip(screen);
@@ -237,224 +217,21 @@ bool Game::Load(char * cmdline){
 	return true;
 }
 
-bool Game::SetupOpenGL(void){
-	return false;
-	/*if(SDL_GL_LoadLibrary(0) == -1){
+bool Game::SetupRenderDevice(void){
+	SDL3GPUBackend *backend = new SDL3GPUBackend();
+	if(!backend->Init(window)){
+		delete backend;
 		return false;
 	}
-	glcontext = SDL_GL_CreateContext(window);
-	if(!glcontext){
-		return false;
-	}
-	glViewport(0, 0, screenbuffer.w, screenbuffer.h);
-	//glGenFramebuffers(1, &fbo);
-	if(!glCreateProgram){
-		return false;
-	}
-	GLuint program = glCreateProgram();
-	if(!program){
-		return false;
-	}
-	
-	GLuint vertshader = glCreateShader(GL_VERTEX_SHADER);
-	if(!vertshader){
-		return false;
-	}
-	const GLchar * vertshadercode = "#version 110\n"
-	"varying vec2 texture_coordinate;"
-	"void main(){"
-	"	gl_Position = gl_ModelViewProjectionMatrix * gl_Vertex;"
-	"	texture_coordinate = vec2(gl_MultiTexCoord0);"
-	"}";
-	GLint shadercodelength = strlen(vertshadercode);
-	if(!glShaderSource){
-		return false;
-	}
-	glShaderSource(vertshader, 1, &vertshadercode, &shadercodelength);
-	if(!glCompileShader){
-		return false;
-	}
-	glCompileShader(vertshader);
-	char buffer[1024];
-	GLsizei length;
-	if(!glGetShaderiv){
-		return false;
-	}
-	glGetShaderiv(vertshader, GL_INFO_LOG_LENGTH, &length);
-	if(length > 0){
-		if(!glGetShaderInfoLog){
-			return false;
-		}
-		glGetShaderInfoLog(vertshader, sizeof(buffer), &length, buffer);
-		if(length > 0){
-			printf("vert ShaderInfo: %s\n", buffer);
-			return false;
-		}
-	}
-	if(!glAttachShader){
-		return false;
-	}
-	glAttachShader(program, vertshader);
-	
-	GLuint fragshader = glCreateShader(GL_FRAGMENT_SHADER);
-	const GLchar * fragshadercode = "#version 110\n"
-	"uniform sampler2D Palette;"
-	"uniform sampler2D IndexedColorTexture;"
-	"varying vec2 texture_coordinate;"
-	"void main(){"
-	"	vec4 index = texture2D(IndexedColorTexture, texture_coordinate);"
-	"	vec4 texel = texture2D(Palette, vec2(index.r, 0));"
-	"	gl_FragColor = texel;"
-	"}";
-	shadercodelength = strlen(fragshadercode);
-	glShaderSource(fragshader, 1, &fragshadercode, &shadercodelength);
-	glCompileShader(fragshader);
-	glGetShaderiv(fragshader, GL_INFO_LOG_LENGTH, &length);
-	if(length > 0){
-		glGetShaderInfoLog(fragshader, sizeof(buffer), &length, buffer);
-		if(length > 0){
-			printf("frag ShaderInfo: %s\n", buffer);
-			return false;
-		}
-	}
-	glAttachShader(program, fragshader);
-	if(!glLinkProgram){
-		return false;
-	}
-	glLinkProgram(program);
-	if(!glGetProgramiv){
-		return false;
-	}
-	glGetProgramiv(program, GL_INFO_LOG_LENGTH, &length);
-	if(length > 0){
-		if(!glGetProgramInfoLog){
-			return false;
-		}
-		glGetProgramInfoLog(program, sizeof(buffer), &length, buffer);
-		if(length > 0){
-			printf("ProgramInfo: %s\n", buffer);
-			return false;
-		}
-	}
-	if(!glUseProgram){
-		return false;
-	}
-	glUseProgram(program);
-	
-	glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
-	glEnable(GL_TEXTURE_2D);
-	glGenTextures(2, gltextures);
-	
-	glBindTexture(GL_TEXTURE_2D, gltextures[0]);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 256, 1, 0, GL_RGBA, GL_UNSIGNED_BYTE, renderer.palette.GetColors());
-	glBindTexture(GL_TEXTURE_2D, gltextures[1]);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-	glTexImage2D(GL_TEXTURE_2D, 0, 1, screenbuffer.w, screenbuffer.h, 0, GL_RED, GL_UNSIGNED_BYTE, screenbuffer.pixels);
-	
-	int palettesampler = glGetUniformLocation(program, "Palette");
-	glActiveTexture(GL_TEXTURE0);
-	glBindTexture(GL_TEXTURE_2D, gltextures[0]);
-	if(!glUniform1i){
-		return false;
-	}
-	glUniform1i(palettesampler, 0);
-	
-	int indexedtexturesampler = glGetUniformLocation(program, "IndexedColorTexture");
-	glActiveTexture(GL_TEXTURE0 + 1);
-	glBindTexture(GL_TEXTURE_2D, gltextures[1]);
-	glUniform1i(indexedtexturesampler, 1);
-	return true;*/
-}
-
-void Game::CreateRenderer(void){
-	if(windowrenderer){
-		SDL_DestroyRenderer(windowrenderer);
-		windowrenderer = 0;
-	}
-	windowrenderer = SDL_CreateRenderer(window, NULL);
-}
-
-void Game::CreateStreamingTexture(void){
-	if(streamingtexture){
-		SDL_DestroyTexture(streamingtexture);
-		streamingtexture = 0;
-	}
-	streamingtexture = SDL_CreateTexture(windowrenderer, SDL_PIXELFORMAT_XRGB8888, SDL_TEXTUREACCESS_STREAMING, screenbuffer.w, screenbuffer.h);
-	streamingtexturepixelformat = SDL_PIXELFORMAT_XRGB8888;
-	if(streamingtexture){
-		SDL_SetTextureScaleMode(streamingtexture, Config::GetInstance().scalefilter ? SDL_SCALEMODE_LINEAR : SDL_SCALEMODE_NEAREST);
-	}
+	renderdevice = backend;
+	renderdevice->SetScaleFilter(Config::GetInstance().scalefilter);
+	return true;
 }
 
 void Game::Present(void){
-	if(usingopengl){
-/*
-		glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-		glBindTexture(GL_TEXTURE_2D, gltextures[1]);
-		glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-		glPixelStorei(GL_PACK_ALIGNMENT, 1);
-		glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, screenbuffer.w, screenbuffer.h, GL_RED, GL_UNSIGNED_BYTE, screenbuffer.pixels);
-		glLoadIdentity();
-		glBegin(GL_QUADS);
-		glTexCoord2f(0.0f, 1.0f);
-		glVertex3f( -1.0f, -1.0f, 0.0f);
-		glTexCoord2f(1.0f, 1.0f);
-		glVertex3f(1.0f,-1.0f, 0.0f);
-		glTexCoord2f(1.0f, 0.0f);
-		glVertex3f( 1.0f,1.0f, 0.0f);
-		glTexCoord2f(0.0f, 0.0f);
-		glVertex3f( -1.0f,1.0f, 0.0f);
-		glEnd();
-		SDL_GL_SwapWindow(window);
-*/
-	}else{
-		if(streamingtexture){
-			void * pixels;
-			int pitch;
-			if(SDL_LockTexture(streamingtexture, 0, &pixels, &pitch) == 0){
-				if(pitch == screenbuffer.w * 1){
-					Uint8 * src = screenbuffer.pixels.data();
-					Uint8 * dst = (Uint8 *)pixels;
-					for(int y = screenbuffer.h; y > 0; y--){
-						for(int x = screenbuffer.w; x > 0; x--){
-							*(dst++) = *(Uint8 *)(&streamingtexturepalette[*src++]);
-						}
-					}
-				}else
-				if(pitch == screenbuffer.w * 2){
-					Uint8 * src = screenbuffer.pixels.data();
-					Uint16 * dst = (Uint16 *)pixels;
-					for(int y = screenbuffer.h; y > 0; y--){
-						for(int x = screenbuffer.w; x > 0; x--){
-							*(dst++) = *(Uint16 *)(&streamingtexturepalette[*src++]);
-						}
-					}
-				}else
-				if(pitch == screenbuffer.w * 4){
-					Uint8 * src = screenbuffer.pixels.data();
-					Uint32 * dst = (Uint32 *)pixels;
-					for(int y = screenbuffer.h; y > 0; y--){
-						for(int x = screenbuffer.w; x > 0; x--){
-							*(dst++) = *(Uint32 *)(&streamingtexturepalette[*src++]);
-						}
-					}
-				}
-				SDL_UnlockTexture(streamingtexture);
-				SDL_RenderTexture(windowrenderer, streamingtexture, NULL, NULL);
-				SDL_RenderPresent(windowrenderer);
-			}
-		}else{
-			void * oldpixels = sdlscreenbuffer->pixels;
-			sdlscreenbuffer->pixels = screenbuffer.pixels.data();
-			SDL_Texture * texture = SDL_CreateTextureFromSurface(windowrenderer, sdlscreenbuffer);
-			sdlscreenbuffer->pixels = oldpixels;
-			SDL_RenderTexture(windowrenderer, texture, NULL, NULL);
-			SDL_DestroyTexture(texture);
-			SDL_RenderPresent(windowrenderer);
-		}
+	if(renderdevice){
+		renderdevice->UploadFrame(screenbuffer.pixels.data(), screenbuffer.w, screenbuffer.h);
+		renderdevice->Present();
 	}
 }
 
@@ -475,18 +252,9 @@ void Game::LoadProgressCallback(int progress, int totalprogressitems){
 }
 
 void Game::SetColors(SDL_Color * colors){
-	if(usingopengl){
-		/*glBindTexture(GL_TEXTURE_2D, gltextures[0]);
-		glPixelStorei(GL_UNPACK_ALIGNMENT, 4);
-		glPixelStorei(GL_PACK_ALIGNMENT, 4);
-		glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, 256, 1, GL_RGBA, GL_UNSIGNED_BYTE, colors);*/
-	}else{
-		SDL_SetPaletteColors(SDL_GetSurfacePalette(sdlscreenbuffer), colors, 0, 256);
-		if(streamingtexture){
-			for(int i = 0; i < 256; i++){
-				streamingtexturepalette[i] = SDL_MapRGB(SDL_GetPixelFormatDetails(streamingtexturepixelformat), NULL, colors[i].r, colors[i].g, colors[i].b);
-			}
-		}
+	memcpy(palettecolors, colors, 256 * sizeof(SDL_Color));
+	if(renderdevice){
+		renderdevice->SetPalette(colors, 256);
 	}
 }
 
@@ -576,9 +344,9 @@ bool Game::Loop(void){
 			int j = 0;
 			for(int y = screenbuffer.h; y > 0; y--){
 				for(int x = screenbuffer.w; x > 0; x--){
-					buffer[i++] = SDL_GetSurfacePalette(sdlscreenbuffer)->colors[screenbuffer.pixels[j]].r;
-					buffer[i++] = SDL_GetSurfacePalette(sdlscreenbuffer)->colors[screenbuffer.pixels[j]].g;
-					buffer[i++] = SDL_GetSurfacePalette(sdlscreenbuffer)->colors[screenbuffer.pixels[j]].b;
+					buffer[i++] = palettecolors[screenbuffer.pixels[j]].r;
+					buffer[i++] = palettecolors[screenbuffer.pixels[j]].g;
+					buffer[i++] = palettecolors[screenbuffer.pixels[j]].b;
 					j++;
 				}
 			}
@@ -1806,7 +1574,7 @@ bool Game::Tick(void){
 									}break;
 									case 1:{ // smooth scaling
 										Config::GetInstance().scalefilter = Config::GetInstance().scalefilter ? false : true;
-										CreateStreamingTexture();
+										if(renderdevice) renderdevice->SetScaleFilter(Config::GetInstance().scalefilter);
 									}break;
 									case 200:{
 										Config::GetInstance().Save();
@@ -1814,7 +1582,7 @@ bool Game::Tick(void){
 									}break;
 									case 201:{
 										Config::GetInstance().Load();
-										CreateStreamingTexture();
+										if(renderdevice) renderdevice->SetScaleFilter(Config::GetInstance().scalefilter);
 										if(Config::GetInstance().fullscreen){
 											SDL_SetWindowFullscreen(window, true);
 										}else{
@@ -6033,13 +5801,9 @@ bool Game::HandleSDLEvents(void){
 	while(SDL_PollEvent(&event) > 0){
 		switch(event.type){
 			case SDL_EVENT_WINDOW_RESIZED:{
-				if(usingopengl){
-					//glViewport(0, 0, event.window.data1, event.window.data2);
-				}
+				// SDL3 GPU swapchain resizes automatically.
 			}break;
 			case SDL_EVENT_WINDOW_FOCUS_GAINED:{
-				// fix for Windows sdl bug where viewport is changed when another app goes fullscreen, causing render to go black
-				SDL_SetRenderViewport(windowrenderer, NULL);
 				if(!world.replay.IsPlaying()){
 					Audio::GetInstance().Unmute();
 				}

--- a/clients/silencer/src/game.h
+++ b/clients/silencer/src/game.h
@@ -1,9 +1,7 @@
 #ifndef GAME_H
 #define GAME_H
 
-#include "shared.h"
-#include "palette.h"
-#include "world.h"
+#include "renderdevice.h"
 #include "renderer.h"
 #include "input.h"
 #include "state.h"
@@ -31,9 +29,7 @@ public:
 private:
 	bool Tick(void);
 	void Present(void);
-	bool SetupOpenGL(void);
-	void CreateRenderer(void);
-	void CreateStreamingTexture(void);
+	bool SetupRenderDevice(void);
 	static Uint32 TimerCallback(void * userdata, SDL_TimerID timerID, Uint32 interval);
 	void SetColors(SDL_Color * colors);
 	void UpdateInputState(Input & input);
@@ -123,16 +119,9 @@ private:
 	class World world;
 	Renderer renderer;
 	SDL_Window * window;
-	SDL_GLContext glcontext;
-	GLuint gltextures[2];
-	GLuint fbo;
-	bool usingopengl;
-	SDL_Renderer * windowrenderer;
+	RenderDevice * renderdevice;
+	SDL_Color palettecolors[256]; // CPU copy — for ffmpeg replay pixel export
 	Surface screenbuffer;
-	SDL_Surface * sdlscreenbuffer;
-	SDL_Texture * streamingtexture;
-	SDL_PixelFormat streamingtexturepixelformat;
-	Uint32 streamingtexturepalette[256];
 	int frames;
 	int fps;
 	Uint64 lasttick;

--- a/clients/silencer/src/renderdevice.h
+++ b/clients/silencer/src/renderdevice.h
@@ -1,0 +1,35 @@
+#ifndef RENDERDEVICE_H
+#define RENDERDEVICE_H
+
+#include "shared.h"
+
+// Abstract rendering interface. All game code talks through this; GPU-specific
+// types never leak into game code. SDL3GPUBackend is the Phase 2 implementation.
+// Console backends (NVN, GNM, D3D12) slot in without touching game code.
+class RenderDevice {
+public:
+	virtual ~RenderDevice() = default;
+
+	// Initialise the device against an existing SDL window.
+	// The window must NOT have SDL_WINDOW_OPENGL set.
+	virtual bool Init(SDL_Window *window) = 0;
+	virtual void Shutdown() = 0;
+
+	// Upload the 256-entry palette. Alpha is forced to 255.
+	// Call whenever the palette changes; the upload is deferred to Present().
+	virtual void SetPalette(const SDL_Color *colors, int count) = 0;
+
+	// Copy the 8-bit indexed pixel buffer for the current frame.
+	// Upload is deferred to Present(); pixels must remain valid until then.
+	virtual void UploadFrame(const Uint8 *indexed_pixels, int w, int h) = 0;
+
+	// Flush pending uploads, run the palette-remap shader, and swap buffers.
+	// No-op (skips render pass) when the window is minimized.
+	virtual void Present() = 0;
+
+	// Nearest-pixel is always used for the indexed→palette step.
+	// Phase 3 will implement bilinear post-remap upscaling via a second pass.
+	virtual void SetScaleFilter(bool linear) = 0;
+};
+
+#endif

--- a/clients/silencer/src/renderdevice.h
+++ b/clients/silencer/src/renderdevice.h
@@ -4,8 +4,15 @@
 #include "shared.h"
 
 // Abstract rendering interface. All game code talks through this; GPU-specific
-// types never leak into game code. SDL3GPUBackend is the Phase 2 implementation.
+// types never leak into game code. SDL3GPUBackend is the Phase 2/3 implementation.
 // Console backends (NVN, GNM, D3D12) slot in without touching game code.
+//
+// Render order each frame:
+//   UploadFrame()                     — queue 8-bit indexed pixels
+//   [DispatchParticleUpdate() ...]     — optional: compute-simulate GPU particles
+//   [DrawParticles() ...]              — optional: queue particle draw (additive, into scene)
+//   [BeginLighting() + AddPointLight() + EndLighting()]  — optional: additive emissive lights
+//   Present()                          — execute all queued work, swap buffers
 class RenderDevice {
 public:
 	virtual ~RenderDevice() = default;
@@ -23,13 +30,53 @@ public:
 	// Upload is deferred to Present(); pixels must remain valid until then.
 	virtual void UploadFrame(const Uint8 *indexed_pixels, int w, int h) = 0;
 
-	// Flush pending uploads, run the palette-remap shader, and swap buffers.
-	// No-op (skips render pass) when the window is minimized.
+	// Flush all pending work: uploads, compute, render passes, swap buffers.
+	// Skips the render pass silently when the window is minimized.
 	virtual void Present() = 0;
 
-	// Nearest-pixel is always used for the indexed→palette step.
-	// Phase 3 will implement bilinear post-remap upscaling via a second pass.
+	// Control upscale filter applied when scene texture is stretched to the window.
+	// Nearest-pixel is always used for the indexed→palette remap step regardless.
 	virtual void SetScaleFilter(bool linear) = 0;
+
+	// -------------------------------------------------------------------------
+	// Phase 3 — Lighting (additive emissive overlay)
+	// Lights are composited additively onto the scene AFTER palette remap, so
+	// they do not conflict with CPU palette lighting already baked into pixels.
+	// Default: no-ops (backends that don't implement lighting just skip it).
+	// -------------------------------------------------------------------------
+
+	// Begin accumulating lights for this frame. Call before AddPointLight().
+	virtual void BeginLighting() {}
+
+	// Submit a soft point light at pixel position (x,y) with the given radius
+	// (pixels), color, and intensity [0,1]. Clamped to an internal max per frame.
+	virtual void AddPointLight(float /*x*/, float /*y*/, float /*radius*/,
+	                           SDL_Color /*color*/, float /*intensity*/) {}
+
+	// Finalize lighting for this frame. Lights are rendered in Present().
+	virtual void EndLighting() {}
+
+	// -------------------------------------------------------------------------
+	// Phase 3 — GPU compute particles (feeds VFX Tool #36)
+	// Particle positions are simulated on the GPU via a compute kernel and drawn
+	// additively into the scene texture before upscaling.
+	// Default: no-ops that return -1 (unsupported on backends without compute).
+	// -------------------------------------------------------------------------
+
+	// Allocate a GPU particle buffer for up to `count` particles.
+	// Returns an opaque handle >= 0, or -1 on failure.
+	virtual int AllocParticleBuffer(Uint32 /*count*/) { return -1; }
+
+	// Release a previously allocated particle buffer.
+	virtual void FreeParticleBuffer(int /*handle*/) {}
+
+	// Dispatch the compute kernel to advance particle positions by dt seconds.
+	// Particles with life <= 0 are skipped.
+	virtual void DispatchParticleUpdate(int /*handle*/, Uint32 /*count*/, float /*dt*/) {}
+
+	// Queue a draw of `count` particles from the buffer into the scene.
+	// Must be called after DispatchParticleUpdate and before Present().
+	virtual void DrawParticles(int /*handle*/, Uint32 /*count*/) {}
 };
 
 #endif

--- a/clients/silencer/src/sdl3gpubackend.cpp
+++ b/clients/silencer/src/sdl3gpubackend.cpp
@@ -2,45 +2,138 @@
 #include <string.h>
 
 // ---------------------------------------------------------------------------
-// MSL shaders (Metal Shading Language — macOS/Metal backend).
-// For Vulkan/D3D12: add SPIR-V / DXIL paths selected via SDL_GetGPUShaderFormats().
+// MSL Shaders (Metal Shading Language — macOS/Metal backend).
+// Each string is compiled independently; structs are redefined per-shader.
+// For Vulkan/D3D12: select SPIR-V/DXIL paths via SDL_GetGPUShaderFormats().
 // ---------------------------------------------------------------------------
 
-// Fullscreen triangle generated from vertex_id — no vertex buffer required.
-// NDC coords: (-1,-1), (3,-1), (-1,3) cover the entire clip space with one triangle.
-// UV coords:  (0,0), (2,0), (0,2) — hardware clips the excess to [0,1].
-static const char *kVertMSL = R"(
+// Shared fullscreen-triangle vertex shader — generates 3 vertices from vertex_id
+// (no VBO). Y-flipped UVs to match Metal's top-down pixel convention.
+static const char *kVertScreenMSL = R"msl(
 #include <metal_stdlib>
 using namespace metal;
-struct VertexOut { float4 position [[position]]; float2 uv; };
-vertex VertexOut vert(uint vid [[vertex_id]]) {
-    const float2 pos[3] = {float2(-1,-1), float2(3,-1), float2(-1,3)};
-    const float2 uv[3]  = {float2(0,1),  float2(2,1),  float2(0,-1)};
-    VertexOut out;
-    out.position = float4(pos[vid], 0, 1);
-    out.uv = uv[vid];
-    return out;
+struct VOut { float4 pos [[position]]; float2 uv; };
+vertex VOut vert_screen(uint vid [[vertex_id]]) {
+    const float2 pos[3] = { float2(-1,-1), float2(3,-1), float2(-1,3) };
+    const float2 uv[3]  = { float2(0,1),  float2(2,1),  float2(0,-1) };
+    VOut o; o.pos = float4(pos[vid],0,1); o.uv = uv[vid]; return o;
 }
-)";
+)msl";
 
-// Palette remap: sample indexed (R8) texture, map the 0-1 value to a palette
-// texel centre, sample the RGBA palette texture.
-// UV math: R8_UNORM stores byte n as n/255.0.  Palette is 256 texels wide, so
-// texel n sits at (n+0.5)/256.0.  Substituting: u = idx*(255/256) + 0.5/256.
-static const char *kFragMSL = R"(
+// Palette remap: R8_UNORM indexed frame + RGBA palette → scene_tex (RGBA8).
+// UV math: R8 stores byte n as n/255.  Palette texel n sits at (n+0.5)/256.
+static const char *kFragRemapMSL = R"msl(
 #include <metal_stdlib>
 using namespace metal;
-struct VertexOut { float4 position [[position]]; float2 uv; };
-fragment float4 frag(VertexOut in [[stage_in]],
+struct VOut { float4 pos [[position]]; float2 uv; };
+fragment float4 frag_remap(VOut in [[stage_in]],
     texture2d<float> frame   [[texture(0)]],
     texture2d<float> palette [[texture(1)]],
-    sampler frame_s   [[sampler(0)]],
-    sampler palette_s [[sampler(1)]]) {
-    float idx = frame.sample(frame_s, in.uv).r;
-    float u   = idx * (255.0 / 256.0) + 0.5 / 256.0;
-    return palette.sample(palette_s, float2(u, 0.5));
+    sampler samp [[sampler(0)]]) {
+    float idx = frame.sample(samp, in.uv).r;
+    float u   = idx * (255.0/256.0) + 0.5/256.0;
+    return palette.sample(samp, float2(u, 0.5));
 }
-)";
+)msl";
+
+// Upscale: sample scene_tex with the chosen filter (nearest or bilinear)
+// and write to swapchain. Sampler is selected at bind time in Present().
+static const char *kFragUpscaleMSL = R"msl(
+#include <metal_stdlib>
+using namespace metal;
+struct VOut { float4 pos [[position]]; float2 uv; };
+fragment float4 frag_upscale(VOut in [[stage_in]],
+    texture2d<float> scene [[texture(0)]],
+    sampler samp [[sampler(0)]]) {
+    return scene.sample(samp, in.uv);
+}
+)msl";
+
+// Additive emissive light disc rendered into scene_tex.
+// Pixel-space distance avoids aspect-ratio distortion.
+// Uniform buffer 0 layout (48 bytes = 3 × float4):
+//   float4[0]: cx, cy, radius, intensity
+//   float4[1]: r,  g,  b,     game_w
+//   float4[2]: game_h, (pad x3)
+static const char *kFragLightMSL = R"msl(
+#include <metal_stdlib>
+using namespace metal;
+struct VOut { float4 pos [[position]]; float2 uv; };
+struct LightParams {
+    float cx, cy, radius, intensity;
+    float r, g, b, gw;
+    float gh, _p0, _p1, _p2;
+};
+fragment float4 frag_light(VOut in [[stage_in]],
+    constant LightParams& p [[buffer(0)]]) {
+    float2 px = in.uv * float2(p.gw, p.gh);
+    float  d  = length(px - float2(p.cx, p.cy));
+    float  f  = 1.0 - smoothstep(0.0, p.radius, d);
+    f = f * f; // quadratic falloff
+    float3 contrib = float3(p.r, p.g, p.b) * f * p.intensity;
+    return float4(contrib, f * p.intensity);
+}
+)msl";
+
+// Particle vertex shader: derives quad corners from a GPU storage buffer.
+// 6 vertices per particle (2 triangles). Dead particles (life<=0) produce
+// a degenerate quad outside clip space and are silently discarded.
+// Uniform buffer 0: float4(game_w, game_h, 0, 0).
+static const char *kVertParticleMSL = R"msl(
+#include <metal_stdlib>
+using namespace metal;
+struct Particle { float x,y,vx,vy,life,max_life; uint color_idx,flags; };
+struct PVert { float4 pos [[position]]; float pal_u; };
+vertex PVert vert_particle(uint vid [[vertex_id]],
+    device const Particle* parts [[buffer(0)]],
+    constant float4& fi [[buffer(1)]]) {
+    const float2 off[6] = {
+        float2(-1.5,-1.5), float2(1.5,-1.5), float2(-1.5,1.5),
+        float2(-1.5, 1.5), float2(1.5,-1.5), float2( 1.5,1.5)
+    };
+    uint pid = vid / 6;
+    uint cor = vid % 6;
+    Particle p = parts[pid];
+    float2 ndc = (float2(p.x, p.y) + off[cor]) / fi.xy * 2.0 - 1.0;
+    ndc.y = -ndc.y;
+    PVert o;
+    o.pos   = p.life > 0.0 ? float4(ndc, 0, 1) : float4(2, 2, 0, 0);
+    o.pal_u = float(p.color_idx) * (255.0/256.0) + 0.5/256.0;
+    return o;
+}
+)msl";
+
+// Particle fragment: palette lookup using the index baked into PVert.pal_u.
+static const char *kFragParticleMSL = R"msl(
+#include <metal_stdlib>
+using namespace metal;
+struct PVert { float4 pos [[position]]; float pal_u; };
+fragment float4 frag_particle(PVert in [[stage_in]],
+    texture2d<float> palette [[texture(0)]],
+    sampler samp [[sampler(0)]]) {
+    return palette.sample(samp, float2(in.pal_u, 0.5));
+}
+)msl";
+
+// Compute kernel: advance particle positions by dt, decay life.
+// Dispatch with threadcount_x=64; caller rounds count up to 64.
+static const char *kComputeParticleMSL = R"msl(
+#include <metal_stdlib>
+using namespace metal;
+struct Particle { float x,y,vx,vy,life,max_life; uint color_idx,flags; };
+kernel void update_particles(
+    device Particle* parts [[buffer(0)]],
+    constant float&  dt    [[buffer(1)]],
+    uint id [[thread_position_in_grid]]) {
+    Particle p = parts[id];
+    if (p.life <= 0.0f) return;
+    p.x    += p.vx * dt;
+    p.y    += p.vy * dt;
+    p.life -= dt;
+    if (p.life < 0.0f) p.life = 0.0f;
+    parts[id] = p;
+}
+)msl";
 
 // ---------------------------------------------------------------------------
 SDL3GPUBackend::SDL3GPUBackend() = default;
@@ -49,8 +142,6 @@ SDL3GPUBackend::~SDL3GPUBackend() { Shutdown(); }
 bool SDL3GPUBackend::Init(SDL_Window *win) {
 	window = win;
 
-	// Phase 2 targets Metal on macOS.  Future: pass format_flags based on
-	// SDL_GetGPUShaderFormats() to support Vulkan (SPIRV) / D3D12 (DXIL).
 	device = SDL_CreateGPUDevice(SDL_GPU_SHADERFORMAT_MSL, false, NULL);
 	if (!device) {
 		SDL_Log("SDL3GPUBackend: SDL_CreateGPUDevice failed: %s", SDL_GetError());
@@ -62,33 +153,55 @@ bool SDL3GPUBackend::Init(SDL_Window *win) {
 		return false;
 	}
 
-	if (!CreatePipeline()) return false;
-
 	SDL_GPUSamplerCreateInfo si = {};
-	si.min_filter    = SDL_GPU_FILTER_NEAREST;
-	si.mag_filter    = SDL_GPU_FILTER_NEAREST;
-	si.mipmap_mode   = SDL_GPU_SAMPLERMIPMAPMODE_NEAREST;
 	si.address_mode_u = SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_EDGE;
 	si.address_mode_v = SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_EDGE;
 	si.address_mode_w = SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_EDGE;
-	sampler = SDL_CreateGPUSampler(device, &si);
-	if (!sampler) {
-		SDL_Log("SDL3GPUBackend: SDL_CreateGPUSampler failed: %s", SDL_GetError());
+	si.mipmap_mode    = SDL_GPU_SAMPLERMIPMAPMODE_NEAREST;
+
+	si.min_filter = SDL_GPU_FILTER_NEAREST;
+	si.mag_filter = SDL_GPU_FILTER_NEAREST;
+	nearest_sampler = SDL_CreateGPUSampler(device, &si);
+	if (!nearest_sampler) {
+		SDL_Log("SDL3GPUBackend: nearest sampler failed: %s", SDL_GetError());
 		return false;
 	}
 
-	return true;
+	si.min_filter = SDL_GPU_FILTER_LINEAR;
+	si.mag_filter = SDL_GPU_FILTER_LINEAR;
+	linear_sampler = SDL_CreateGPUSampler(device, &si);
+	if (!linear_sampler) {
+		SDL_Log("SDL3GPUBackend: linear sampler failed: %s", SDL_GetError());
+		return false;
+	}
+
+	return CreatePipelines();
 }
 
 void SDL3GPUBackend::Shutdown() {
 	if (!device) return;
 	SDL_WaitForGPUIdle(device);
-	if (frame_tex)    { SDL_ReleaseGPUTexture(device, frame_tex);   frame_tex   = nullptr; }
-	if (palette_tex)  { SDL_ReleaseGPUTexture(device, palette_tex); palette_tex = nullptr; }
-	if (pipeline)     { SDL_ReleaseGPUGraphicsPipeline(device, pipeline); pipeline = nullptr; }
-	if (sampler)      { SDL_ReleaseGPUSampler(device, sampler);     sampler     = nullptr; }
-	if (frame_tbuf)   { SDL_ReleaseGPUTransferBuffer(device, frame_tbuf);   frame_tbuf   = nullptr; }
-	if (palette_tbuf) { SDL_ReleaseGPUTransferBuffer(device, palette_tbuf); palette_tbuf = nullptr; }
+
+	if (frame_tex)         { SDL_ReleaseGPUTexture(device, frame_tex);          frame_tex         = nullptr; }
+	if (palette_tex)       { SDL_ReleaseGPUTexture(device, palette_tex);        palette_tex       = nullptr; }
+	if (scene_tex)         { SDL_ReleaseGPUTexture(device, scene_tex);          scene_tex         = nullptr; }
+	if (remap_pipeline)    { SDL_ReleaseGPUGraphicsPipeline(device, remap_pipeline);   remap_pipeline   = nullptr; }
+	if (upscale_pipeline)  { SDL_ReleaseGPUGraphicsPipeline(device, upscale_pipeline); upscale_pipeline = nullptr; }
+	if (light_pipeline)    { SDL_ReleaseGPUGraphicsPipeline(device, light_pipeline);   light_pipeline   = nullptr; }
+	if (particle_pipeline) { SDL_ReleaseGPUGraphicsPipeline(device, particle_pipeline); particle_pipeline = nullptr; }
+	if (particle_compute)  { SDL_ReleaseGPUComputePipeline(device, particle_compute);  particle_compute  = nullptr; }
+	if (nearest_sampler)   { SDL_ReleaseGPUSampler(device, nearest_sampler);    nearest_sampler   = nullptr; }
+	if (linear_sampler)    { SDL_ReleaseGPUSampler(device, linear_sampler);     linear_sampler    = nullptr; }
+	if (frame_tbuf)        { SDL_ReleaseGPUTransferBuffer(device, frame_tbuf);  frame_tbuf        = nullptr; }
+	if (palette_tbuf)      { SDL_ReleaseGPUTransferBuffer(device, palette_tbuf); palette_tbuf     = nullptr; }
+
+	for (int i = 0; i < kMaxParticleBuffers; i++) {
+		if (particle_bufs[i].buf) {
+			SDL_ReleaseGPUBuffer(device, particle_bufs[i].buf);
+			particle_bufs[i] = {};
+		}
+	}
+
 	SDL_ReleaseWindowFromGPUDevice(device, window);
 	SDL_DestroyGPUDevice(device);
 	device = nullptr;
@@ -97,53 +210,205 @@ void SDL3GPUBackend::Shutdown() {
 SDL_GPUShader *SDL3GPUBackend::LoadShader(SDL_GPUShaderStage stage,
                                            const char *msl_source,
                                            const char *entrypoint,
-                                           Uint32 num_samplers) {
+                                           Uint32 num_samplers,
+                                           Uint32 num_uniform_buffers,
+                                           Uint32 num_storage_buffers) {
 	SDL_GPUShaderCreateInfo info = {};
-	info.code        = (const Uint8 *)msl_source;
-	info.code_size   = strlen(msl_source);
-	info.format      = SDL_GPU_SHADERFORMAT_MSL;
-	info.stage       = stage;
-	info.entrypoint  = entrypoint;
-	info.num_samplers = num_samplers;
+	info.code                = (const Uint8 *)msl_source;
+	info.code_size           = strlen(msl_source);
+	info.format              = SDL_GPU_SHADERFORMAT_MSL;
+	info.stage               = stage;
+	info.entrypoint          = entrypoint;
+	info.num_samplers        = num_samplers;
+	info.num_uniform_buffers = num_uniform_buffers;
+	info.num_storage_buffers = num_storage_buffers;
 	return SDL_CreateGPUShader(device, &info);
 }
 
-bool SDL3GPUBackend::CreatePipeline() {
-	SDL_GPUShader *vert = LoadShader(SDL_GPU_SHADERSTAGE_VERTEX,   kVertMSL, "vert", 0);
-	SDL_GPUShader *frag = LoadShader(SDL_GPU_SHADERSTAGE_FRAGMENT, kFragMSL, "frag", 2);
-	if (!vert || !frag) {
-		SDL_Log("SDL3GPUBackend: shader compilation failed: %s", SDL_GetError());
-		if (vert) SDL_ReleaseGPUShader(device, vert);
-		if (frag) SDL_ReleaseGPUShader(device, frag);
+bool SDL3GPUBackend::CreatePipelines() {
+	// --- Remap pipeline: R8 indexed frame → scene_tex (RGBA8) ---
+	{
+		SDL_GPUShader *vs = LoadShader(SDL_GPU_SHADERSTAGE_VERTEX,   kVertScreenMSL, "vert_screen", 0);
+		SDL_GPUShader *fs = LoadShader(SDL_GPU_SHADERSTAGE_FRAGMENT, kFragRemapMSL,  "frag_remap",  2);
+		if (!vs || !fs) {
+			SDL_Log("SDL3GPUBackend: remap shaders failed: %s", SDL_GetError());
+			if (vs) SDL_ReleaseGPUShader(device, vs);
+			if (fs) SDL_ReleaseGPUShader(device, fs);
+			return false;
+		}
+
+		SDL_GPUColorTargetDescription ct = {};
+		ct.format = SDL_GPU_TEXTUREFORMAT_R8G8B8A8_UNORM;
+
+		SDL_GPUGraphicsPipelineCreateInfo pi = {};
+		pi.vertex_shader   = vs;
+		pi.fragment_shader = fs;
+		pi.primitive_type  = SDL_GPU_PRIMITIVETYPE_TRIANGLELIST;
+		pi.target_info.color_target_descriptions = &ct;
+		pi.target_info.num_color_targets         = 1;
+
+		remap_pipeline = SDL_CreateGPUGraphicsPipeline(device, &pi);
+		SDL_ReleaseGPUShader(device, vs);
+		SDL_ReleaseGPUShader(device, fs);
+		if (!remap_pipeline) {
+			SDL_Log("SDL3GPUBackend: remap pipeline failed: %s", SDL_GetError());
+			return false;
+		}
+	}
+
+	// --- Upscale pipeline: scene_tex → swapchain (swapchain format) ---
+	{
+		SDL_GPUShader *vs = LoadShader(SDL_GPU_SHADERSTAGE_VERTEX,   kVertScreenMSL,  "vert_screen", 0);
+		SDL_GPUShader *fs = LoadShader(SDL_GPU_SHADERSTAGE_FRAGMENT, kFragUpscaleMSL, "frag_upscale", 1);
+		if (!vs || !fs) {
+			SDL_Log("SDL3GPUBackend: upscale shaders failed: %s", SDL_GetError());
+			if (vs) SDL_ReleaseGPUShader(device, vs);
+			if (fs) SDL_ReleaseGPUShader(device, fs);
+			return false;
+		}
+
+		SDL_GPUColorTargetDescription ct = {};
+		ct.format = SDL_GetGPUSwapchainTextureFormat(device, window);
+
+		SDL_GPUGraphicsPipelineCreateInfo pi = {};
+		pi.vertex_shader   = vs;
+		pi.fragment_shader = fs;
+		pi.primitive_type  = SDL_GPU_PRIMITIVETYPE_TRIANGLELIST;
+		pi.target_info.color_target_descriptions = &ct;
+		pi.target_info.num_color_targets         = 1;
+
+		upscale_pipeline = SDL_CreateGPUGraphicsPipeline(device, &pi);
+		SDL_ReleaseGPUShader(device, vs);
+		SDL_ReleaseGPUShader(device, fs);
+		if (!upscale_pipeline) {
+			SDL_Log("SDL3GPUBackend: upscale pipeline failed: %s", SDL_GetError());
+			return false;
+		}
+	}
+
+	return true;
+}
+
+bool SDL3GPUBackend::CreateLightPipeline() {
+	// Additive blend: src×srcAlpha + dst×1 (classic emissive additive)
+	SDL_GPUColorTargetBlendState blend = {};
+	blend.enable_blend             = true;
+	blend.src_color_blendfactor    = SDL_GPU_BLENDFACTOR_SRC_ALPHA;
+	blend.dst_color_blendfactor    = SDL_GPU_BLENDFACTOR_ONE;
+	blend.color_blend_op           = SDL_GPU_BLENDOP_ADD;
+	blend.src_alpha_blendfactor    = SDL_GPU_BLENDFACTOR_ZERO;
+	blend.dst_alpha_blendfactor    = SDL_GPU_BLENDFACTOR_ONE;
+	blend.alpha_blend_op           = SDL_GPU_BLENDOP_ADD;
+
+	SDL_GPUShader *vs = LoadShader(SDL_GPU_SHADERSTAGE_VERTEX,   kVertScreenMSL, "vert_screen", 0);
+	SDL_GPUShader *fs = LoadShader(SDL_GPU_SHADERSTAGE_FRAGMENT, kFragLightMSL,  "frag_light",
+	                               /*num_samplers=*/0, /*num_uniform_buffers=*/1);
+	if (!vs || !fs) {
+		SDL_Log("SDL3GPUBackend: light shaders failed: %s", SDL_GetError());
+		if (vs) SDL_ReleaseGPUShader(device, vs);
+		if (fs) SDL_ReleaseGPUShader(device, fs);
 		return false;
 	}
 
-	SDL_GPUColorTargetDescription color_target = {};
-	color_target.format = SDL_GetGPUSwapchainTextureFormat(device, window);
+	SDL_GPUColorTargetDescription ct = {};
+	ct.format      = SDL_GPU_TEXTUREFORMAT_R8G8B8A8_UNORM;
+	ct.blend_state = blend;
 
 	SDL_GPUGraphicsPipelineCreateInfo pi = {};
-	pi.vertex_shader        = vert;
-	pi.fragment_shader      = frag;
-	pi.primitive_type       = SDL_GPU_PRIMITIVETYPE_TRIANGLELIST;
-	pi.target_info.color_target_descriptions   = &color_target;
-	pi.target_info.num_color_targets           = 1;
-	pi.target_info.has_depth_stencil_target    = false;
+	pi.vertex_shader   = vs;
+	pi.fragment_shader = fs;
+	pi.primitive_type  = SDL_GPU_PRIMITIVETYPE_TRIANGLELIST;
+	pi.target_info.color_target_descriptions = &ct;
+	pi.target_info.num_color_targets         = 1;
 
-	pipeline = SDL_CreateGPUGraphicsPipeline(device, &pi);
-	SDL_ReleaseGPUShader(device, vert);
-	SDL_ReleaseGPUShader(device, frag);
-	if (!pipeline) {
-		SDL_Log("SDL3GPUBackend: SDL_CreateGPUGraphicsPipeline failed: %s", SDL_GetError());
+	light_pipeline = SDL_CreateGPUGraphicsPipeline(device, &pi);
+	SDL_ReleaseGPUShader(device, vs);
+	SDL_ReleaseGPUShader(device, fs);
+	if (!light_pipeline) {
+		SDL_Log("SDL3GPUBackend: light pipeline failed: %s", SDL_GetError());
 		return false;
 	}
 	return true;
 }
 
+bool SDL3GPUBackend::CreateParticlePipelines() {
+	// Compute pipeline: advance particle positions.
+	{
+		SDL_GPUComputePipelineCreateInfo ci = {};
+		ci.code                        = (const Uint8 *)kComputeParticleMSL;
+		ci.code_size                   = strlen(kComputeParticleMSL);
+		ci.format                      = SDL_GPU_SHADERFORMAT_MSL;
+		ci.entrypoint                  = "update_particles";
+		ci.num_readwrite_storage_buffers = 1;
+		ci.num_uniform_buffers         = 1;
+		ci.threadcount_x               = 64;
+		ci.threadcount_y               = 1;
+		ci.threadcount_z               = 1;
+		particle_compute = SDL_CreateGPUComputePipeline(device, &ci);
+		if (!particle_compute) {
+			SDL_Log("SDL3GPUBackend: particle compute pipeline failed: %s", SDL_GetError());
+			return false;
+		}
+	}
+
+	// Graphics pipeline: draw particle quads additively into scene_tex.
+	{
+		// Vertex reads from storage buffer (particles) + uniform (frame_info).
+		SDL_GPUShader *vs = LoadShader(SDL_GPU_SHADERSTAGE_VERTEX,
+		                               kVertParticleMSL, "vert_particle",
+		                               /*num_samplers=*/0,
+		                               /*num_uniform_buffers=*/1,
+		                               /*num_storage_buffers=*/1);
+		SDL_GPUShader *fs = LoadShader(SDL_GPU_SHADERSTAGE_FRAGMENT,
+		                               kFragParticleMSL, "frag_particle",
+		                               /*num_samplers=*/1);
+		if (!vs || !fs) {
+			SDL_Log("SDL3GPUBackend: particle shaders failed: %s", SDL_GetError());
+			if (vs) SDL_ReleaseGPUShader(device, vs);
+			if (fs) SDL_ReleaseGPUShader(device, fs);
+			return false;
+		}
+
+		SDL_GPUColorTargetBlendState blend = {};
+		blend.enable_blend             = true;
+		blend.src_color_blendfactor    = SDL_GPU_BLENDFACTOR_SRC_ALPHA;
+		blend.dst_color_blendfactor    = SDL_GPU_BLENDFACTOR_ONE;
+		blend.color_blend_op           = SDL_GPU_BLENDOP_ADD;
+		blend.src_alpha_blendfactor    = SDL_GPU_BLENDFACTOR_ZERO;
+		blend.dst_alpha_blendfactor    = SDL_GPU_BLENDFACTOR_ONE;
+		blend.alpha_blend_op           = SDL_GPU_BLENDOP_ADD;
+
+		SDL_GPUColorTargetDescription ct = {};
+		ct.format      = SDL_GPU_TEXTUREFORMAT_R8G8B8A8_UNORM;
+		ct.blend_state = blend;
+
+		SDL_GPUGraphicsPipelineCreateInfo pi = {};
+		pi.vertex_shader   = vs;
+		pi.fragment_shader = fs;
+		pi.primitive_type  = SDL_GPU_PRIMITIVETYPE_TRIANGLELIST;
+		pi.target_info.color_target_descriptions = &ct;
+		pi.target_info.num_color_targets         = 1;
+
+		particle_pipeline = SDL_CreateGPUGraphicsPipeline(device, &pi);
+		SDL_ReleaseGPUShader(device, vs);
+		SDL_ReleaseGPUShader(device, fs);
+		if (!particle_pipeline) {
+			SDL_Log("SDL3GPUBackend: particle graphics pipeline failed: %s", SDL_GetError());
+			return false;
+		}
+	}
+	return true;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
 void SDL3GPUBackend::SetPalette(const SDL_Color *colors, int count) {
 	int n = count < 256 ? count : 256;
 	for (int i = 0; i < n; i++) {
-		palette_colors[i] = colors[i];
-		palette_colors[i].a = 255; // GPU RGBA upload requires explicit alpha
+		palette_colors[i]   = colors[i];
+		palette_colors[i].a = 255;
 	}
 	palette_dirty = true;
 }
@@ -155,61 +420,147 @@ void SDL3GPUBackend::UploadFrame(const Uint8 *indexed_pixels, int w, int h) {
 	frame_dirty    = true;
 }
 
-void SDL3GPUBackend::SetScaleFilter(bool /*linear*/) {
-	// Phase 2: always nearest-pixel (can't linear-filter palette indices).
-	// Phase 3: second render-target pass will upscale with bilinear filter.
+void SDL3GPUBackend::SetScaleFilter(bool linear) {
+	use_linear = linear;
 }
 
+// Phase 3 — lighting
+void SDL3GPUBackend::BeginLighting() {
+	pending_light_count = 0;
+	lighting_active     = true;
+}
+
+void SDL3GPUBackend::AddPointLight(float x, float y, float radius,
+                                    SDL_Color color, float intensity) {
+	if (!lighting_active || pending_light_count >= kMaxLights) return;
+	LightEntry &le = pending_lights[pending_light_count++];
+	le.x         = x;
+	le.y         = y;
+	le.radius    = radius;
+	le.intensity = intensity;
+	le.r         = color.r / 255.0f;
+	le.g         = color.g / 255.0f;
+	le.b         = color.b / 255.0f;
+}
+
+void SDL3GPUBackend::EndLighting() {
+	// Lighting is composited in Present(); nothing to flush here.
+}
+
+// Phase 3 — GPU particles
+int SDL3GPUBackend::AllocParticleBuffer(Uint32 count) {
+	if (!device) return -1;
+	// Lazy pipeline creation on first particle buffer allocation.
+	if (!particle_compute && !CreateParticlePipelines()) return -1;
+
+	for (int i = 0; i < kMaxParticleBuffers; i++) {
+		if (!particle_bufs[i].buf) {
+			SDL_GPUBufferCreateInfo bi = {};
+			bi.usage = SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_READ  |
+			           SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_WRITE |
+			           SDL_GPU_BUFFERUSAGE_GRAPHICS_STORAGE_READ;
+			bi.size  = sizeof(GPUParticle) * count;
+			particle_bufs[i].buf      = SDL_CreateGPUBuffer(device, &bi);
+			particle_bufs[i].capacity = count;
+			return particle_bufs[i].buf ? i : -1;
+		}
+	}
+	return -1; // no free slots
+}
+
+void SDL3GPUBackend::FreeParticleBuffer(int handle) {
+	if (handle < 0 || handle >= kMaxParticleBuffers) return;
+	if (particle_bufs[handle].buf) {
+		SDL_WaitForGPUIdle(device);
+		SDL_ReleaseGPUBuffer(device, particle_bufs[handle].buf);
+		particle_bufs[handle] = {};
+	}
+}
+
+void SDL3GPUBackend::DispatchParticleUpdate(int handle, Uint32 count, float dt) {
+	if (handle < 0 || handle >= kMaxParticleBuffers) return;
+	if (!particle_bufs[handle].buf) return;
+	if (pending_particle_update_count >= kMaxParticleBuffers) return;
+	PendingParticleUpdate &u = pending_particle_updates[pending_particle_update_count++];
+	u.handle = handle;
+	u.count  = count;
+	u.dt     = dt;
+}
+
+void SDL3GPUBackend::DrawParticles(int handle, Uint32 count) {
+	if (handle < 0 || handle >= kMaxParticleBuffers) return;
+	if (!particle_bufs[handle].buf) return;
+	if (pending_particle_draw_count >= kMaxParticleBuffers) return;
+	PendingParticleDraw &d = pending_particle_draws[pending_particle_draw_count++];
+	d.handle = handle;
+	d.count  = count;
+}
+
+// ---------------------------------------------------------------------------
+// Present — executes all queued work in a single command buffer.
+// ---------------------------------------------------------------------------
 void SDL3GPUBackend::Present() {
-	if (!device || !pipeline) return;
+	if (!device || !remap_pipeline || !upscale_pipeline) return;
 
 	// Lazily create/resize frame texture.
 	if (frame_dirty && pending_pixels) {
-		if (!frame_tex ||
-		    frame_tex_w != pending_w ||
-		    frame_tex_h != pending_h) {
-			if (frame_tex) { SDL_ReleaseGPUTexture(device, frame_tex); }
+		if (!frame_tex || frame_tex_w != pending_w || frame_tex_h != pending_h) {
+			if (frame_tex) SDL_ReleaseGPUTexture(device, frame_tex);
 			SDL_GPUTextureCreateInfo ti = {};
-			ti.type        = SDL_GPU_TEXTURETYPE_2D;
-			ti.format      = SDL_GPU_TEXTUREFORMAT_R8_UNORM;
-			ti.usage       = SDL_GPU_TEXTUREUSAGE_SAMPLER;
-			ti.width       = (Uint32)pending_w;
-			ti.height      = (Uint32)pending_h;
-			ti.layer_count_or_depth = 1;
-			ti.num_levels  = 1;
+			ti.type                   = SDL_GPU_TEXTURETYPE_2D;
+			ti.format                 = SDL_GPU_TEXTUREFORMAT_R8_UNORM;
+			ti.usage                  = SDL_GPU_TEXTUREUSAGE_SAMPLER;
+			ti.width                  = (Uint32)pending_w;
+			ti.height                 = (Uint32)pending_h;
+			ti.layer_count_or_depth   = 1;
+			ti.num_levels             = 1;
 			frame_tex   = SDL_CreateGPUTexture(device, &ti);
 			frame_tex_w = pending_w;
 			frame_tex_h = pending_h;
 		}
-		// Resize transfer buffer if needed.
 		Uint32 needed = (Uint32)(pending_w * pending_h);
 		if (!frame_tbuf || frame_tbuf_sz < needed) {
 			if (frame_tbuf) SDL_ReleaseGPUTransferBuffer(device, frame_tbuf);
 			SDL_GPUTransferBufferCreateInfo tbi = {};
-			tbi.usage = SDL_GPU_TRANSFERBUFFERUSAGE_UPLOAD;
-			tbi.size  = needed;
+			tbi.usage     = SDL_GPU_TRANSFERBUFFERUSAGE_UPLOAD;
+			tbi.size      = needed;
 			frame_tbuf    = SDL_CreateGPUTransferBuffer(device, &tbi);
 			frame_tbuf_sz = needed;
+		}
+
+		// Create/resize scene texture (RGBA8, COLOR_TARGET + SAMPLER).
+		if (!scene_tex || scene_tex_w != pending_w || scene_tex_h != pending_h) {
+			if (scene_tex) SDL_ReleaseGPUTexture(device, scene_tex);
+			SDL_GPUTextureCreateInfo ti = {};
+			ti.type                 = SDL_GPU_TEXTURETYPE_2D;
+			ti.format               = SDL_GPU_TEXTUREFORMAT_R8G8B8A8_UNORM;
+			ti.usage                = SDL_GPU_TEXTUREUSAGE_SAMPLER |
+			                          SDL_GPU_TEXTUREUSAGE_COLOR_TARGET;
+			ti.width                = (Uint32)pending_w;
+			ti.height               = (Uint32)pending_h;
+			ti.layer_count_or_depth = 1;
+			ti.num_levels           = 1;
+			scene_tex   = SDL_CreateGPUTexture(device, &ti);
+			scene_tex_w = pending_w;
+			scene_tex_h = pending_h;
 		}
 	}
 
 	// Lazily create palette texture.
 	if (!palette_tex) {
 		SDL_GPUTextureCreateInfo ti = {};
-		ti.type        = SDL_GPU_TEXTURETYPE_2D;
-		ti.format      = SDL_GPU_TEXTUREFORMAT_R8G8B8A8_UNORM;
-		ti.usage       = SDL_GPU_TEXTUREUSAGE_SAMPLER;
-		ti.width       = 256;
-		ti.height      = 1;
+		ti.type                 = SDL_GPU_TEXTURETYPE_2D;
+		ti.format               = SDL_GPU_TEXTUREFORMAT_R8G8B8A8_UNORM;
+		ti.usage                = SDL_GPU_TEXTUREUSAGE_SAMPLER;
+		ti.width                = 256;
+		ti.height               = 1;
 		ti.layer_count_or_depth = 1;
-		ti.num_levels  = 1;
+		ti.num_levels           = 1;
 		palette_tex = SDL_CreateGPUTexture(device, &ti);
-
-		// First use — ensure transfer buffer exists.
 		if (!palette_tbuf) {
 			SDL_GPUTransferBufferCreateInfo tbi = {};
-			tbi.usage = SDL_GPU_TRANSFERBUFFERUSAGE_UPLOAD;
-			tbi.size  = 256 * 4;
+			tbi.usage    = SDL_GPU_TRANSFERBUFFERUSAGE_UPLOAD;
+			tbi.size     = 256 * 4;
 			palette_tbuf = SDL_CreateGPUTransferBuffer(device, &tbi);
 		}
 		palette_dirty = true;
@@ -218,8 +569,8 @@ void SDL3GPUBackend::Present() {
 	SDL_GPUCommandBuffer *cmd = SDL_AcquireGPUCommandBuffer(device);
 	if (!cmd) return;
 
-	// Upload passes (only when data changed).
-	if ((frame_dirty && pending_pixels) || palette_dirty) {
+	// ---- 1. Copy pass: upload frame + palette ----
+	if ((frame_dirty && pending_pixels && frame_tex && frame_tbuf) || palette_dirty) {
 		SDL_GPUCopyPass *copy = SDL_BeginGPUCopyPass(cmd);
 
 		if (frame_dirty && pending_pixels && frame_tex && frame_tbuf) {
@@ -263,7 +614,116 @@ void SDL3GPUBackend::Present() {
 		SDL_EndGPUCopyPass(copy);
 	}
 
-	// Acquire swapchain — returns null when minimized; skip render pass.
+	// ---- 2. Compute pass: advance particle positions ----
+	if (pending_particle_update_count > 0 && particle_compute) {
+		for (int i = 0; i < pending_particle_update_count; i++) {
+			PendingParticleUpdate &u = pending_particle_updates[i];
+			int h = u.handle;
+			if (h < 0 || h >= kMaxParticleBuffers || !particle_bufs[h].buf) continue;
+
+			SDL_GPUStorageBufferReadWriteBinding rw = {};
+			rw.buffer = particle_bufs[h].buf;
+			rw.cycle  = false;
+
+			SDL_GPUComputePass *cp = SDL_BeginGPUComputePass(cmd, nullptr, 0, &rw, 1);
+			SDL_BindGPUComputePipeline(cp, particle_compute);
+			SDL_PushGPUComputeUniformData(cmd, 0, &u.dt, sizeof(float));
+			Uint32 groups = (u.count + 63) / 64;
+			SDL_DispatchGPUCompute(cp, groups, 1, 1);
+			SDL_EndGPUComputePass(cp);
+		}
+		pending_particle_update_count = 0;
+	}
+
+	// ---- 3. Remap pass: indexed frame → scene_tex (CLEAR) ----
+	if (frame_tex && palette_tex && scene_tex) {
+		SDL_GPUColorTargetInfo ct = {};
+		ct.texture     = scene_tex;
+		ct.load_op     = SDL_GPU_LOADOP_CLEAR;
+		ct.store_op    = SDL_GPU_STOREOP_STORE;
+		ct.clear_color = {0, 0, 0, 1};
+
+		SDL_GPURenderPass *pass = SDL_BeginGPURenderPass(cmd, &ct, 1, nullptr);
+		if (pass) {
+			SDL_BindGPUGraphicsPipeline(pass, remap_pipeline);
+			SDL_GPUTextureSamplerBinding binds[2] = {
+				{frame_tex,   nearest_sampler},
+				{palette_tex, nearest_sampler},
+			};
+			SDL_BindGPUFragmentSamplers(pass, 0, binds, 2);
+			SDL_DrawGPUPrimitives(pass, 3, 1, 0, 0);
+			SDL_EndGPURenderPass(pass);
+		}
+	}
+
+	// ---- 4. Effects pass: particles + lights → scene_tex (LOAD, additive) ----
+	bool has_particles = (pending_particle_draw_count > 0) && particle_pipeline;
+	bool has_lights    = (pending_light_count > 0) && lighting_active;
+
+	if ((has_particles || has_lights) && scene_tex) {
+		// Lazy light pipeline creation.
+		if (has_lights && !light_pipeline) {
+			has_lights = CreateLightPipeline();
+		}
+
+		SDL_GPUColorTargetInfo ct = {};
+		ct.texture  = scene_tex;
+		ct.load_op  = SDL_GPU_LOADOP_LOAD; // preserve remap output
+		ct.store_op = SDL_GPU_STOREOP_STORE;
+
+		SDL_GPURenderPass *pass = SDL_BeginGPURenderPass(cmd, &ct, 1, nullptr);
+		if (pass) {
+			// Draw particles (additive blend baked into particle_pipeline).
+			if (has_particles) {
+				SDL_BindGPUGraphicsPipeline(pass, particle_pipeline);
+				for (int i = 0; i < pending_particle_draw_count; i++) {
+					PendingParticleDraw &d = pending_particle_draws[i];
+					int h = d.handle;
+					if (h < 0 || h >= kMaxParticleBuffers || !particle_bufs[h].buf) continue;
+
+					SDL_GPUBuffer *buf = particle_bufs[h].buf;
+					SDL_BindGPUVertexStorageBuffers(pass, 0, &buf, 1);
+
+					float fi[4] = {(float)scene_tex_w, (float)scene_tex_h, 0.f, 0.f};
+					SDL_PushGPUVertexUniformData(cmd, 0, fi, sizeof(fi));
+
+					SDL_GPUTextureSamplerBinding pal_bind = {palette_tex, nearest_sampler};
+					SDL_BindGPUFragmentSamplers(pass, 0, &pal_bind, 1);
+
+					SDL_DrawGPUPrimitives(pass, d.count * 6, 1, 0, 0);
+				}
+			}
+
+			// Draw lights (additive blend baked into light_pipeline).
+			if (has_lights && light_pipeline) {
+				SDL_BindGPUGraphicsPipeline(pass, light_pipeline);
+				struct LightParams { float cx,cy,radius,intensity; float r,g,b,gw; float gh,p0,p1,p2; };
+				for (int i = 0; i < pending_light_count; i++) {
+					LightEntry &le = pending_lights[i];
+					LightParams lp = {};
+					lp.cx        = le.x;
+					lp.cy        = le.y;
+					lp.radius    = le.radius;
+					lp.intensity = le.intensity;
+					lp.r         = le.r;
+					lp.g         = le.g;
+					lp.b         = le.b;
+					lp.gw        = (float)scene_tex_w;
+					lp.gh        = (float)scene_tex_h;
+					SDL_PushGPUFragmentUniformData(cmd, 0, &lp, sizeof(lp));
+					SDL_DrawGPUPrimitives(pass, 3, 1, 0, 0);
+				}
+			}
+
+			SDL_EndGPURenderPass(pass);
+		}
+	}
+
+	pending_particle_draw_count = 0;
+	pending_light_count         = 0;
+	lighting_active             = false;
+
+	// ---- 5. Acquire swapchain — null when minimized ----
 	SDL_GPUTexture *swapchain = nullptr;
 	Uint32 sw_w = 0, sw_h = 0;
 	SDL_WaitAndAcquireGPUSwapchainTexture(cmd, window, &swapchain, &sw_w, &sw_h);
@@ -272,23 +732,24 @@ void SDL3GPUBackend::Present() {
 		return;
 	}
 
-	SDL_GPUColorTargetInfo ct = {};
-	ct.texture     = swapchain;
-	ct.load_op     = SDL_GPU_LOADOP_CLEAR;
-	ct.store_op    = SDL_GPU_STOREOP_STORE;
-	ct.clear_color = {0, 0, 0, 1};
+	// ---- 6. Upscale pass: scene_tex → swapchain ----
+	if (scene_tex) {
+		SDL_GPUColorTargetInfo ct = {};
+		ct.texture     = swapchain;
+		ct.load_op     = SDL_GPU_LOADOP_CLEAR;
+		ct.store_op    = SDL_GPU_STOREOP_STORE;
+		ct.clear_color = {0, 0, 0, 1};
 
-	SDL_GPURenderPass *pass = SDL_BeginGPURenderPass(cmd, &ct, 1, nullptr);
-	if (pass && frame_tex && palette_tex) {
-		SDL_BindGPUGraphicsPipeline(pass, pipeline);
-		SDL_GPUTextureSamplerBinding bindings[2] = {
-			{frame_tex,   sampler},
-			{palette_tex, sampler},
-		};
-		SDL_BindGPUFragmentSamplers(pass, 0, bindings, 2);
-		SDL_DrawGPUPrimitives(pass, 3, 1, 0, 0);
+		SDL_GPURenderPass *pass = SDL_BeginGPURenderPass(cmd, &ct, 1, nullptr);
+		if (pass) {
+			SDL_BindGPUGraphicsPipeline(pass, upscale_pipeline);
+			SDL_GPUSampler *up_samp = use_linear ? linear_sampler : nearest_sampler;
+			SDL_GPUTextureSamplerBinding bind = {scene_tex, up_samp};
+			SDL_BindGPUFragmentSamplers(pass, 0, &bind, 1);
+			SDL_DrawGPUPrimitives(pass, 3, 1, 0, 0);
+			SDL_EndGPURenderPass(pass);
+		}
 	}
-	if (pass) SDL_EndGPURenderPass(pass);
 
 	SDL_SubmitGPUCommandBuffer(cmd);
 }

--- a/clients/silencer/src/sdl3gpubackend.cpp
+++ b/clients/silencer/src/sdl3gpubackend.cpp
@@ -1,0 +1,294 @@
+#include "sdl3gpubackend.h"
+#include <string.h>
+
+// ---------------------------------------------------------------------------
+// MSL shaders (Metal Shading Language — macOS/Metal backend).
+// For Vulkan/D3D12: add SPIR-V / DXIL paths selected via SDL_GetGPUShaderFormats().
+// ---------------------------------------------------------------------------
+
+// Fullscreen triangle generated from vertex_id — no vertex buffer required.
+// NDC coords: (-1,-1), (3,-1), (-1,3) cover the entire clip space with one triangle.
+// UV coords:  (0,0), (2,0), (0,2) — hardware clips the excess to [0,1].
+static const char *kVertMSL = R"(
+#include <metal_stdlib>
+using namespace metal;
+struct VertexOut { float4 position [[position]]; float2 uv; };
+vertex VertexOut vert(uint vid [[vertex_id]]) {
+    const float2 pos[3] = {float2(-1,-1), float2(3,-1), float2(-1,3)};
+    const float2 uv[3]  = {float2(0,1),  float2(2,1),  float2(0,-1)};
+    VertexOut out;
+    out.position = float4(pos[vid], 0, 1);
+    out.uv = uv[vid];
+    return out;
+}
+)";
+
+// Palette remap: sample indexed (R8) texture, map the 0-1 value to a palette
+// texel centre, sample the RGBA palette texture.
+// UV math: R8_UNORM stores byte n as n/255.0.  Palette is 256 texels wide, so
+// texel n sits at (n+0.5)/256.0.  Substituting: u = idx*(255/256) + 0.5/256.
+static const char *kFragMSL = R"(
+#include <metal_stdlib>
+using namespace metal;
+struct VertexOut { float4 position [[position]]; float2 uv; };
+fragment float4 frag(VertexOut in [[stage_in]],
+    texture2d<float> frame   [[texture(0)]],
+    texture2d<float> palette [[texture(1)]],
+    sampler frame_s   [[sampler(0)]],
+    sampler palette_s [[sampler(1)]]) {
+    float idx = frame.sample(frame_s, in.uv).r;
+    float u   = idx * (255.0 / 256.0) + 0.5 / 256.0;
+    return palette.sample(palette_s, float2(u, 0.5));
+}
+)";
+
+// ---------------------------------------------------------------------------
+SDL3GPUBackend::SDL3GPUBackend() = default;
+SDL3GPUBackend::~SDL3GPUBackend() { Shutdown(); }
+
+bool SDL3GPUBackend::Init(SDL_Window *win) {
+	window = win;
+
+	// Phase 2 targets Metal on macOS.  Future: pass format_flags based on
+	// SDL_GetGPUShaderFormats() to support Vulkan (SPIRV) / D3D12 (DXIL).
+	device = SDL_CreateGPUDevice(SDL_GPU_SHADERFORMAT_MSL, false, NULL);
+	if (!device) {
+		SDL_Log("SDL3GPUBackend: SDL_CreateGPUDevice failed: %s", SDL_GetError());
+		return false;
+	}
+
+	if (!SDL_ClaimWindowForGPUDevice(device, window)) {
+		SDL_Log("SDL3GPUBackend: SDL_ClaimWindowForGPUDevice failed: %s", SDL_GetError());
+		return false;
+	}
+
+	if (!CreatePipeline()) return false;
+
+	SDL_GPUSamplerCreateInfo si = {};
+	si.min_filter    = SDL_GPU_FILTER_NEAREST;
+	si.mag_filter    = SDL_GPU_FILTER_NEAREST;
+	si.mipmap_mode   = SDL_GPU_SAMPLERMIPMAPMODE_NEAREST;
+	si.address_mode_u = SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_EDGE;
+	si.address_mode_v = SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_EDGE;
+	si.address_mode_w = SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_EDGE;
+	sampler = SDL_CreateGPUSampler(device, &si);
+	if (!sampler) {
+		SDL_Log("SDL3GPUBackend: SDL_CreateGPUSampler failed: %s", SDL_GetError());
+		return false;
+	}
+
+	return true;
+}
+
+void SDL3GPUBackend::Shutdown() {
+	if (!device) return;
+	SDL_WaitForGPUIdle(device);
+	if (frame_tex)    { SDL_ReleaseGPUTexture(device, frame_tex);   frame_tex   = nullptr; }
+	if (palette_tex)  { SDL_ReleaseGPUTexture(device, palette_tex); palette_tex = nullptr; }
+	if (pipeline)     { SDL_ReleaseGPUGraphicsPipeline(device, pipeline); pipeline = nullptr; }
+	if (sampler)      { SDL_ReleaseGPUSampler(device, sampler);     sampler     = nullptr; }
+	if (frame_tbuf)   { SDL_ReleaseGPUTransferBuffer(device, frame_tbuf);   frame_tbuf   = nullptr; }
+	if (palette_tbuf) { SDL_ReleaseGPUTransferBuffer(device, palette_tbuf); palette_tbuf = nullptr; }
+	SDL_ReleaseWindowFromGPUDevice(device, window);
+	SDL_DestroyGPUDevice(device);
+	device = nullptr;
+}
+
+SDL_GPUShader *SDL3GPUBackend::LoadShader(SDL_GPUShaderStage stage,
+                                           const char *msl_source,
+                                           const char *entrypoint,
+                                           Uint32 num_samplers) {
+	SDL_GPUShaderCreateInfo info = {};
+	info.code        = (const Uint8 *)msl_source;
+	info.code_size   = strlen(msl_source);
+	info.format      = SDL_GPU_SHADERFORMAT_MSL;
+	info.stage       = stage;
+	info.entrypoint  = entrypoint;
+	info.num_samplers = num_samplers;
+	return SDL_CreateGPUShader(device, &info);
+}
+
+bool SDL3GPUBackend::CreatePipeline() {
+	SDL_GPUShader *vert = LoadShader(SDL_GPU_SHADERSTAGE_VERTEX,   kVertMSL, "vert", 0);
+	SDL_GPUShader *frag = LoadShader(SDL_GPU_SHADERSTAGE_FRAGMENT, kFragMSL, "frag", 2);
+	if (!vert || !frag) {
+		SDL_Log("SDL3GPUBackend: shader compilation failed: %s", SDL_GetError());
+		if (vert) SDL_ReleaseGPUShader(device, vert);
+		if (frag) SDL_ReleaseGPUShader(device, frag);
+		return false;
+	}
+
+	SDL_GPUColorTargetDescription color_target = {};
+	color_target.format = SDL_GetGPUSwapchainTextureFormat(device, window);
+
+	SDL_GPUGraphicsPipelineCreateInfo pi = {};
+	pi.vertex_shader        = vert;
+	pi.fragment_shader      = frag;
+	pi.primitive_type       = SDL_GPU_PRIMITIVETYPE_TRIANGLELIST;
+	pi.target_info.color_target_descriptions   = &color_target;
+	pi.target_info.num_color_targets           = 1;
+	pi.target_info.has_depth_stencil_target    = false;
+
+	pipeline = SDL_CreateGPUGraphicsPipeline(device, &pi);
+	SDL_ReleaseGPUShader(device, vert);
+	SDL_ReleaseGPUShader(device, frag);
+	if (!pipeline) {
+		SDL_Log("SDL3GPUBackend: SDL_CreateGPUGraphicsPipeline failed: %s", SDL_GetError());
+		return false;
+	}
+	return true;
+}
+
+void SDL3GPUBackend::SetPalette(const SDL_Color *colors, int count) {
+	int n = count < 256 ? count : 256;
+	for (int i = 0; i < n; i++) {
+		palette_colors[i] = colors[i];
+		palette_colors[i].a = 255; // GPU RGBA upload requires explicit alpha
+	}
+	palette_dirty = true;
+}
+
+void SDL3GPUBackend::UploadFrame(const Uint8 *indexed_pixels, int w, int h) {
+	pending_pixels = indexed_pixels;
+	pending_w      = w;
+	pending_h      = h;
+	frame_dirty    = true;
+}
+
+void SDL3GPUBackend::SetScaleFilter(bool /*linear*/) {
+	// Phase 2: always nearest-pixel (can't linear-filter palette indices).
+	// Phase 3: second render-target pass will upscale with bilinear filter.
+}
+
+void SDL3GPUBackend::Present() {
+	if (!device || !pipeline) return;
+
+	// Lazily create/resize frame texture.
+	if (frame_dirty && pending_pixels) {
+		if (!frame_tex ||
+		    frame_tex_w != pending_w ||
+		    frame_tex_h != pending_h) {
+			if (frame_tex) { SDL_ReleaseGPUTexture(device, frame_tex); }
+			SDL_GPUTextureCreateInfo ti = {};
+			ti.type        = SDL_GPU_TEXTURETYPE_2D;
+			ti.format      = SDL_GPU_TEXTUREFORMAT_R8_UNORM;
+			ti.usage       = SDL_GPU_TEXTUREUSAGE_SAMPLER;
+			ti.width       = (Uint32)pending_w;
+			ti.height      = (Uint32)pending_h;
+			ti.layer_count_or_depth = 1;
+			ti.num_levels  = 1;
+			frame_tex   = SDL_CreateGPUTexture(device, &ti);
+			frame_tex_w = pending_w;
+			frame_tex_h = pending_h;
+		}
+		// Resize transfer buffer if needed.
+		Uint32 needed = (Uint32)(pending_w * pending_h);
+		if (!frame_tbuf || frame_tbuf_sz < needed) {
+			if (frame_tbuf) SDL_ReleaseGPUTransferBuffer(device, frame_tbuf);
+			SDL_GPUTransferBufferCreateInfo tbi = {};
+			tbi.usage = SDL_GPU_TRANSFERBUFFERUSAGE_UPLOAD;
+			tbi.size  = needed;
+			frame_tbuf    = SDL_CreateGPUTransferBuffer(device, &tbi);
+			frame_tbuf_sz = needed;
+		}
+	}
+
+	// Lazily create palette texture.
+	if (!palette_tex) {
+		SDL_GPUTextureCreateInfo ti = {};
+		ti.type        = SDL_GPU_TEXTURETYPE_2D;
+		ti.format      = SDL_GPU_TEXTUREFORMAT_R8G8B8A8_UNORM;
+		ti.usage       = SDL_GPU_TEXTUREUSAGE_SAMPLER;
+		ti.width       = 256;
+		ti.height      = 1;
+		ti.layer_count_or_depth = 1;
+		ti.num_levels  = 1;
+		palette_tex = SDL_CreateGPUTexture(device, &ti);
+
+		// First use — ensure transfer buffer exists.
+		if (!palette_tbuf) {
+			SDL_GPUTransferBufferCreateInfo tbi = {};
+			tbi.usage = SDL_GPU_TRANSFERBUFFERUSAGE_UPLOAD;
+			tbi.size  = 256 * 4;
+			palette_tbuf = SDL_CreateGPUTransferBuffer(device, &tbi);
+		}
+		palette_dirty = true;
+	}
+
+	SDL_GPUCommandBuffer *cmd = SDL_AcquireGPUCommandBuffer(device);
+	if (!cmd) return;
+
+	// Upload passes (only when data changed).
+	if ((frame_dirty && pending_pixels) || palette_dirty) {
+		SDL_GPUCopyPass *copy = SDL_BeginGPUCopyPass(cmd);
+
+		if (frame_dirty && pending_pixels && frame_tex && frame_tbuf) {
+			Uint8 *dst = (Uint8 *)SDL_MapGPUTransferBuffer(device, frame_tbuf, false);
+			if (dst) {
+				memcpy(dst, pending_pixels, (size_t)(pending_w * pending_h));
+				SDL_UnmapGPUTransferBuffer(device, frame_tbuf);
+				SDL_GPUTextureTransferInfo src = {};
+				src.transfer_buffer = frame_tbuf;
+				src.rows_per_layer  = (Uint32)pending_h;
+				src.pixels_per_row  = (Uint32)pending_w;
+				SDL_GPUTextureRegion region = {};
+				region.texture = frame_tex;
+				region.w = (Uint32)pending_w;
+				region.h = (Uint32)pending_h;
+				region.d = 1;
+				SDL_UploadToGPUTexture(copy, &src, &region, false);
+			}
+			frame_dirty = false;
+		}
+
+		if (palette_dirty && palette_tex && palette_tbuf) {
+			Uint8 *dst = (Uint8 *)SDL_MapGPUTransferBuffer(device, palette_tbuf, false);
+			if (dst) {
+				memcpy(dst, palette_colors, 256 * 4);
+				SDL_UnmapGPUTransferBuffer(device, palette_tbuf);
+				SDL_GPUTextureTransferInfo src = {};
+				src.transfer_buffer = palette_tbuf;
+				src.rows_per_layer  = 1;
+				src.pixels_per_row  = 256;
+				SDL_GPUTextureRegion region = {};
+				region.texture = palette_tex;
+				region.w = 256;
+				region.h = 1;
+				region.d = 1;
+				SDL_UploadToGPUTexture(copy, &src, &region, false);
+			}
+			palette_dirty = false;
+		}
+
+		SDL_EndGPUCopyPass(copy);
+	}
+
+	// Acquire swapchain — returns null when minimized; skip render pass.
+	SDL_GPUTexture *swapchain = nullptr;
+	Uint32 sw_w = 0, sw_h = 0;
+	SDL_WaitAndAcquireGPUSwapchainTexture(cmd, window, &swapchain, &sw_w, &sw_h);
+	if (!swapchain) {
+		SDL_SubmitGPUCommandBuffer(cmd);
+		return;
+	}
+
+	SDL_GPUColorTargetInfo ct = {};
+	ct.texture     = swapchain;
+	ct.load_op     = SDL_GPU_LOADOP_CLEAR;
+	ct.store_op    = SDL_GPU_STOREOP_STORE;
+	ct.clear_color = {0, 0, 0, 1};
+
+	SDL_GPURenderPass *pass = SDL_BeginGPURenderPass(cmd, &ct, 1, nullptr);
+	if (pass && frame_tex && palette_tex) {
+		SDL_BindGPUGraphicsPipeline(pass, pipeline);
+		SDL_GPUTextureSamplerBinding bindings[2] = {
+			{frame_tex,   sampler},
+			{palette_tex, sampler},
+		};
+		SDL_BindGPUFragmentSamplers(pass, 0, bindings, 2);
+		SDL_DrawGPUPrimitives(pass, 3, 1, 0, 0);
+	}
+	if (pass) SDL_EndGPURenderPass(pass);
+
+	SDL_SubmitGPUCommandBuffer(cmd);
+}

--- a/clients/silencer/src/sdl3gpubackend.h
+++ b/clients/silencer/src/sdl3gpubackend.h
@@ -1,0 +1,58 @@
+#ifndef SDL3GPUBACKEND_H
+#define SDL3GPUBACKEND_H
+
+#include "renderdevice.h"
+
+// SDL3 GPU API backend — Metal on macOS, Vulkan on Linux/Windows.
+// Implements the indexed-color palette remap shader:
+//   frame_tex (R8_UNORM, 640×480) + palette_tex (RGBA8, 256×1)
+//   → fullscreen triangle → swapchain
+//
+// Shader strategy (Phase 2): MSL source strings for Metal. Future platforms
+// add SPIR-V / DXIL paths selected at runtime via SDL_GetGPUShaderFormats().
+class SDL3GPUBackend : public RenderDevice {
+public:
+	SDL3GPUBackend();
+	~SDL3GPUBackend() override;
+
+	bool Init(SDL_Window *window) override;
+	void Shutdown() override;
+
+	void SetPalette(const SDL_Color *colors, int count) override;
+	void UploadFrame(const Uint8 *indexed_pixels, int w, int h) override;
+	void Present() override;
+	void SetScaleFilter(bool linear) override;
+
+private:
+	bool CreatePipeline();
+	SDL_GPUShader *LoadShader(SDL_GPUShaderStage stage,
+	                          const char *msl_source,
+	                          const char *entrypoint,
+	                          Uint32 num_samplers);
+
+	SDL_Window              *window       = nullptr;
+	SDL_GPUDevice           *device       = nullptr;
+	SDL_GPUTexture          *frame_tex    = nullptr;
+	SDL_GPUTexture          *palette_tex  = nullptr;
+	SDL_GPUGraphicsPipeline *pipeline     = nullptr;
+	SDL_GPUSampler          *sampler      = nullptr;
+
+	// Persistent transfer buffers — reused every frame, resized if needed.
+	SDL_GPUTransferBuffer *frame_tbuf    = nullptr;
+	SDL_GPUTransferBuffer *palette_tbuf  = nullptr;
+	Uint32                 frame_tbuf_sz = 0;
+	int                    frame_tex_w   = 0;
+	int                    frame_tex_h   = 0;
+
+	// Palette CPU copy (for dirty tracking and ffmpeg replay path in game.cpp).
+	SDL_Color palette_colors[256] = {};
+	bool      palette_dirty       = true;
+
+	// Pending frame upload state.
+	const Uint8 *pending_pixels  = nullptr;
+	int          pending_w       = 0;
+	int          pending_h       = 0;
+	bool         frame_dirty     = false;
+};
+
+#endif

--- a/clients/silencer/src/sdl3gpubackend.h
+++ b/clients/silencer/src/sdl3gpubackend.h
@@ -3,13 +3,20 @@
 
 #include "renderdevice.h"
 
-// SDL3 GPU API backend — Metal on macOS, Vulkan on Linux/Windows.
-// Implements the indexed-color palette remap shader:
-//   frame_tex (R8_UNORM, 640×480) + palette_tex (RGBA8, 256×1)
-//   → fullscreen triangle → swapchain
+// SDL3 GPU API backend — Metal on macOS (auto-selects Vulkan on Linux/Windows).
 //
-// Shader strategy (Phase 2): MSL source strings for Metal. Future platforms
-// add SPIR-V / DXIL paths selected at runtime via SDL_GetGPUShaderFormats().
+// Phase 2 — palette remap shader: frame_tex (R8_UNORM) → scene_tex (RGBA8)
+// Phase 3 — offscreen scene + bilinear upscale + additive lights + GPU particles
+//
+// Render pass ordering inside Present():
+//   copy pass   — upload frame_tex and palette_tex (dirty-flagged)
+//   compute pass — advance particle positions (one dispatch per pending update)
+//   remap pass  — indexed frame → scene_tex  (CLEAR, remap_pipeline)
+//   effects pass — particles + lights → scene_tex  (LOAD, additive blend)
+//   upscale pass — scene_tex → swapchain  (CLEAR, nearest or bilinear)
+//
+// Shader strategy: MSL source strings (Metal). SDL_GetGPUShaderFormats() is the
+// hook for adding SPIR-V (Vulkan) / DXIL (D3D12) paths on other platforms.
 class SDL3GPUBackend : public RenderDevice {
 public:
 	SDL3GPUBackend();
@@ -23,36 +30,95 @@ public:
 	void Present() override;
 	void SetScaleFilter(bool linear) override;
 
+	// Phase 3 — lighting
+	void BeginLighting() override;
+	void AddPointLight(float x, float y, float radius,
+	                   SDL_Color color, float intensity) override;
+	void EndLighting() override;
+
+	// Phase 3 — GPU compute particles
+	int  AllocParticleBuffer(Uint32 count) override;
+	void FreeParticleBuffer(int handle) override;
+	void DispatchParticleUpdate(int handle, Uint32 count, float dt) override;
+	void DrawParticles(int handle, Uint32 count) override;
+
 private:
-	bool CreatePipeline();
+	bool CreatePipelines();
+	bool CreateLightPipeline();
+	bool CreateParticlePipelines();
 	SDL_GPUShader *LoadShader(SDL_GPUShaderStage stage,
 	                          const char *msl_source,
 	                          const char *entrypoint,
-	                          Uint32 num_samplers);
+	                          Uint32 num_samplers,
+	                          Uint32 num_uniform_buffers = 0,
+	                          Uint32 num_storage_buffers = 0);
 
-	SDL_Window              *window       = nullptr;
-	SDL_GPUDevice           *device       = nullptr;
-	SDL_GPUTexture          *frame_tex    = nullptr;
-	SDL_GPUTexture          *palette_tex  = nullptr;
-	SDL_GPUGraphicsPipeline *pipeline     = nullptr;
-	SDL_GPUSampler          *sampler      = nullptr;
+	SDL_Window    *window = nullptr;
+	SDL_GPUDevice *device = nullptr;
 
-	// Persistent transfer buffers — reused every frame, resized if needed.
-	SDL_GPUTransferBuffer *frame_tbuf    = nullptr;
-	SDL_GPUTransferBuffer *palette_tbuf  = nullptr;
+	// --- Indexed frame texture (R8_UNORM, game resolution) ---
+	SDL_GPUTexture        *frame_tex    = nullptr;
+	SDL_GPUTransferBuffer *frame_tbuf   = nullptr;
 	Uint32                 frame_tbuf_sz = 0;
-	int                    frame_tex_w   = 0;
-	int                    frame_tex_h   = 0;
+	int                    frame_tex_w  = 0;
+	int                    frame_tex_h  = 0;
 
-	// Palette CPU copy (for dirty tracking and ffmpeg replay path in game.cpp).
+	// --- Palette texture (RGBA8, 256×1) ---
+	SDL_GPUTexture        *palette_tex  = nullptr;
+	SDL_GPUTransferBuffer *palette_tbuf = nullptr;
+
+	// --- Scene texture (RGBA8, game resolution, COLOR_TARGET|SAMPLER) ---
+	// Remap writes here; effects (lights, particles) composite additively here.
+	// Upscale pass reads from here to produce the final swapchain image.
+	SDL_GPUTexture *scene_tex   = nullptr;
+	int             scene_tex_w = 0;
+	int             scene_tex_h = 0;
+
+	// --- Pipelines ---
+	SDL_GPUGraphicsPipeline *remap_pipeline    = nullptr; // indexed → scene_tex
+	SDL_GPUGraphicsPipeline *upscale_pipeline  = nullptr; // scene_tex → swapchain
+	SDL_GPUGraphicsPipeline *light_pipeline    = nullptr; // additive disc → scene_tex
+	SDL_GPUGraphicsPipeline *particle_pipeline = nullptr; // particles → scene_tex
+	SDL_GPUComputePipeline  *particle_compute  = nullptr; // update particle positions
+
+	// --- Samplers ---
+	SDL_GPUSampler *nearest_sampler = nullptr;
+	SDL_GPUSampler *linear_sampler  = nullptr;
+	bool            use_linear      = false;
+
+	// --- Palette CPU copy ---
 	SDL_Color palette_colors[256] = {};
 	bool      palette_dirty       = true;
 
-	// Pending frame upload state.
-	const Uint8 *pending_pixels  = nullptr;
-	int          pending_w       = 0;
-	int          pending_h       = 0;
-	bool         frame_dirty     = false;
+	// --- Pending frame upload ---
+	const Uint8 *pending_pixels = nullptr;
+	int          pending_w      = 0;
+	int          pending_h      = 0;
+	bool         frame_dirty    = false;
+
+	// --- Pending lighting (Phase 3) ---
+	// Additive emissive — no conflict with CPU palette lighting.
+	static const int kMaxLights = 64;
+	struct LightEntry { float x, y, radius, intensity, r, g, b; };
+	LightEntry pending_lights[kMaxLights];
+	int        pending_light_count = 0;
+	bool       lighting_active     = false; // BeginLighting called this frame
+
+	// --- Pending particle operations (Phase 3) ---
+	static const int kMaxParticleBuffers = 8;
+
+	// GPU particle struct — must match MSL layout (naturally 4-byte aligned, 32 bytes).
+	struct GPUParticle { float x, y, vx, vy, life, max_life; Uint32 color_idx, flags; };
+
+	struct ParticleBuffer { SDL_GPUBuffer *buf = nullptr; Uint32 capacity = 0; };
+	ParticleBuffer particle_bufs[kMaxParticleBuffers];
+
+	struct PendingParticleUpdate { int handle; Uint32 count; float dt; };
+	struct PendingParticleDraw   { int handle; Uint32 count; };
+	PendingParticleUpdate pending_particle_updates[kMaxParticleBuffers];
+	PendingParticleDraw   pending_particle_draws[kMaxParticleBuffers];
+	int pending_particle_update_count = 0;
+	int pending_particle_draw_count   = 0;
 };
 
 #endif


### PR DESCRIPTION
## Summary

Phases 2 and 3 of the SDL3 GPU migration (epic #42). Builds on Phase 1 (PR #49, merged).

---

## Phase 2 — RenderDevice abstraction + SDL3 GPU backend

- `renderdevice.h` — abstract interface: `Init`, `Shutdown`, `SetPalette`, `UploadFrame`, `Present`, `SetScaleFilter`
- `sdl3gpubackend.h` / `sdl3gpubackend.cpp` — SDL3 GPU implementation (Metal on macOS)
- Palette expansion moves CPU → GPU via MSL palette-remap shader
- Fullscreen triangle from `vertex_id` (no VBO)
- Persistent transfer buffers with dirty flags
- `game.h` / `game.cpp`: removed SDL_Renderer, SDL_Texture, OpenGL fields; delegates to `RenderDevice`

## Phase 3 — Offscreen RT, bilinear upscale, GPU lights, particle compute

### Offscreen scene texture + bilinear upscale
- `scene_tex`: RGBA8 at game resolution — remap writes here, not to swapchain
- Separate `remap_pipeline` (RGBA8 target) and `upscale_pipeline` (swapchain target)
- `SetScaleFilter(true)` now works — bilinear sampler on upscale pass

### Additive emissive lighting (unblocks #41)
- `BeginLighting / AddPointLight / EndLighting` on `RenderDevice` (default no-ops)
- MSL soft-disc shader rendered additively into scene_tex (load_op=LOAD after remap)
- Additive model: no conflict with CPU palette lighting already baked into pixels

### GPU compute particles (unblocks #36)
- `AllocParticleBuffer / FreeParticleBuffer / DispatchParticleUpdate / DrawParticles` on `RenderDevice` (default no-ops returning -1)
- MSL compute kernel: advance x/y/vx/vy/life per particle (threadcount_x=64)
- Vertex shader derives quads from storage buffer + vertex_id; fragment does palette lookup
- Additive blend into scene_tex; lazy pipeline creation on first use

### Render ordering in Present()
```
copy pass  → compute (particles) → remap → effects (particles+lights) → upscale
```

Closes #42
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/arsia-mons/silencer/pull/51" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
