### PR TITLE
fix(terraform): lifecycle ignore_changes on SGs, map API port as standalone rule

### DIFF
--- a/infra/terraform/admin.tf
+++ b/infra/terraform/admin.tf
@@ -30,6 +30,12 @@ resource "aws_security_group" "admin" {
     protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }
+
+  # Mongo and LavinMQ ingress from lobby are managed by separate
+  # aws_vpc_security_group_ingress_rule resources to avoid circular deps.
+  lifecycle {
+    ignore_changes = [ingress]
+  }
 }
 
 # Cross-SG rules. Defined as separate resources because admin SG <-> lobby

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -90,20 +90,28 @@ resource "aws_security_group" "lobby" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  ingress {
-    description = "Community map API (HTTP)"
-    from_port   = 15172
-    to_port     = 15172
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
   egress {
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }
+
+  # Inline ingress is authoritative only for the rules defined above.
+  # Cross-SG and additional per-port rules are in separate
+  # aws_vpc_security_group_ingress_rule resources; ignore drift from those.
+  lifecycle {
+    ignore_changes = [ingress]
+  }
+}
+
+resource "aws_vpc_security_group_ingress_rule" "lobby_map_api" {
+  security_group_id = aws_security_group.lobby.id
+  ip_protocol       = "tcp"
+  from_port         = 15172
+  to_port           = 15172
+  cidr_ipv4         = "0.0.0.0/0"
+  description       = "Community map API (HTTP)"
 }
 
 resource "aws_eip" "lobby" {


### PR DESCRIPTION
Prevents Terraform from removing existing ingress rules (LavinMQ/MongoDB) when applying. Adds port 15172 as a standalone rule instead of inline. Already applied via `terraform apply`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/arsia-mons/silencer/pull/61" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
