### PR TITLE
fix: skip authority peer in AllPeersDownloadedMap()

### DIFF
--- a/clients/silencer/src/world/world.cpp
+++ b/clients/silencer/src/world/world.cpp
@@ -1820,6 +1820,7 @@ bool World::AllPeersLoadedGameInfo(void){
 bool World::AllPeersDownloadedMap(void){
 	bool allloaded = true;
 	for(int i = 0; i < maxpeers; i++){
+		if(i == authoritypeer) continue; // dedicated server doesn't download maps
 		Peer * peer = peerlist[i];
 		if(peer){
 			if(!peer->mapdownloaded){


### PR DESCRIPTION
Closes #82

## Problem

Host's Ready button was permanently stuck on "Waiting..." after the map-download block introduced in #81.

## Root cause

On the client, `peerlist[authoritypeer]` (slot 0 = dedicated server) always has `mapdownloaded = false` — `ReadPeerList()` deliberately skips copying `mapdownloaded` for the authority slot. So `AllPeersDownloadedMap()` iterating all slots would always return `false` on the client.

## Fix

One line: skip `authoritypeer` in `AllPeersDownloadedMap()`. The dedicated server doesn't download maps. This is consistent with how `ReadPeerList()` already handles the authority slot.