### PR TITLE
Fix map listing, async map download on join, host Ready block

### DIFF
--- a/clients/silencer/src/game/game.cpp
+++ b/clients/silencer/src/game/game.cpp
@@ -484,6 +484,17 @@ bool Game::Tick(void){
 		}
 		if(world.gameplaystate == World::INLOBBY){
 			ProcessMapDownload();
+			if(gamejoininterface){
+				Interface * gamejoiniface = static_cast<Interface *>(world.GetObjectFromId(gamejoininterface));
+				if(gamejoiniface){
+					Button * readybtn = static_cast<Button *>(gamejoiniface->GetObjectWithUid(world, 25));
+					if(readybtn){
+						Peer * localpeer = world.peerlist[world.localpeerid];
+						bool blocked = localpeer && localpeer->ishost && !world.AllPeersDownloadedMap();
+						strcpy(readybtn->text, blocked ? "Waiting..." : "Ready");
+					}
+				}
+			}
 		}
 		/*Peer * localpeer = world.peerlist[world.localpeerid];
 		if(localpeer){
@@ -4742,7 +4753,11 @@ bool Game::ProcessLobbyInterface(Interface * iface){
 							}break;
 							case 25:{ // start game/ready
 								if(gamejoininterface){
-									world.SendReady();
+									Peer * localpeer = world.peerlist[world.localpeerid];
+									bool ishost = localpeer && localpeer->ishost;
+									if(!ishost || world.AllPeersDownloadedMap()){
+										world.SendReady();
+									}
 								}
 							}break;
 							case 26:{ // change team

--- a/clients/silencer/src/game/game.cpp
+++ b/clients/silencer/src/game/game.cpp
@@ -113,6 +113,12 @@ Game::Game() : renderer(world), screenbuffer(640, 480){
 }
 
 Game::~Game(){
+	// Join background download threads before tearing down SDL so they don't
+	// reference freed resources. Increment generation first so any in-flight
+	// result is discarded after the join returns.
+	mapjoingeneration.fetch_add(1, std::memory_order_relaxed);
+	if(mapjointhread.joinable()) mapjointhread.join();
+	if(dlthread.joinable()) dlthread.join();
 	// Bring the control server down first. Stop() runs the shutdown drain we
 	// registered at Load() time, fulfilling promises for both queued and
 	// pendingWaits commands so handler threads can unblock from fut.get() before
@@ -733,6 +739,12 @@ bool Game::Tick(void){
 								gamecreateinterface = 0;
 							}
 							mapexistchecked = false;
+						// Invalidate any in-flight server map fetch for the previous
+						// game; the thread will see the stale generation and discard
+						// its result. Detach so we don't block here.
+						mapjoingeneration.fetch_add(1, std::memory_order_relaxed);
+						mapjoinstate.store(0, std::memory_order_relaxed);
+						if(mapjointhread.joinable()) mapjointhread.detach();
 							world.SetTech(Config::GetInstance().defaulttechchoices[GetSelectedAgency()]);
 							gamejoininterface = CreateGameJoinInterface()->id;
 							LobbyGame * lobbygame = world.lobby.GetGameById(currentlobbygameid);
@@ -5826,19 +5838,43 @@ void Game::ProcessMapDownload(void){
 			if(!localpeer->mapdownloaded){
 				if(!mapexistchecked){
 					std::string mapfilename = FindMap(world.gameinfo.mapname, &world.gameinfo.maphash);
-					if(mapfilename.size() == 0){
-						// Map not available locally; try the community map server before
-						// falling back to peer-to-peer chunk transfer.
-						mapfilename = FetchMapFromServer(
-							world.gameinfo.mapname,
-							world.gameinfo.maphash,
-							Config::GetInstance().mapapiurl);
-					}
 					if(mapfilename.size() > 0){
 						world.SendMapDownloaded();
 						LoadMapData(mapfilename.c_str());
+						mapexistchecked = true;
+					} else {
+						// Map not available locally. Try the community map server
+						// asynchronously so the game loop (and UDP keepalives) stay
+						// responsive during the fetch. Falling back to peer-to-peer
+						// chunk transfer happens once the async result is known.
+						int js = mapjoinstate.load(std::memory_order_acquire);
+						if(js == 0){
+							mapjoinstate.store(1, std::memory_order_relaxed);
+							uint32_t gen = mapjoingeneration.load(std::memory_order_relaxed);
+							std::string dlname = world.gameinfo.mapname;
+							std::array<unsigned char, 20> sha1;
+							memcpy(sha1.data(), world.gameinfo.maphash, 20);
+							std::string apiURL = Config::GetInstance().mapapiurl;
+							mapjointhread = std::thread([this, dlname, sha1, apiURL, gen]() mutable {
+								std::string path = FetchMapFromServer(dlname.c_str(), sha1.data(), apiURL.c_str());
+								if(mapjoingeneration.load(std::memory_order_relaxed) != gen) return;
+								std::lock_guard<std::mutex> lk(mapjoinmutex);
+								mapjoinpath = path;
+								mapjoinstate.store(path.empty() ? 3 : 2, std::memory_order_release);
+							});
+						} else if(js == 2){
+							// Server had the map; hand it to the engine.
+							std::string path;
+							{ std::lock_guard<std::mutex> lk(mapjoinmutex); path = mapjoinpath; }
+							world.SendMapDownloaded();
+							LoadMapData(path.c_str());
+							mapexistchecked = true;
+						} else if(js == 3){
+							// Server doesn't have it; fall through to P2P chunk transfer.
+							mapexistchecked = true;
+						}
+						// js == 1: fetch in progress; come back next tick.
 					}
-					mapexistchecked = true;
 				}else{
 					if(!world.currentmapdataprocessed || world.tickcount - lastmapchunkrequest > 24){
 						// request map chunks after received, or if last request was a while ago

--- a/clients/silencer/src/game/game.h
+++ b/clients/silencer/src/game/game.h
@@ -12,7 +12,9 @@
 #include "updater.h"
 #include "controlserver.h"
 #include <map>
+#include <array>
 #include <atomic>
+#include <mutex>
 #include <thread>
 
 class Game
@@ -187,6 +189,13 @@ private:
 	std::atomic<int> dlresult{0};      // 0=idle, 1=success, -1=fail
 	std::string dlitemname;            // key in servermaps being downloaded
 	std::thread dlthread;
+	// Pre-game map fetch (join path): async server download before P2P fallback.
+	// State: 0=idle 1=in-flight 2=downloaded 3=not-on-server.
+	std::atomic<int>      mapjoinstate{0};
+	std::atomic<uint32_t> mapjoingeneration{0}; // incremented on reset to discard stale results
+	std::string           mapjoinpath;           // absolute path set by thread when state→2
+	std::mutex            mapjoinmutex;          // guards mapjoinpath
+	std::thread           mapjointhread;
 	Uint32 lastmusicplaytime;
 	char currentmusictrack[256];
 	bool fullscreentoggled;

--- a/clients/silencer/src/game/team.cpp
+++ b/clients/silencer/src/game/team.cpp
@@ -21,6 +21,7 @@ Team::Team() : Object(ObjectTypes::TEAM){
 		peeroverlayids[i] = 0;
 		peerreadyoverlayids[i] = 0;
 		peerleveloverlayids[i] = 0;
+		peermapoverlayids[i] = 0;
 	}
 	peerschecksum = 0;
 	oldsecretprogress = 0;
@@ -225,6 +226,10 @@ void Team::Tick(World & world){
 					world.MarkDestroyObject(peerreadyoverlayids[i]);
 					peerreadyoverlayids[i] = 0;
 				}
+				if(peermapoverlayids[i]){
+					world.MarkDestroyObject(peermapoverlayids[i]);
+					peermapoverlayids[i] = 0;
+				}
 			}
 		}
 		for(int i = 0; i < numpeers; i++){
@@ -274,6 +279,27 @@ void Team::Tick(World & world){
 						}else{
 							overlay->res_index = 19;
 						}
+					}
+				}
+				if(!peermapoverlayids[i]){
+					if(peeroverlayids[i]){
+						User * user = world.lobby.GetUserInfo(peer->accountid);
+						Overlay * mapoverlay = (Overlay *)world.CreateObject(ObjectTypes::OVERLAY);
+						if(mapoverlay){
+							mapoverlay->text = "(dl)";
+							mapoverlay->textbank = 132;
+							mapoverlay->textwidth = 4;
+							mapoverlay->effectcolor = 170;
+							mapoverlay->x = 473 + (strlen(user->name) * 6) + 3 + 20;
+							mapoverlay->y = 72 + (number * 55) + (i * 13);
+							mapoverlay->draw = !peer->mapdownloaded && !world.choosingtech;
+							peermapoverlayids[i] = mapoverlay->id;
+						}
+					}
+				}else{
+					Overlay * mapoverlay = static_cast<Overlay *>(world.GetObjectFromId(peermapoverlayids[i]));
+					if(mapoverlay){
+						mapoverlay->draw = !peer->mapdownloaded && !world.choosingtech;
 					}
 				}
 			}
@@ -332,6 +358,10 @@ void Team::DestroyOverlays(World & world){
 		if(peerleveloverlayids[i]){
 			world.MarkDestroyObject(peerleveloverlayids[i]);
 			peerleveloverlayids[i] = 0;
+		}
+		if(peermapoverlayids[i]){
+			world.MarkDestroyObject(peermapoverlayids[i]);
+			peermapoverlayids[i] = 0;
 		}
 	}
 	if(overlayid){

--- a/clients/silencer/src/game/team.h
+++ b/clients/silencer/src/game/team.h
@@ -27,6 +27,7 @@ public:
 	Uint16 peeroverlayids[4];
 	Uint16 peerreadyoverlayids[4];
 	Uint16 peerleveloverlayids[4];
+	Uint16 peermapoverlayids[4];
 	Uint8 number;
 	Uint8 secrets;
 	Uint16 secretdelivered;

--- a/clients/silencer/src/net/mapfetch.cpp
+++ b/clients/silencer/src/net/mapfetch.cpp
@@ -150,7 +150,9 @@ std::string FetchMapFromServer(const char * mapname,
     }
 
     // Save to <DataDir>/level/download/<mapname>.
-    CDDataDir();
+    // Use the absolute path returned by GetDataDir(); do NOT call CDDataDir()
+    // here because this function may run on a background thread and chdir(2)
+    // is process-wide.
     std::string dir = GetDataDir() + "level/download";
     CreateDirectory(dir.c_str());
     std::string path = dir + "/" + mapname;

--- a/infra/terraform/cloud-init-admin.yaml.tftpl
+++ b/infra/terraform/cloud-init-admin.yaml.tftpl
@@ -74,6 +74,7 @@ write_files:
       AMQP_URL=amqp://silencer:$LAVINMQ_PWD@127.0.0.1:5672/
       JWT_SECRET=$JWT
       LOBBY_PLAYER_AUTH_URL=http://lobby.${internal_zone_name}:15171
+      LOBBY_MAP_API_URL=http://lobby.${internal_zone_name}:15172
       BACKUP_DIR=/var/lib/silencer-backups
       BACKUP_CRON=0 */6 * * *
       BACKUP_KEEP=10


