### PR TITLE
ci: build verification workflows for macOS + Windows

### DIFF
--- a/.github/workflows/ci-build-macos.yml
+++ b/.github/workflows/ci-build-macos.yml
@@ -1,0 +1,59 @@
+name: CI Build (macOS)
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-build-macos-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  build:
+    if: github.event_name == 'push' || github.event.pull_request.draft == false
+    runs-on: macos-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install deps (Homebrew)
+        run: brew install minizip dylibbundler
+
+      - name: Install SDL3 + SDL3_mixer
+        uses: libsdl-org/setup-sdl@main
+        with:
+          version: 3-latest
+          version-sdl-mixer: 3-latest
+
+      - name: Configure
+        run: |
+          cmake -B build -S clients/silencer \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_OSX_DEPLOYMENT_TARGET=11.0
+
+      - name: Build
+        run: cmake --build build --config Release -j"$(sysctl -n hw.ncpu)"
+
+      - name: Bundle dylibs
+        working-directory: build
+        run: |
+          mkdir -p Silencer.app/Contents/Frameworks
+          dylibbundler \
+            -s "$SDL3_ROOT/lib" \
+            -s "$SDL3_mixer_ROOT/lib" \
+            --overwrite-dir \
+            --bundle-deps \
+            --create-dir \
+            --fix-file Silencer.app/Contents/MacOS/Silencer \
+            --dest-dir Silencer.app/Contents/Frameworks/ \
+            --install-path @rpath/ \
+            </dev/null
+          install_name_tool -add_rpath @executable_path/../Frameworks \
+            Silencer.app/Contents/MacOS/Silencer 2>/dev/null || true
+          echo "--- bundled dylibs ---"
+          ls Silencer.app/Contents/Frameworks/
+
+      - name: Verify bundled dependencies
+        run: tests/e2e/check-bundle-macos.sh build/Silencer.app

--- a/.github/workflows/ci-build-macos.yml
+++ b/.github/workflows/ci-build-macos.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  build:
+  build-macos:
     if: github.event_name == 'push' || github.event.pull_request.draft == false
     runs-on: macos-latest
     timeout-minutes: 20

--- a/.github/workflows/ci-build-macos.yml
+++ b/.github/workflows/ci-build-macos.yml
@@ -27,14 +27,23 @@ jobs:
           version: 3-latest
           version-sdl-mixer: 3-latest
 
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.4
+
       - name: Configure
         run: |
           cmake -B build -S clients/silencer \
             -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_OSX_DEPLOYMENT_TARGET=11.0
+            -DCMAKE_OSX_DEPLOYMENT_TARGET=11.0 \
+            -DCMAKE_C_COMPILER_LAUNCHER=sccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
 
       - name: Build
         run: cmake --build build --config Release -j"$(sysctl -n hw.ncpu)"
+
+      - name: sccache stats
+        if: always()
+        run: sccache --show-stats
 
       - name: Bundle dylibs
         working-directory: build

--- a/.github/workflows/ci-build-windows.yml
+++ b/.github/workflows/ci-build-windows.yml
@@ -35,20 +35,26 @@ jobs:
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.4
 
+      - name: Setup MSVC dev environment
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
+
       - name: Configure
         shell: pwsh
         env:
           VCPKG_BINARY_SOURCES: "clear;files,${{ github.workspace }}/.vcpkg-cache,readwrite"
         run: |
           cmake -B build -S clients/silencer `
-            -A x64 `
+            -G Ninja `
+            -DCMAKE_BUILD_TYPE=Release `
             -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" `
             -DVCPKG_TARGET_TRIPLET=x64-windows `
             -DCMAKE_C_COMPILER_LAUNCHER=sccache `
             -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
 
       - name: Build
-        run: cmake --build build --config Release -- -maxcpucount
+        run: cmake --build build
 
       - name: sccache stats
         if: always()
@@ -60,7 +66,7 @@ jobs:
         run: |
           $stage = "build/package/silencer"
           New-Item -ItemType Directory -Force -Path $stage | Out-Null
