### PR TITLE
feat(maps): route map API through admin HTTPS proxy, close public port

### DIFF
--- a/.github/workflows/deploy-admin-api.yml
+++ b/.github/workflows/deploy-admin-api.yml
@@ -105,11 +105,13 @@ jobs:
           # 1. Update image ref
           echo "IMAGE=$IMAGE_REF" | sudo tee /etc/silencer/admin-api.image > /dev/null
 
-          # 2. Idempotently add ASSETS_DIR to the secret-fetch script so it
-          #    survives future secret rotations (the script overwrites the env
+          # 2. Idempotently add non-secret env vars to the secret-fetch script so
+          #    they survive future secret rotations (the script overwrites the env
           #    file on every run, so appending to the env file alone isn't durable).
           grep -q 'ASSETS_DIR=/assets' /usr/local/sbin/silencer-fetch-secrets || \
             sudo sed -i '/^GITHUB_BACKUP_REPO/a ASSETS_DIR=/assets' /usr/local/sbin/silencer-fetch-secrets
+          grep -q 'LOBBY_MAP_API_URL=' /usr/local/sbin/silencer-fetch-secrets || \
+            sudo sed -i '/^ASSETS_DIR/a LOBBY_MAP_API_URL=http://lobby.arsiamons.com:15172' /usr/local/sbin/silencer-fetch-secrets
 
           # 3. Regenerate env file to pick up ASSETS_DIR immediately
           sudo /usr/local/sbin/silencer-fetch-secrets

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_OSX_DEPLOYMENT_TARGET=11.0 \
             -DSILENCER_LOBBY_HOST="$lobby" \
-            -DSILENCER_MAP_API_URL="http://$lobby:15172" \
+            -DSILENCER_MAP_API_URL="https://admin.arsiamons.com/api/maps" \
             -DSILENCER_VERSION="${GITHUB_REF_NAME#v}"
 
       - name: Build
@@ -170,7 +170,7 @@ jobs:
             -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" `
             -DVCPKG_TARGET_TRIPLET=x64-windows `
             -DSILENCER_LOBBY_HOST="$lobby" `