### PR DESCRIPTION
Closes #80

## Changes

### Bug 1: Community maps not appearing in Create Game
Added `LOBBY_MAP_API_URL=http://lobby.${internal_zone_name}:15172` to `cloud-init-admin.yaml.tftpl` so the admin API can proxy `/api/maps` to the lobby server. The env var was missing — the admin EC2 was defaulting to localhost, returning 502.

### Bug 2: Players kicked when joining game with unknown map
Rewrote `ProcessMapDownload()` to be **async** — map fetch now runs in a background thread (`mapjointhread`) with a generation counter to safely discard stale results. The old synchronous curl call (10s timeout) matched the 10s peer timeout exactly, causing the dedicated server to kick the joiner before the download finished.

Also removed an unsafe `CDDataDir()` call from `FetchMapFromServer()` — it did a process-wide `chdir(2)` which is not thread-safe. `GetDataDir()` already returns an absolute path.

Fixed a latent bug: `dlthread` (used in the Create Game download flow) was never joined in `~Game()`.

### Feature: Block host Ready until all peers have the map
- **Visual feedback**: the Ready button text switches to `"Waiting..."` each frame while blocked, reverting to `"Ready"` once all peers have the map.
- **Per-peer indicator**: added `peermapoverlayids[4]` to `Team`. While a peer's `mapdownloaded == false` in the pre-game lobby, a small `(dl)` text overlay appears next to their name in the team billboard, disappearing automatically when they finish downloading.

## Testing
- Built successfully on macOS (cmake --build, zero new errors)
- Infra change requires Terraform apply to take effect on the admin EC2
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/arsia-mons/silencer/pull/81" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