-          Copy-Item build/Release/Silencer.exe $stage/
+          Copy-Item build/Silencer.exe $stage/
           $vcpkgBin = "build/vcpkg_installed/x64-windows/bin"
           Copy-Item "$vcpkgBin/*.dll" $stage/
           Copy-Item -Recurse shared/assets $stage/assets

--- a/.github/workflows/ci-build-windows.yml
+++ b/.github/workflows/ci-build-windows.yml
@@ -26,6 +26,12 @@ jobs:
           restore-keys: |
             vcpkg-${{ runner.os }}-
 
+      - name: Cache vcpkg tool downloads
+        uses: actions/cache@v4
+        with:
+          path: C:\vcpkg\downloads\tools
+          key: vcpkg-tools-${{ runner.os }}-v1
+
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.4
 

--- a/.github/workflows/ci-build-windows.yml
+++ b/.github/workflows/ci-build-windows.yml
@@ -25,6 +25,9 @@ jobs:
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.4
+
       - name: Configure
         shell: pwsh
         env:
@@ -33,10 +36,17 @@ jobs:
           cmake -B build -S clients/silencer `
             -A x64 `
             -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" `
-            -DVCPKG_TARGET_TRIPLET=x64-windows
+            -DVCPKG_TARGET_TRIPLET=x64-windows `
+            -DCMAKE_C_COMPILER_LAUNCHER=sccache `
+            -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
 
       - name: Build
         run: cmake --build build --config Release -- -maxcpucount
+
+      - name: sccache stats
+        if: always()
+        shell: pwsh
+        run: sccache --show-stats
 
       - name: Package
         shell: pwsh

--- a/.github/workflows/ci-build-windows.yml
+++ b/.github/workflows/ci-build-windows.yml
@@ -1,0 +1,55 @@
+name: CI Build (Windows)
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-build-windows-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  build:
+    if: github.event_name == 'push' || github.event.pull_request.draft == false
+    runs-on: windows-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Export GitHub Actions cache variables for vcpkg
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+
+      - name: Configure
+        shell: pwsh
+        env:
+          VCPKG_BINARY_SOURCES: clear;x-gha,readwrite
+        run: |
+          cmake -B build -S clients/silencer `
+            -A x64 `
+            -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" `
+            -DVCPKG_TARGET_TRIPLET=x64-windows
+
+      - name: Build
+        run: cmake --build build --config Release -- -maxcpucount
+
+      - name: Package
+        shell: pwsh
+        run: |
+          $stage = "build/package/silencer"
+          New-Item -ItemType Directory -Force -Path $stage | Out-Null
+          Copy-Item build/Release/Silencer.exe $stage/
+          $vcpkgBin = "build/vcpkg_installed/x64-windows/bin"
+          Copy-Item "$vcpkgBin/*.dll" $stage/
+          Copy-Item -Recurse shared/assets $stage/assets
+          Write-Host "--- packaged files ---"
+          Get-ChildItem $stage
+
+      - name: Verify bundled dependencies
+        shell: pwsh
+        run: pwsh tests/e2e/check-bundle-windows.ps1 -PackageDir build/package/silencer

--- a/.github/workflows/ci-build-windows.yml
+++ b/.github/workflows/ci-build-windows.yml
@@ -18,12 +18,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Export GitHub Actions cache variables for vcpkg
-        uses: actions/github-script@v7
+      - name: Cache vcpkg binaries
+        uses: actions/cache@v4
         with:
-          script: |
-            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+          path: ${{ github.workspace }}/.vcpkg-cache
+          key: vcpkg-${{ runner.os }}-${{ hashFiles('clients/silencer/vcpkg.json') }}
+          restore-keys: |
+            vcpkg-${{ runner.os }}-
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.4
@@ -31,7 +32,7 @@ jobs:
       - name: Configure
         shell: pwsh
         env:
-          VCPKG_BINARY_SOURCES: clear;x-gha,readwrite
+          VCPKG_BINARY_SOURCES: "clear;files,${{ github.workspace }}/.vcpkg-cache,readwrite"
         run: |
           cmake -B build -S clients/silencer `
             -A x64 `

