### PR TITLE
ci: build Dockerfiles on PRs

### DIFF
--- a/.github/workflows/ci-build-admin-api.yml
+++ b/.github/workflows/ci-build-admin-api.yml
@@ -17,7 +17,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  build:
+  build-admin-api:
     if: github.event_name == 'push' || github.event.pull_request.draft == false
     # Match the deploy workflow's runner so a CI pass implies a deploy build will succeed.
     runs-on: ubuntu-24.04-arm

--- a/.github/workflows/ci-build-admin-api.yml
+++ b/.github/workflows/ci-build-admin-api.yml
@@ -1,0 +1,38 @@
+name: CI Build (admin-api Docker)
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - 'services/admin-api/**'
+      - '.github/workflows/ci-build-admin-api.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'services/admin-api/**'
+      - '.github/workflows/ci-build-admin-api.yml'
+
+concurrency:
+  group: ci-build-admin-api-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  build:
+    if: github.event_name == 'push' || github.event.pull_request.draft == false
+    # Match the deploy workflow's runner so a CI pass implies a deploy build will succeed.
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build image (no push)
+        uses: docker/build-push-action@v6
+        with:
+          context: services/admin-api
+          file: services/admin-api/Dockerfile
+          push: false
+          platforms: linux/arm64
+          cache-from: type=gha,scope=admin-api
+          cache-to: type=gha,scope=admin-api,mode=max

--- a/.github/workflows/ci-build-admin-web.yml
+++ b/.github/workflows/ci-build-admin-web.yml
@@ -1,0 +1,37 @@
+name: CI Build (admin-web Docker)
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - 'web/admin/**'
+      - '.github/workflows/ci-build-admin-web.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'web/admin/**'
+      - '.github/workflows/ci-build-admin-web.yml'
+
+concurrency:
+  group: ci-build-admin-web-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  build:
+    if: github.event_name == 'push' || github.event.pull_request.draft == false
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build image (no push)
+        uses: docker/build-push-action@v6
+        with:
+          context: web/admin
+          file: web/admin/Dockerfile
+          push: false
+          platforms: linux/arm64
+          cache-from: type=gha,scope=admin-web
+          cache-to: type=gha,scope=admin-web,mode=max

--- a/.github/workflows/ci-build-admin-web.yml
+++ b/.github/workflows/ci-build-admin-web.yml
@@ -17,7 +17,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  build:
+  build-admin-web:
     if: github.event_name == 'push' || github.event.pull_request.draft == false
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 20

--- a/.github/workflows/ci-build-lobby-docker.yml
+++ b/.github/workflows/ci-build-lobby-docker.yml
@@ -25,7 +25,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  build:
+  build-lobby-docker:
     if: github.event_name == 'push' || github.event.pull_request.draft == false
     runs-on: ubuntu-24.04
     timeout-minutes: 45

--- a/.github/workflows/ci-build-lobby-docker.yml
+++ b/.github/workflows/ci-build-lobby-docker.yml
@@ -8,14 +8,14 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
-      - 'services/lobby/Dockerfile'
+      - 'services/lobby/**'
       - 'clients/silencer/**'
       - 'shared/assets/**'
       - '.github/workflows/ci-build-lobby-docker.yml'
   push:
     branches: [main]
     paths:
-      - 'services/lobby/Dockerfile'
+      - 'services/lobby/**'
       - 'clients/silencer/**'
       - 'shared/assets/**'
       - '.github/workflows/ci-build-lobby-docker.yml'

--- a/.github/workflows/ci-build-lobby-docker.yml
+++ b/.github/workflows/ci-build-lobby-docker.yml
@@ -1,0 +1,44 @@
+name: CI Build (lobby Docker)
+
+# The lobby image is dev-only (infra/docker-compose.yml); production builds the
+# Go binary + dedicated server natively in deploy.yml. This job exists to keep
+# the compose dev path from rotting — exactly the failure mode of PR #71.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - 'services/lobby/Dockerfile'
+      - 'clients/silencer/**'
+      - 'shared/assets/**'
+      - '.github/workflows/ci-build-lobby-docker.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'services/lobby/Dockerfile'
+      - 'clients/silencer/**'
+      - 'shared/assets/**'
+      - '.github/workflows/ci-build-lobby-docker.yml'
+
+concurrency:
+  group: ci-build-lobby-docker-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  build:
+    if: github.event_name == 'push' || github.event.pull_request.draft == false
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build image (no push)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: services/lobby/Dockerfile
+          push: false
+          cache-from: type=gha,scope=lobby
+          cache-to: type=gha,scope=lobby,mode=max


### PR DESCRIPTION
## Summary

Adds three new GitHub Actions workflows that build the repo's Dockerfiles on pull requests, so breakage is caught before merge.

- `ci-build-admin-api.yml` — builds `services/admin-api/Dockerfile` on PRs touching that dir. Same runner (`ubuntu-24.04-arm`) and platform (`linux/arm64`) as `deploy-admin-api.yml`, so a CI pass implies the deploy build will succeed. Shares the GHA layer cache with the deploy workflow via `scope=admin-api`.
- `ci-build-admin-web.yml` — same pattern for `web/admin/Dockerfile`.
- `ci-build-lobby-docker.yml` — builds `services/lobby/Dockerfile` on changes to the Dockerfile or its COPY sources (`clients/silencer/**`, `shared/assets/**`). x86 runner since the image is dev-only (used by `infra/docker-compose.yml`); production builds the lobby + dedicated server natively in `deploy.yml`. Path-filtered to avoid running on every PR — the C++/SDL3 build is slow.

No image is pushed in any of the three jobs.

## Test plan

- [ ] Open this PR; verify only `ci-build-admin-api` triggers paths-wise — actually, this PR only touches `.github/workflows/*`, so each workflow's own paths filter (which includes its own filename) should fire all three on this PR.
- [ ] Confirm all three jobs go green on this PR.
- [ ] In a follow-up PR, deliberately revert the `third_party/` line from `services/lobby/Dockerfile` on a branch and confirm `ci-build-lobby-docker` fails.
- [ ] Confirm path filters work: a PR touching only `services/lobby/*.go` should NOT trigger `ci-build-lobby-docker` (Go-only changes don't affect the image build).


---
_Generated by [Claude Code](https://claude.ai/code/session_01ThyLG6mxAfE5vcb9MYPLRs)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/arsia-mons/silencer/pull/72" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
