### PR TITLE
feat: Designer UI — manage published maps (#74)

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -86,6 +86,7 @@ services:
       AMQP_URL: "amqp://silencer:silencer@rabbitmq:5672/"
       JWT_SECRET: "${JWT_SECRET:-changeme-in-production}"
       LOBBY_PLAYER_AUTH_URL: "http://lobby:15171"
+      LOBBY_MAP_API_URL: "http://lobby:15172"
       BACKUP_DIR: "/backups"
       BACKUP_CRON: "0 */6 * * *"
       BACKUP_KEEP: "10"

--- a/services/admin-api/src/routes/maps.js
+++ b/services/admin-api/src/routes/maps.js
@@ -52,4 +52,25 @@ router.get('/*', async (req, res) => {
   }
 });
 
+// DELETE /api/maps/:name — delete a published map
+router.delete('/:name', async (req, res) => {
+  try {
+    const fwd = {};
+    if (req.headers['x-api-key']) fwd['X-Api-Key'] = req.headers['x-api-key'];
+    const r = await fetch(`${LOBBY_MAP_API_URL}/api/maps/${encodeURIComponent(req.params.name)}`, {
+      method: 'DELETE',
+      headers: fwd,
+    });
+    const ct = r.headers.get('content-type') || '';
+    if (ct.includes('application/json')) {
+      res.status(r.status).json(await r.json());
+    } else {
+      const text = (await r.text()).trim();
+      res.status(r.status).json({ error: text || r.statusText });
+    }
+  } catch {
+    res.status(502).json({ error: 'map API unreachable' });
+  }
+});
+
 export default router;

--- a/services/lobby/maps.go
+++ b/services/lobby/maps.go
@@ -160,6 +160,35 @@ func (s *MapStore) List() []*MapMeta {
 	return out
 }
 
+// Delete removes a map by name. If no other name references the same SHA-1
+// blob, the file is also deleted from disk.
+func (s *MapStore) Delete(name string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	meta := s.byName[strings.ToUpper(name)]
+	if meta == nil {
+		return false
+	}
+	delete(s.byName, strings.ToUpper(name))
+
+	// Check whether any remaining byName entry still references this SHA-1.
+	stillReferenced := false
+	for _, m := range s.byName {
+		if m.SHA1 == meta.SHA1 {
+			stillReferenced = true
+			break
+		}
+	}
+	if !stillReferenced {
+		delete(s.bySHA1, strings.ToLower(meta.SHA1))
+		_ = os.Remove(s.mapPath(meta.SHA1))
+	}
+	s.saveIndex()
+	log.Printf("[map-api] deleted map: %s (sha1=%s, blob_removed=%v)", name, meta.SHA1[:8], !stillReferenced)
+	return true
+}
+
 func setCORSHeaders(w http.ResponseWriter, origin string) {
 	if origin == "" {
 		return
@@ -170,7 +199,7 @@ func setCORSHeaders(w http.ResponseWriter, origin string) {
 		allow = "*"
 	}
 	w.Header().Set("Access-Control-Allow-Origin", allow)
-	w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+	w.Header().Set("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS")
 	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, X-Filename, X-Author, X-Api-Key")
 	w.Header().Set("Access-Control-Max-Age", "86400")
 }
@@ -233,19 +262,42 @@ func StartMapAPIServer(addr string, ms *MapStore) {
 		}
 	})
 
