### PR TITLE
fix(deploy): replace heredoc with printf (YAML parse fix)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -219,11 +219,7 @@ jobs:
 
             # Ensure map API listens on :15172 (idempotent drop-in).
             sudo mkdir -p /etc/systemd/system/silencer-lobby.service.d
-            sudo tee /etc/systemd/system/silencer-lobby.service.d/map-api.conf > /dev/null <<'EOF'
-[Service]
-ExecStart=
-ExecStart=/opt/silencer/current/silencer-lobby -addr :517 -db /var/lib/silencer/lobby.json -maps-dir /var/lib/silencer/maps -map-api-addr :15172 -update-manifest /opt/silencer/update.json -public-addr lobby.arsiamons.com -game-binary /opt/silencer/current/silencer
-EOF
+            printf '[Service]\nExecStart=\nExecStart=/opt/silencer/current/silencer-lobby -addr :517 -db /var/lib/silencer/lobby.json -maps-dir /var/lib/silencer/maps -map-api-addr :15172 -update-manifest /opt/silencer/update.json -public-addr lobby.arsiamons.com -game-binary /opt/silencer/current/silencer\n' | sudo tee /etc/systemd/system/silencer-lobby.service.d/map-api.conf > /dev/null
             sudo systemctl daemon-reload
             sudo systemctl restart silencer-lobby
             sleep 2


### PR DESCRIPTION
The `[Service]` heredoc content at column 0 was exiting the YAML block scalar, silently breaking the `workflow_run` and `workflow_dispatch` triggers. Replace with `printf` to keep content at proper YAML indentation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/arsia-mons/silencer/pull/62" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
