### PR TITLE
fix(maps): handle plain-text error responses from lobby proxy

### DIFF
--- a/services/admin-api/src/routes/maps.js
+++ b/services/admin-api/src/routes/maps.js
@@ -26,7 +26,13 @@ router.post('/', express.raw({ type: 'application/octet-stream', limit: '10mb' }
       body: req.body,
       headers: { 'Content-Type': 'application/octet-stream', ...fwd },
     });
-    res.status(r.status).json(await r.json());
+    const ct = r.headers.get('content-type') || '';
+    if (ct.includes('application/json')) {
+      res.status(r.status).json(await r.json());
+    } else {
+      const text = (await r.text()).trim();
+      res.status(r.status).json({ error: text || r.statusText });
+    }
   } catch {
     res.status(502).json({ error: 'map API unreachable' });
   }


### PR DESCRIPTION
Avoids false 502 when lobby returns plain text 400/401.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/arsia-mons/silencer/pull/67" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