--- a/.github/workflows/ci-build-windows.yml
+++ b/.github/workflows/ci-build-windows.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  build:
+  build-windows:
     if: github.event_name == 'push' || github.event.pull_request.draft == false
     runs-on: windows-latest
     timeout-minutes: 30

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,18 +150,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Export GitHub Actions cache variables for vcpkg
-        uses: actions/github-script@v7
+      - name: Cache vcpkg binaries
+        uses: actions/cache@v4
         with:
-          script: |
-            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+          path: ${{ github.workspace }}/.vcpkg-cache
+          key: vcpkg-${{ runner.os }}-${{ hashFiles('clients/silencer/vcpkg.json') }}
+          restore-keys: |
+            vcpkg-${{ runner.os }}-
 
       - name: Configure
         shell: pwsh
         env:
           LOBBY_HOST: ${{ vars.LOBBY_HOST }}
-          VCPKG_BINARY_SOURCES: clear;x-gha,readwrite
+          VCPKG_BINARY_SOURCES: "clear;files,${{ github.workspace }}/.vcpkg-cache,readwrite"
         run: |
           $lobby = if ($env:LOBBY_HOST) { $env:LOBBY_HOST } else { "lobby.arsiamons.com" }
           $ver = $env:GITHUB_REF_NAME -replace '^v', ''

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,6 +164,11 @@ jobs:
           path: C:\vcpkg\downloads\tools
           key: vcpkg-tools-${{ runner.os }}-v1
 
+      - name: Setup MSVC dev environment
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
+
       - name: Configure
         shell: pwsh
         env:
@@ -173,7 +178,8 @@ jobs:
           $lobby = if ($env:LOBBY_HOST) { $env:LOBBY_HOST } else { "lobby.arsiamons.com" }
           $ver = $env:GITHUB_REF_NAME -replace '^v', ''
           cmake -B build -S clients/silencer `
-            -A x64 `
+            -G Ninja `
+            -DCMAKE_BUILD_TYPE=Release `
             -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" `
             -DVCPKG_TARGET_TRIPLET=x64-windows `
             -DSILENCER_LOBBY_HOST="$lobby" `
@@ -181,14 +187,14 @@ jobs:
             -DSILENCER_VERSION="$ver"
 
       - name: Build
-        run: cmake --build build --config Release -- -maxcpucount
+        run: cmake --build build
 
       - name: Package
         shell: pwsh
         run: |
           $stage = "build/package/silencer"
           New-Item -ItemType Directory -Force -Path $stage | Out-Null
-          Copy-Item build/Release/Silencer.exe $stage/
+          Copy-Item build/Silencer.exe $stage/
           # SDL2 / SDL2_mixer / zlib + transitive audio codec DLLs live in
           # the vcpkg manifest-mode install dir. Bulk-copy them so the zip
           # is self-contained — without these, Silencer.exe fails to start

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,6 +158,12 @@ jobs:
           restore-keys: |
             vcpkg-${{ runner.os }}-
 
+      - name: Cache vcpkg tool downloads
+        uses: actions/cache@v4
+        with:
+          path: C:\vcpkg\downloads\tools
+          key: vcpkg-tools-${{ runner.os }}-v1
+
       - name: Configure
         shell: pwsh
         env:

--- a/tests/e2e/check-bundle-macos.sh
+++ b/tests/e2e/check-bundle-macos.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Verifies a built Silencer.app bundle is self-contained: every non-system
+# dylib reference (in the main binary and in each bundled dylib) must resolve
+# to a file inside Contents/Frameworks/.
+#
+# Usage: tests/e2e/check-bundle-macos.sh <path-to-Silencer.app>
+set -euo pipefail
+
+APP="${1:?usage: $0 <path-to-Silencer.app>}"
+BINARY="$APP/Contents/MacOS/Silencer"
+FRAMEWORKS="$APP/Contents/Frameworks"
+
+[ -x "$BINARY" ] || { echo "no executable at $BINARY" >&2; exit 1; }
+
+errors=0
+
+check_file() {
+	local file="$1"
+	local refs
+	refs=$(otool -L "$file" | tail -n +2 | awk '{print $1}')
+	while IFS= read -r ref; do
+		case "$ref" in
+			"") ;;
+			/System/*|/usr/lib/*) ;;
+			@executable_path/*|@loader_path/*) ;;
+			@rpath/*)
+				local lib="${ref#@rpath/}"
+				if [ ! -f "$FRAMEWORKS/$lib" ]; then
+					echo "MISSING in Frameworks/: $lib (referenced from $file)"
+					errors=$((errors + 1))
+				fi
+				;;
+			/*)
+				echo "UNBUNDLED absolute path: $ref (in $file)"
+				errors=$((errors + 1))
+				;;
+			*)
+				echo "UNRECOGNIZED ref: $ref (in $file)"
+				errors=$((errors + 1))
+				;;
+		esac
+	done <<< "$refs"
+}
+
+check_file "$BINARY"
+
+if [ -d "$FRAMEWORKS" ]; then
+	while IFS= read -r dylib; do
+		check_file "$dylib"
+	done < <(find "$FRAMEWORKS" -name "*.dylib" -type f)
+fi
+
+if [ "$errors" -gt 0 ]; then
+	echo "----"
+	echo "FAIL: $errors unbundled dependency reference(s) detected"
+	exit 1
+fi
+
+echo "PASS: all non-system dylib references resolve into $FRAMEWORKS/"

--- a/tests/e2e/check-bundle-windows.ps1
+++ b/tests/e2e/check-bundle-windows.ps1
@@ -1,0 +1,88 @@
+# Verifies a packaged Silencer Windows build is self-contained: every DLL
+# imported by Silencer.exe (transitively) must resolve to a file inside the
+# package dir or to a system DLL under C:\Windows\System32 (or SysWOW64).
+#
+# Usage: pwsh tests/e2e/check-bundle-windows.ps1 -PackageDir <dir>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)] [string] $PackageDir
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path $PackageDir)) {
+    throw "Package dir not found: $PackageDir"
+}
+$PackageDir = (Resolve-Path $PackageDir).Path
+
+$exe = Join-Path $PackageDir 'Silencer.exe'
+if (-not (Test-Path $exe)) {
+    throw "Silencer.exe not found in $PackageDir"
+}
+
+$vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
+if (-not (Test-Path $vswhere)) {
+    throw "vswhere.exe not found at $vswhere — VS Build Tools required"
+}
+$vsInstall = & $vswhere -latest -property installationPath
+$dumpbin = Get-ChildItem (Join-Path $vsInstall 'VC\Tools\MSVC') -Directory |
+    ForEach-Object { Join-Path $_.FullName 'bin\Hostx64\x64\dumpbin.exe' } |
+    Where-Object { Test-Path $_ } |
+    Select-Object -First 1
+if (-not $dumpbin) {
+    throw "dumpbin.exe not found under $vsInstall\VC\Tools\MSVC"
+}
+
+function Get-ImportedDlls {
+    param([string] $Path)
+    $output = & $dumpbin /nologo /dependents $Path 2>&1
+    return $output |
+        Where-Object { $_ -match '^\s+\S+\.dll\s*$' } |
+        ForEach-Object { $_.Trim() }
+}
+
+function Resolve-Dll {
+    param([string] $Dll)
+    $candidates = @(
+        Join-Path $PackageDir $Dll
+        Join-Path "$env:WINDIR\System32" $Dll
+        Join-Path "$env:WINDIR\SysWOW64" $Dll
+    )
+    foreach ($c in $candidates) {
+        if (Test-Path $c) { return (Resolve-Path $c).Path }
+    }
+    return $null
+}
+
+$checked = @{}
+$queue = [System.Collections.Queue]::new()
+$queue.Enqueue($exe)
+$missing = @()
+
+while ($queue.Count -gt 0) {
+    $current = $queue.Dequeue()
+    Write-Host "scanning $current"
+    foreach ($dll in (Get-ImportedDlls $current)) {
+        $key = $dll.ToLower()
+        if ($checked.ContainsKey($key)) { continue }
+        $checked[$key] = $true
+        $resolved = Resolve-Dll $dll
+        if (-not $resolved) {
+            $missing += "$dll (referenced by $current)"
+            continue
+        }
+        if ($resolved.StartsWith($PackageDir, [System.StringComparison]::OrdinalIgnoreCase)) {
+            $queue.Enqueue($resolved)
+        }
+    }
+}
+
+if ($missing.Count -gt 0) {
+    Write-Host "----"
+    Write-Host "FAIL: $($missing.Count) unbundled DLL reference(s) — present neither in $PackageDir nor in System32:"
+    $missing | ForEach-Object { Write-Host "  $_" }
+    exit 1
+}
+
+Write-Host "PASS: all imported DLLs resolve in package dir or system dirs"

--- a/tests/e2e/check-bundle-windows.ps1
+++ b/tests/e2e/check-bundle-windows.ps1
@@ -37,6 +37,9 @@ if (-not $dumpbin) {
 function Get-ImportedDlls {
     param([string] $Path)
     $output = & $dumpbin /nologo /dependents $Path 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "dumpbin failed (exit $LASTEXITCODE) for ${Path}:`n$($output -join "`n")"
+    }
     return $output |
         Where-Object { $_ -match '^\s+\S+\.dll\s*$' } |
         ForEach-Object { $_.Trim() }

--- a/tests/e2e/check-bundle-windows.ps1
+++ b/tests/e2e/check-bundle-windows.ps1
@@ -44,6 +44,11 @@ function Get-ImportedDlls {
 
 function Resolve-Dll {
     param([string] $Dll)
+    # API Set DLLs (api-ms-win-*, ext-ms-*) are virtual — the OS loader
+    # redirects them to the real implementation (ucrtbase.dll etc.) at
+    # runtime, so they don't appear as files under System32. Guaranteed
+    # present on Windows 10+; treat as system-resolved.
+    if ($Dll -match '^(api|ext)-ms-') { return $true }
     $candidates = @(
         Join-Path $PackageDir $Dll
         Join-Path "$env:WINDIR\System32" $Dll
@@ -72,7 +77,7 @@ while ($queue.Count -gt 0) {
             $missing += "$dll (referenced by $current)"
             continue
         }
-        if ($resolved.StartsWith($PackageDir, [System.StringComparison]::OrdinalIgnoreCase)) {
+        if ($resolved -is [string] -and $resolved.StartsWith($PackageDir, [System.StringComparison]::OrdinalIgnoreCase)) {
             $queue.Enqueue($resolved)
         }
     }


### PR DESCRIPTION
## Summary

Adds two CI workflows that catch the recurring gotcha of a new C++ dependency added to `CMakeLists.txt` without a matching entry in the platform package step — the build itself still succeeds, but the shipped binary fails to load on a clean machine.

- **`.github/workflows/ci-build-macos.yml`** — mirrors `release.yml`'s mac build + `dylibbundler` step (minus signing/notarization), then runs the bundle check.
- **`.github/workflows/ci-build-windows.yml`** — mirrors `release.yml`'s windows build + DLL copy, then runs the bundle check.
- **`tests/e2e/check-bundle-macos.sh`** — `otool -L` walks `Silencer.app` and every bundled dylib; fails on any unresolved `@rpath/*` reference or non-system absolute path.
- **`tests/e2e/check-bundle-windows.ps1`** — `dumpbin /dependents` recursively walks `Silencer.exe`; fails on any DLL not present in the package dir or `C:\Windows\System32`/`SysWOW64`.

Both checks are static (no display/audio runtime), no dependency on `clients/cli/` or the headless control socket.

## Triggers

- `pull_request` (`opened`, `synchronize`, `reopened`, `ready_for_review`) — gated by `draft == false`. Concurrency keyed by PR number with `cancel-in-progress: true`.
- `push: branches: [main]` — verifies post-merge state (catches squash-merge commits and stale-base merges). Concurrency keyed by `github.ref` with `cancel-in-progress: false` so every main commit is fully tested.

## Test plan

- [ ] Watch this PR's macOS + Windows checks run; confirm both build, bundle, and pass the dependency check on a clean source tree.
- [ ] Manually intro a regression locally (e.g., delete a DLL from `build/package/silencer/` after packaging on Windows, or remove a dylib from `Silencer.app/Contents/Frameworks/` on macOS) and confirm the check script fails with a clear message.
- [ ] After merge, confirm the `push: main` trigger also fires and passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/arsia-mons/silencer/pull/60" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
