### PR TITLE
fix(world): capture peer team before RemovePeer in HandleDisconnect

### DIFF
--- a/clients/silencer/src/world/world.cpp
+++ b/clients/silencer/src/world/world.cpp
@@ -1165,6 +1165,9 @@ void World::HandleDisconnect(Uint8 peerid){
 		}
 	}
 	ClearSnapshotQueue();
+	// Capture team before RemovePeer strips the peer from all teams.
+	// GetPeerTeam searches team membership lists, so it must run first.
+	Team * leavingTeam = (mode == AUTHORITY) ? GetPeerTeam(peerid) : 0;
 	for(std::list<Object *>::iterator it = objectlist.begin(); it != objectlist.end(); it++){
 		Object * object = *it;
 		if(object->type == ObjectTypes::TEAM){
@@ -1190,11 +1193,10 @@ void World::HandleDisconnect(Uint8 peerid){
 		if(gameplaystate == INGAME && peerlist[peerid]->accountid != 0){
 			Peer * leavingPeer = peerlist[peerid];
 			User * user = lobby.GetUserInfo(leavingPeer->accountid);
-			Team * team = GetPeerTeam(peerid);
-			if(user && team){
+			if(user && leavingTeam){
 				user->statscopy = leavingPeer->stats;
-				user->statsagency = team->agency;
-				user->teamnumber = team->number;
+				user->statsagency = leavingTeam->agency;
+				user->teamnumber = leavingTeam->number;
 				lobby.RegisterStats(*user, 0, gameinfo.id);
 			}
 		}


### PR DESCRIPTION
## Problem

Closes #84

When a player quits mid-game, `World::HandleDisconnect` was supposed to call `lobby.RegisterStats` to persist partial stats (kills, deaths, XP, etc.). It never did — because `GetPeerTeam(peerid)` was called **after** the peer had already been removed from all teams by the `RemovePeer` sweep above it.

`GetPeerTeam` searches `Team::peers[]` and returns `null` when the peer isn't in any team. The `if(user && team)` guard then short-circuited and `lobby.RegisterStats` was silently skipped for every early leaver.

## Fix

Call `GetPeerTeam(peerid)` before the `RemovePeer` loop and pass the saved reference (`leavingTeam`) into the stats block:

```cpp
// Capture team before RemovePeer strips the peer from all teams.
// GetPeerTeam searches team membership lists, so it must run first.
Team * leavingTeam = (mode == AUTHORITY) ? GetPeerTeam(peerid) : 0;
for(...) { team->RemovePeer(peerid); }
...
if(user && leavingTeam) {
    ...
    lobby.RegisterStats(*user, 0, gameinfo.id);
}
```

Only evaluated on the authority (dedicated server), no behaviour change for replicas.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/arsia-mons/silencer/pull/85" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
