### PR TITLE
fix(maps): use lobby.silencer.internal for map API proxy

### DIFF
--- a/.github/workflows/deploy-admin-api.yml
+++ b/.github/workflows/deploy-admin-api.yml
@@ -111,7 +111,7 @@ jobs:
           grep -q 'ASSETS_DIR=/assets' /usr/local/sbin/silencer-fetch-secrets || \
             sudo sed -i '/^GITHUB_BACKUP_REPO/a ASSETS_DIR=/assets' /usr/local/sbin/silencer-fetch-secrets
           grep -q 'LOBBY_MAP_API_URL=' /usr/local/sbin/silencer-fetch-secrets || \
-            sudo sed -i '/^ASSETS_DIR/a LOBBY_MAP_API_URL=http://lobby.arsiamons.com:15172' /usr/local/sbin/silencer-fetch-secrets
+            sudo sed -i '/^ASSETS_DIR/a LOBBY_MAP_API_URL=http://lobby.silencer.internal:15172' /usr/local/sbin/silencer-fetch-secrets
 
           # 3. Regenerate env file to pick up ASSETS_DIR immediately
           sudo /usr/local/sbin/silencer-fetch-secrets


### PR DESCRIPTION
Fixes proxy timeout: admin API must use the internal DNS hostname so traffic stays within VPC and the SG source rule matches.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/arsia-mons/silencer/pull/65" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
