### PR TITLE
fix(deploy): replace LOBBY_MAP_API_URL if already present

### DIFF
--- a/.github/workflows/deploy-admin-api.yml
+++ b/.github/workflows/deploy-admin-api.yml
@@ -110,8 +110,9 @@ jobs:
           #    file on every run, so appending to the env file alone isn't durable).
           grep -q 'ASSETS_DIR=/assets' /usr/local/sbin/silencer-fetch-secrets || \
             sudo sed -i '/^GITHUB_BACKUP_REPO/a ASSETS_DIR=/assets' /usr/local/sbin/silencer-fetch-secrets
-          grep -q 'LOBBY_MAP_API_URL=' /usr/local/sbin/silencer-fetch-secrets || \
-            sudo sed -i '/^ASSETS_DIR/a LOBBY_MAP_API_URL=http://lobby.silencer.internal:15172' /usr/local/sbin/silencer-fetch-secrets
+          grep -q 'LOBBY_MAP_API_URL=' /usr/local/sbin/silencer-fetch-secrets \
+            && sudo sed -i 's|LOBBY_MAP_API_URL=.*|LOBBY_MAP_API_URL=http://lobby.silencer.internal:15172|' /usr/local/sbin/silencer-fetch-secrets \
+            || sudo sed -i '/^ASSETS_DIR/a LOBBY_MAP_API_URL=http://lobby.silencer.internal:15172' /usr/local/sbin/silencer-fetch-secrets
 
           # 3. Regenerate env file to pick up ASSETS_DIR immediately
           sudo /usr/local/sbin/silencer-fetch-secrets


### PR DESCRIPTION
grep guard was skipping the sed update because old value was already in the file.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/arsia-mons/silencer/pull/66" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