-	// /api/maps/ — download by SHA-1 or by name
+	// /api/maps/ — download by SHA-1 or by name, or DELETE by name
 	mux.HandleFunc("/api/maps/", func(w http.ResponseWriter, r *http.Request) {
 		setCORSHeaders(w, r.Header.Get("Origin"))
 		if r.Method == http.MethodOptions {
 			w.WriteHeader(http.StatusNoContent)
 			return
 		}
+
+		sub := strings.TrimPrefix(r.URL.Path, "/api/maps/")
+
+		// DELETE /api/maps/{name}
+		if r.Method == http.MethodDelete {
+			if ms.apiKey != "" {
+				key := r.Header.Get("X-Api-Key")
+				if key == "" {
+					key = r.URL.Query().Get("key")
+				}
+				if key != ms.apiKey {
+					http.Error(w, "unauthorized", http.StatusUnauthorized)
+					return
+				}
+			}
+			name := filepath.Base(sub)
+			if !ms.Delete(name) {
+				http.NotFound(w, r)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]string{"deleted": name})
+			return
+		}
+
 		if r.Method != http.MethodGet {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 			return
 		}
-
-		sub := strings.TrimPrefix(r.URL.Path, "/api/maps/")
 
 		// /api/maps/by-sha1/{sha1hex}
 		if strings.HasPrefix(sub, "by-sha1/") {

--- a/web/admin/app/designer/page.tsx
+++ b/web/admin/app/designer/page.tsx
@@ -92,16 +92,67 @@ export default function DesignerPage() {
   const [pubAuthor, setPubAuthor]     = useState('');
   const [pubStatus, setPubStatus]     = useState<PubStatus | null>(null);
 
+  // Published maps panel
+  const [showMaps, setShowMaps]             = useState(false);
+  const [mapList, setMapList]               = useState<Array<{ sha1: string; name: string; size: number; author: string; uploaded_at: string }>>([]);
+  const [mapListLoading, setMapListLoading] = useState(false);
+  const [mapListError, setMapListError]     = useState<string | null>(null);
+  const [deleteStatus, setDeleteStatus]     = useState<Record<string, string>>({});
+  const [lastPublishedSha1, setLastPublishedSha1] = useState<string | null>(null);
+
+  const fetchMapList = useCallback(async () => {
+    setMapListLoading(true);
+    setMapListError(null);
+    try {
+      const r = await fetch('/api/maps');
+      if (!r.ok) throw new Error(`HTTP ${r.status}`);
+      const data = await r.json();
+      const sorted = [...data].sort((a: { uploaded_at: string }, b: { uploaded_at: string }) =>
+        new Date(b.uploaded_at).getTime() - new Date(a.uploaded_at).getTime()
+      );
+      setMapList(sorted);
+    } catch (e) {
+      setMapListError(e instanceof Error ? e.message : 'Failed to load');
+    } finally {
+      setMapListLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (showMaps) fetchMapList();
+  }, [showMaps, fetchMapList]);
+
+  const handleDeleteMap = useCallback(async (name: string) => {
+    if (!confirm(`Delete "${name}" from the server?`)) return;
+    setDeleteStatus(s => ({ ...s, [name]: 'deleting…' }));
+    try {
+      const headers: Record<string, string> = {};
+      if (pubApiKey) headers['X-Api-Key'] = pubApiKey;
+      const r = await fetch(`/api/maps/${encodeURIComponent(name)}`, { method: 'DELETE', headers });
+      if (r.ok) {
+        setDeleteStatus(s => ({ ...s, [name]: '✓ deleted' }));
+        fetchMapList();
+      } else {
+        const body = await r.json().catch(() => ({ error: r.statusText }));
+        setDeleteStatus(s => ({ ...s, [name]: `✗ ${body.error ?? r.statusText}` }));
+      }
+    } catch {
+      setDeleteStatus(s => ({ ...s, [name]: '✗ network error' }));
+    }
+  }, [pubApiKey, fetchMapList]);
+
   const handlePublish = useCallback(async () => {
     setPubStatus({ ok: null, msg: 'Publishing…' });
     const result = await publishMap({ author: pubAuthor, apiUrl: pubApiUrl, apiKey: pubApiKey });
     if (result.ok) {
       const sha1 = String((result.meta as Record<string, unknown>)?.sha1 ?? '');
       setPubStatus({ ok: true, msg: `✓ Published  sha1: ${sha1.slice(0, 8)}…` });
+      setLastPublishedSha1(sha1);
+      fetchMapList();
     } else {
       setPubStatus({ ok: false, msg: result.error ?? 'Unknown error' });
     }
-  }, [publishMap, pubAuthor, pubApiUrl, pubApiKey]);
+  }, [publishMap, pubAuthor, pubApiUrl, pubApiKey, fetchMapList]);
 
   // Sync resize inputs when map changes
   useEffect(() => {
@@ -422,6 +473,76 @@ export default function DesignerPage() {
               )}
             </div>
           )}
+
+          {/* Manage published maps */}
+          <div className="relative flex items-center">
+            <button
+              onClick={() => setShowMaps(p => !p)}
+              className={`px-3 py-1 text-xs font-mono border rounded transition-colors ${showMaps ? 'border-game-primary text-game-primary bg-game-dark' : 'border-game-border text-game-textDim hover:border-game-primary hover:text-game-text'}`}
+            >
+              📋 MAPS
+            </button>
+            {showMaps && (
+              <div className="absolute top-8 left-0 z-50 bg-game-bgCard border border-game-border rounded p-3 w-96 shadow-lg">
+                <div className="flex items-center justify-between mb-2">
+                  <div className="text-xs font-mono text-game-primary">Published Maps</div>
+                  <button
+                    onClick={fetchMapList}
+                    className="text-xs font-mono text-game-textDim hover:text-game-text border border-game-border rounded px-2 py-0.5 transition-colors"
+                    title="Refresh"
+                  >↻ refresh</button>
+                </div>
+                {pubApiKey === '' && (
+                  <div className="mb-2">
+                    <input
+                      type="password"
+                      placeholder="API key for delete (optional)"
+                      onChange={e => setPubApiKey(e.target.value)}
+                      className="w-full px-2 py-1 text-xs font-mono bg-game-bg border border-game-border rounded text-game-text focus:outline-none focus:border-game-primary"
+                    />
+                  </div>
+                )}
+                {mapListLoading && <div className="text-xs font-mono text-game-textDim">Loading…</div>}
+                {mapListError  && <div className="text-xs font-mono text-red-400">{mapListError}</div>}
+                {!mapListLoading && !mapListError && mapList.length === 0 && (
+                  <div className="text-xs font-mono text-game-textDim">No maps published yet.</div>
+                )}
+                {!mapListLoading && mapList.length > 0 && (
+                  <div className="flex flex-col gap-1 max-h-72 overflow-y-auto">
+                    {mapList.map(m => (
+                      <div
+                        key={m.sha1}
+                        className={`flex items-center gap-2 px-2 py-1 rounded text-xs font-mono ${lastPublishedSha1 === m.sha1 ? 'bg-game-primary bg-opacity-10 border border-game-primary' : 'bg-game-bg'}`}
+                      >
+                        <div className="flex-1 min-w-0">
+                          <div className="text-game-text truncate">{m.name}</div>
+                          <div className="text-game-textDim text-[10px]">{m.author} · {(m.size / 1024).toFixed(1)}KB · {new Date(m.uploaded_at).toLocaleDateString()}</div>
+                        </div>
+                        {deleteStatus[m.name] ? (
+                          <span className={`text-[10px] ${deleteStatus[m.name].startsWith('✓') ? 'text-game-primary' : 'text-red-400'}`}>
+                            {deleteStatus[m.name]}
+                          </span>
+                        ) : (
+                          <button
+                            onClick={() => handleDeleteMap(m.name)}
+                            className="text-[10px] text-red-400 hover:text-red-300 border border-red-800 hover:border-red-500 rounded px-1.5 py-0.5 transition-colors flex-shrink-0"
+                          >
+                            ✕
+                          </button>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                )}
+                <button
+                  onClick={() => setShowMaps(false)}
+                  className="mt-2 w-full px-2 py-1 text-xs font-mono border border-game-border text-game-textDim rounded hover:border-game-primary transition-colors"
+                >
+                  Close
+                </button>
+              </div>
+            )}
+          </div>
 
           {/* Props */}
           {map && (

--- a/web/admin/app/designer/page.tsx
+++ b/web/admin/app/designer/page.tsx
@@ -16,6 +16,7 @@ import MapPropertiesPanel from './MapPropertiesPanel';
 import ActorListPanel from './ActorListPanel';
 import Minimap from './Minimap';
 import type { MapActor } from '../../lib/types';
+import { API } from '../../lib/api';
 
 interface VisState {
   bg: boolean[];
@@ -104,7 +105,7 @@ export default function DesignerPage() {
     setMapListLoading(true);
     setMapListError(null);
     try {
-      const r = await fetch('/api/maps');
+      const r = await fetch(`${API}/maps`);
       if (!r.ok) throw new Error(`HTTP ${r.status}`);
       const data = await r.json();
       const sorted = [...data].sort((a: { uploaded_at: string }, b: { uploaded_at: string }) =>
@@ -128,7 +129,7 @@ export default function DesignerPage() {
     try {
       const headers: Record<string, string> = {};
       if (pubApiKey) headers['X-Api-Key'] = pubApiKey;
-      const r = await fetch(`/api/maps/${encodeURIComponent(name)}`, { method: 'DELETE', headers });
+      const r = await fetch(`${API}/maps/${encodeURIComponent(name)}`, { method: 'DELETE', headers });
       if (r.ok) {
         setDeleteStatus(s => ({ ...s, [name]: '✓ deleted' }));
         fetchMapList();


### PR DESCRIPTION
## Summary

Implements the Published Maps management panel in the designer UI.

Closes #74

## Changes

### Designer UI
- Added **📋 MAPS** toolbar button (always visible)
- Panel shows map list sorted by upload date (name, author, size, date)
- Delete button per map (prompts for API key, calls DELETE)
- Refresh button to reload the list
- Highlights the map just published by SHA1
- Auto-refreshes after a publish
- Fixed: use `API` constant from `lib/api.ts` so fetches work on dev server (not just Cloudflare-proxied production)

### Lobby (Go)
- Added `Delete(name string)` method with ref-count blob cleanup
- Added `DELETE /api/maps/{name}` HTTP handler with API key auth
- Added `DELETE` to CORS allowed methods

### Admin API
- Added `DELETE /api/maps/:name` proxy route

### Docker Compose
- Added `LOBBY_MAP_API_URL: http://lobby:15172` to admin-api service (was defaulting to localhost which is unreachable from within the container)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/arsia-mons/silencer/pull/77" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