-            -DSILENCER_MAP_API_URL="http://$lobby`:15172" `
+            -DSILENCER_MAP_API_URL="https://admin.arsiamons.com/api/maps" `
             -DSILENCER_VERSION="$ver"
 
       - name: Build

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -106,12 +106,12 @@ resource "aws_security_group" "lobby" {
 }
 
 resource "aws_vpc_security_group_ingress_rule" "lobby_map_api" {
-  security_group_id = aws_security_group.lobby.id
-  ip_protocol       = "tcp"
-  from_port         = 15172
-  to_port           = 15172
-  cidr_ipv4         = "0.0.0.0/0"
-  description       = "Community map API (HTTP)"
+  security_group_id            = aws_security_group.lobby.id
+  referenced_security_group_id = aws_security_group.admin.id
+  ip_protocol                  = "tcp"
+  from_port                    = 15172
+  to_port                      = 15172
+  description                  = "Community map API from admin-api proxy only"
 }
 
 resource "aws_eip" "lobby" {

--- a/services/admin-api/src/config.js
+++ b/services/admin-api/src/config.js
@@ -4,6 +4,7 @@ export const AMQP_URL = process.env.AMQP_URL || 'amqp://silencer:silencer@localh
 export const JWT_SECRET = process.env.JWT_SECRET || 'changeme-in-production';
 export const JWT_EXPIRES_IN = '8h';
 export const LOBBY_PLAYER_AUTH_URL = process.env.LOBBY_PLAYER_AUTH_URL || 'http://localhost:15171';
+export const LOBBY_MAP_API_URL = process.env.LOBBY_MAP_API_URL || 'http://localhost:15172';
 // Path to shared/assets directory (game binary assets).  Set via ASSETS_DIR env var in production.
 // Defaults to the shared/assets directory relative to the repo root for local dev.
 import { fileURLToPath } from 'url';

--- a/services/admin-api/src/index.js
+++ b/services/admin-api/src/index.js
@@ -16,6 +16,7 @@ import gameStatsRoutes from './routes/gamestats.js';
 import spritesRoutes        from './routes/sprites.js';
 import actorsRoutes from './routes/actors.js';
 import behaviortreesRoutes from './routes/behaviortrees.js';
+import mapsRoutes from './routes/maps.js';
 import { startBackupScheduler } from './backup/scheduler.js';
 import AdminUser from './db/models/AdminUser.js';
 
@@ -41,6 +42,7 @@ api.use('/gamestats',     gameStatsRoutes);
 api.use('/sprites',       spritesRoutes);
 api.use('/actors',        actorsRoutes);
 api.use('/behaviortrees', behaviortreesRoutes);
+api.use('/maps',          mapsRoutes);
 api.get('/health',        (_req, res) => res.json({ ok: true }));
 app.use('/api', api);
 

--- a/services/admin-api/src/routes/maps.js
+++ b/services/admin-api/src/routes/maps.js
@@ -1,0 +1,49 @@
+import express from 'express';
+import { LOBBY_MAP_API_URL } from '../config.js';
+
+const router = express.Router();
+
+// GET /api/maps — list published maps
+router.get('/', async (_req, res) => {
+  try {
+    const r = await fetch(`${LOBBY_MAP_API_URL}/api/maps`);
+    res.status(r.status).json(await r.json());
+  } catch {
+    res.status(502).json({ error: 'map API unreachable' });
+  }
+});
+
+// POST /api/maps — upload a map (binary body proxied through)
+router.post('/', express.raw({ type: 'application/octet-stream', limit: '10mb' }), async (req, res) => {
+  try {
+    const fwd = {};
+    if (req.headers['x-filename']) fwd['X-Filename'] = req.headers['x-filename'];
+    if (req.headers['x-author'])   fwd['X-Author']   = req.headers['x-author'];
+    if (req.headers['x-api-key'])  fwd['X-Api-Key']  = req.headers['x-api-key'];
+
+    const r = await fetch(`${LOBBY_MAP_API_URL}/api/maps`, {
+      method: 'POST',
+      body: req.body,
+      headers: { 'Content-Type': 'application/octet-stream', ...fwd },
+    });
+    res.status(r.status).json(await r.json());
+  } catch {
+    res.status(502).json({ error: 'map API unreachable' });
+  }
+});
+
+// GET /api/maps/* — download by sha1 or name
+router.get('/*', async (req, res) => {
+  try {
+    const r = await fetch(`${LOBBY_MAP_API_URL}/api/maps${req.path}`);
+    if (!r.ok) { res.status(r.status).send(await r.text()); return; }
+    const cd = r.headers.get('content-disposition');
+    if (cd) res.set('Content-Disposition', cd);
+    res.set('Content-Type', r.headers.get('content-type') || 'application/octet-stream');
+    res.send(Buffer.from(await r.arrayBuffer()));
+  } catch {
+    res.status(502).json({ error: 'map API unreachable' });
+  }
+});
+
+export default router;

--- a/web/admin/app/designer/page.tsx
+++ b/web/admin/app/designer/page.tsx
@@ -376,7 +376,7 @@ export default function DesignerPage() {
                       <input
                         value={pubApiUrl}
                         onChange={e => setPubApiUrl(e.target.value)}
-                        placeholder="http://host:15172"
+                        placeholder="(leave blank to use this server's /api/maps)"
                         className="w-full mt-1 px-2 py-1 text-xs font-mono bg-game-bg border border-game-border rounded text-game-text focus:outline-none focus:border-game-primary"
                       />
                     </div>


### PR DESCRIPTION
Fixes mixed-content browser block. Admin API proxies `/api/maps` to the lobby internally. Port 15172 restricted to admin SG only. Game clients and designer now use `https://admin.arsiamons.com/api/maps`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/arsia-mons/silencer/pull/64" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
