### PR TITLE
feat(designer): snap-to-grid for actor and platform placement

### DIFF
--- a/web/admin/app/designer/ActorContextMenu.tsx
+++ b/web/admin/app/designer/ActorContextMenu.tsx
@@ -3,8 +3,8 @@ import { useEffect, useRef, useState } from 'react';
 import { ACTOR_DEFS, ACTOR_TYPE_HINTS } from './Toolbar';
 import type { MapActor } from '../../lib/types';
 
-// Guards (0,2,3) and robot (6) use direction as a facing boolean only: 0=Right, 1=Left
-const FACING_ACTOR_IDS = new Set([0, 2, 3, 6]);
+// Guards (0,2,3) use direction as a facing boolean only: 0=Right, 1=Left
+const FACING_ACTOR_IDS = new Set([0, 2, 3]);
 const FACING_LABELS: Record<number, string> = { 0: 'Right', 1: 'Left' };
 const DIRECTION_LABELS: Record<number, string> = {
   0:'Right', 1:'Down-Right', 2:'Down', 3:'Down-Left',
@@ -16,7 +16,6 @@ interface FieldState {
   direction: string;
   matchid: string;
   securityid: string;
-  subplane: string;
 }
 
 interface Props {
@@ -39,7 +38,6 @@ export default function ActorContextMenu({ actor, actorIdx, screenX, screenY, on
     direction:  String(actor.direction ?? 0),
     matchid:    String(actor.matchid ?? 0),
     securityid: String(actor.securityid ?? 0),
-    subplane:   String(actor.subplane ?? 0),
   });
   const [confirmDelete, setConfirmDelete] = useState(false);
 
@@ -64,7 +62,6 @@ export default function ActorContextMenu({ actor, actorIdx, screenX, screenY, on
       direction:  parseInt(fields.direction,  10) || 0,
       matchid:    parseInt(fields.matchid,    10) || 0,
       securityid: parseInt(fields.securityid, 10) || 0,
-      subplane:   parseInt(fields.subplane,   10) || 0,
     });
     onClose();
   };
@@ -137,11 +134,6 @@ export default function ActorContextMenu({ actor, actorIdx, screenX, screenY, on
           <option value="5">5 — Low or High</option>
           <option value="6">6 — Medium or High</option>
         </select>
-      </div>
-
-      <div className="mb-3">
-        <div className={lbl}>Subplane</div>
-        <input type="number" value={fields.subplane} min={0} onChange={e => setFields(f => ({ ...f, subplane: e.target.value }))} className={inp} />
       </div>
 
       <div className="flex gap-2">

--- a/web/admin/app/designer/ActorContextMenu.tsx
+++ b/web/admin/app/designer/ActorContextMenu.tsx
@@ -3,6 +3,9 @@ import { useEffect, useRef, useState } from 'react';
 import { ACTOR_DEFS, ACTOR_TYPE_HINTS } from './Toolbar';
 import type { MapActor } from '../../lib/types';
 
+// Guards (0,2,3) and robot (6) use direction as a facing boolean only: 0=Right, 1=Left
+const FACING_ACTOR_IDS = new Set([0, 2, 3, 6]);
+const FACING_LABELS: Record<number, string> = { 0: 'Right', 1: 'Left' };
 const DIRECTION_LABELS: Record<number, string> = {
   0:'Right', 1:'Down-Right', 2:'Down', 3:'Down-Left',
   4:'Left', 5:'Up-Left', 6:'Up', 7:'Up-Right',
@@ -102,12 +105,20 @@ export default function ActorContextMenu({ actor, actorIdx, screenX, screenY, on
       </div>
 
       <div className="mb-1.5">
-        <div className={lbl}>Direction</div>
-        <select value={fields.direction} onChange={e => setFields(f => ({ ...f, direction: e.target.value }))} className={inp + ' cursor-pointer'}>
-          {Object.entries(DIRECTION_LABELS).map(([v, l]) => (
-            <option key={v} value={v}>{v} — {l}</option>
-          ))}
-        </select>
+        <div className={lbl}>Direction / Facing</div>
+        {FACING_ACTOR_IDS.has(actor.id) ? (
+          <select value={fields.direction} onChange={e => setFields(f => ({ ...f, direction: e.target.value }))} className={inp + ' cursor-pointer'}>
+            {Object.entries(FACING_LABELS).map(([v, l]) => (
+              <option key={v} value={v}>{v} — {l}</option>
+            ))}
+          </select>
+        ) : (
+          <select value={fields.direction} onChange={e => setFields(f => ({ ...f, direction: e.target.value }))} className={inp + ' cursor-pointer'}>
+            {Object.entries(DIRECTION_LABELS).map(([v, l]) => (
+              <option key={v} value={v}>{v} — {l}</option>
+            ))}
+          </select>
+        )}
       </div>
 
       <div className="mb-1.5">

--- a/web/admin/app/designer/ActorContextMenu.tsx
+++ b/web/admin/app/designer/ActorContextMenu.tsx
@@ -127,8 +127,16 @@ export default function ActorContextMenu({ actor, actorIdx, screenX, screenY, on
       </div>
 
       <div className="mb-1.5">
-        <div className={lbl}>Security ID</div>
-        <input type="number" value={fields.securityid} min={0} onChange={e => setFields(f => ({ ...f, securityid: e.target.value }))} className={inp} />
+        <div className={lbl}>Security ID — spawn condition</div>
+        <select value={fields.securityid} onChange={e => setFields(f => ({ ...f, securityid: e.target.value }))} className={inp + ' cursor-pointer'}>
+          <option value="0">0 — Always spawn</option>
+          <option value="1">1 — Low security only</option>
+          <option value="2">2 — Medium security only</option>
+          <option value="3">3 — Low or Medium</option>
+          <option value="4">4 — High security only</option>
+          <option value="5">5 — Low or High</option>
+          <option value="6">6 — Medium or High</option>
+        </select>
       </div>
 
       <div className="mb-3">

--- a/web/admin/app/designer/ActorListPanel.tsx
+++ b/web/admin/app/designer/ActorListPanel.tsx
@@ -16,8 +16,17 @@ interface Props {
 
 export default function ActorListPanel({ actors, highlightIdx, onCenter, onActorRightClick }: Props) {
   const [expanded, setExpanded] = useState(true);
+  const [query, setQuery] = useState('');
 
   if (!actors) return null;
+
+  const filtered = actors
+    .map((actor, i) => ({ actor, i }))
+    .filter(({ actor }) => {
+      if (!query) return true;
+      const def = getActorDef(actor.id);
+      return def.label.toLowerCase().includes(query.toLowerCase());
+    });
 
   return (
     <div className="border-t border-game-border flex-shrink-0 flex flex-col min-h-0">
@@ -29,28 +38,41 @@ export default function ActorListPanel({ actors, highlightIdx, onCenter, onActor
         <span>{expanded ? '▲' : '▼'}</span>
       </button>
       {expanded && (
-        <div className="overflow-y-auto" style={{ maxHeight: '180px' }}>
-          {actors.length === 0 && (
-            <div className="px-3 py-2 text-xs text-game-muted font-mono">No actors placed</div>
-          )}
-          {actors.map((actor, i) => {
-            const def = getActorDef(actor.id);
-            const isSelected = i === highlightIdx;
-            return (
-              <div
-                key={i}
-                className={`flex items-center gap-2 px-3 py-1 text-xs font-mono cursor-pointer border-b border-game-border/30 select-none transition-colors ${isSelected ? 'bg-[#1a2e1a] text-game-text' : 'hover:bg-game-dark text-game-textDim'}`}
-                onClick={() => onCenter?.(actor)}
-                onContextMenu={e => { e.preventDefault(); onActorRightClick?.(i, e.clientX, e.clientY); }}
-                title="Click to center · right-click to edit"
-              >
-                <span className={`w-2 h-2 rounded-full flex-shrink-0 inline-block ${isSelected ? 'ring-1 ring-white' : ''}`} style={{ background: def.color }} />
-                <span className="flex-1 truncate">{def.label}</span>
-                <span className="text-game-muted text-[10px]">{actor.x},{actor.y}</span>
+        <>
+          <div className="px-2 py-1 border-b border-game-border/50 bg-game-bgCard flex-shrink-0">
+            <input
+              type="text"
+              value={query}
+              onChange={e => setQuery(e.target.value)}
+              placeholder="filter actors…"
+              className="w-full bg-transparent text-[11px] font-mono text-game-text placeholder:text-game-muted outline-none border border-game-border/40 rounded px-2 py-0.5 focus:border-game-primary/60"
+            />
+          </div>
+          <div className="overflow-y-auto" style={{ maxHeight: '180px' }}>
+            {filtered.length === 0 && (
+              <div className="px-3 py-2 text-xs text-game-muted font-mono">
+                {query ? 'No matches' : 'No actors placed'}
               </div>
-            );
-          })}
-        </div>
+            )}
+            {filtered.map(({ actor, i }) => {
+              const def = getActorDef(actor.id);
+              const isSelected = i === highlightIdx;
+              return (
+                <div
+                  key={i}
+                  className={`flex items-center gap-2 px-3 py-1 text-xs font-mono cursor-pointer border-b border-game-border/30 select-none transition-colors ${isSelected ? 'bg-[#1a2e1a] text-game-text' : 'hover:bg-game-dark text-game-textDim'}`}
+                  onClick={() => onCenter?.(actor)}
+                  onContextMenu={e => { e.preventDefault(); onActorRightClick?.(i, e.clientX, e.clientY); }}
+                  title="Click to center · right-click to edit"
+                >
+                  <span className={`w-2 h-2 rounded-full flex-shrink-0 inline-block ${isSelected ? 'ring-1 ring-white' : ''}`} style={{ background: def.color }} />
+                  <span className="flex-1 truncate">{def.label}</span>
+                  <span className="text-game-muted text-[10px]">{actor.x},{actor.y}</span>
+                </div>
+              );
+            })}
+          </div>
+        </>
       )}
     </div>
   );

--- a/web/admin/app/designer/MapCanvas.tsx
+++ b/web/admin/app/designer/MapCanvas.tsx
@@ -124,11 +124,9 @@ interface Props {
   gridSize: number;
   tileSelection?: { tx1: number; ty1: number; tx2: number; ty2: number; layerType: 'bg' | 'fg'; layerIdx: number } | null;
   onTileSelection?: (sel: { tx1: number; ty1: number; tx2: number; ty2: number; layerType: 'bg' | 'fg'; layerIdx: number } | null) => void;
-  tileCopyBuffer?: { w: number; h: number; tiles: Array<{ tile_id: number; flip: number; lum: number }> } | null;
+  tileCopyBuffer?: { w: number; h: number; layers: [Array<{ tile_id: number; flip: number; lum: number }>, Array<{ tile_id: number; flip: number; lum: number }>, Array<{ tile_id: number; flip: number; lum: number }>, Array<{ tile_id: number; flip: number; lum: number }>] } | null;
   pastePending?: boolean;
   onTilePaste?: (tx: number, ty: number) => void;
-  copyLayerType?: 'bg' | 'fg';
-  copyLayerIdx?: number;
 }
 
 export default function MapCanvas({
@@ -151,8 +149,6 @@ export default function MapCanvas({
   tileCopyBuffer,
   pastePending,
   onTilePaste,
-  copyLayerType,
-  copyLayerIdx,
 }: Props) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const overlayCanvasRef = useRef<HTMLCanvasElement>(null);
@@ -720,20 +716,23 @@ export default function MapCanvas({
         ctx.restore();
       }
 
-      // Paste preview at hover tile
+      // Paste preview at hover tile — render all 4 layers composited
       if (hasPastePreview) {
         const { tx: hx, ty: hy } = hoverTileRef.current;
-        const { w, h, tiles } = tileCopyBuffer!;
+        const { w, h, layers } = tileCopyBuffer!;
         ctx.save();
         ctx.globalAlpha = 0.55;
-        for (let dy = 0; dy < h; dy++) {
-          for (let dx = 0; dx < w; dx++) {
-            const tile = tiles[dy * w + dx];
-            if (!tile || tile.tile_id === 0) continue;
-            const imgs = tileImages?.get(tile.tile_id);
-            const img = imgs?.[0];
-            if (!img) continue;
-            ctx.drawImage(img, (hx + dx) * 64 * zoom + pan.x, (hy + dy) * 64 * zoom + pan.y, 64 * zoom, 64 * zoom);
+        for (let li = 0; li < 4; li++) {
+          const layerCells = layers[li];
+          for (let dy = 0; dy < h; dy++) {
+            for (let dx = 0; dx < w; dx++) {
+              const tile = layerCells[dy * w + dx];
+              if (!tile || tile.tile_id === 0) continue;
+              const imgs = tileImages?.get(tile.tile_id);
+              const img = imgs?.[0];
+              if (!img) continue;
+              ctx.drawImage(img, (hx + dx) * 64 * zoom + pan.x, (hy + dy) * 64 * zoom + pan.y, 64 * zoom, 64 * zoom);
+            }
           }
         }
         ctx.globalAlpha = 1;
@@ -802,7 +801,7 @@ export default function MapCanvas({
       if (tx >= 0 && tx < map.width && ty >= 0 && ty < map.height) {
         isSelectingTile.current = true;
         tileSelStartRef.current = { tx, ty };
-        onTileSelection?.({ tx1: tx, ty1: ty, tx2: tx, ty2: ty, layerType: copyLayerType ?? 'bg', layerIdx: copyLayerIdx ?? activeLayer });
+        onTileSelection?.({ tx1: tx, ty1: ty, tx2: tx, ty2: ty, layerType: 'bg', layerIdx: 0 });
       }
     } else if (activeTool === 'TILE_BG' || activeTool === 'TILE_FG') {
       isPainting.current = true;
@@ -892,7 +891,7 @@ export default function MapCanvas({
   }, [map, activeTool, activeLayer, selectedTileId, canvasToTile, canvasToWorld, zoom, eraseLayerType,
       onTilePaint, onPlatformRemove, onActorPlace, onDragPlatformChange, onBeginPaint,
       selectedPlatformIdx, onPlatformSelect, onActorSelect, highlightActorIdx, snap,
-      pastePending, onTilePaste, onTileSelection, copyLayerType, copyLayerIdx]);
+      pastePending, onTilePaste, onTileSelection]);
 
   // Right-click: actors take priority, fall through to tile property editor
   const handleContextMenu = useCallback((e: React.MouseEvent<HTMLCanvasElement>) => {
@@ -952,7 +951,7 @@ export default function MapCanvas({
       onTileSelection?.({
         tx1: Math.min(stx, tx), ty1: Math.min(sty, ty),
         tx2: Math.max(stx, tx), ty2: Math.max(sty, ty),
-        layerType: copyLayerType ?? 'bg', layerIdx: copyLayerIdx ?? activeLayer,
+        layerType: 'bg', layerIdx: 0,
       });
       return;
     }
@@ -1023,7 +1022,7 @@ export default function MapCanvas({
     }
   }, [map, activeTool, activeLayer, selectedTileId, canvasToTile, canvasToWorld, eraseLayerType,
       onTilePaint, onPanChange, onCursorChange, onDragPlatformChange, snap,
-      onTileSelection, copyLayerType, copyLayerIdx]);
+      onTileSelection]);
 
   const handleMouseUp = useCallback((e: React.MouseEvent<HTMLCanvasElement>) => {
     if (isPanning.current) {

--- a/web/admin/app/designer/MapCanvas.tsx
+++ b/web/admin/app/designer/MapCanvas.tsx
@@ -101,6 +101,7 @@ interface Props {
   onZoomChange: (zoom: number) => void;
   onPanChange: (val: { x: number; y: number } | ((prev: { x: number; y: number }) => { x: number; y: number })) => void;
   onTilePaint: (layerType: 'bg' | 'fg', layerIdx: number, tx: number, ty: number, tileId: number) => void;
+  onFloodFill?: (layerType: 'bg' | 'fg', layerIdx: number, updates: Array<{ x: number; y: number; tile_id: number; flip: number; lum: number }>) => void;
   onPlatformDraw: (platform: MapPlatform) => void;
   onPlatformRemove: (idx: number) => void;
   onActorPlace: (pos: { wx: number; wy: number }) => void;
@@ -136,7 +137,7 @@ interface Props {
 export default function MapCanvas({
   map, tileImages, spriteImages, vis, activeTool, activeLayer, selectedTileId,
   zoom, pan, onZoomChange, onPanChange,
-  onTilePaint, onPlatformDraw, onPlatformRemove, onActorPlace, onActorRemove, onActorRightClick,
+  onTilePaint, onFloodFill, onPlatformDraw, onPlatformRemove, onActorPlace, onActorRemove, onActorRightClick,
   onTileRightClick,
   onBeginPaint, onCommitPaint,
   selectedActorId, dragPlatform, onDragPlatformChange,
@@ -814,6 +815,32 @@ export default function MapCanvas({
       return;
     }
 
+    if (activeTool === 'FLOOD_FILL') {
+      if (!onFloodFill || !selectedTileId || tx < 0 || tx >= map.width || ty < 0 || ty >= map.height) return;
+      const lt = (eraseLayerType ?? 'bg') as 'bg' | 'fg';
+      const layerArr = lt === 'fg' ? map.layers.fg : map.layers.bg;
+      const targetId = layerArr[activeLayer][ty * map.width + tx]?.tile_id ?? 0;
+      if (targetId === selectedTileId) return;
+      // BFS 4-connected flood fill
+      const visited = new Uint8Array(map.width * map.height);
+      const queue: Array<[number, number]> = [[tx, ty]];
+      const updates: Array<{ x: number; y: number; tile_id: number; flip: number; lum: number }> = [];
+      visited[ty * map.width + tx] = 1;
+      while (queue.length) {
+        const [cx, cy] = queue.shift()!;
+        updates.push({ x: cx, y: cy, tile_id: selectedTileId, flip: 0, lum: 0 });
+        for (const [nx, ny] of [[cx-1,cy],[cx+1,cy],[cx,cy-1],[cx,cy+1]] as [number,number][]) {
+          if (nx < 0 || nx >= map.width || ny < 0 || ny >= map.height) continue;
+          if (visited[ny * map.width + nx]) continue;
+          if ((layerArr[activeLayer][ny * map.width + nx]?.tile_id ?? 0) !== targetId) continue;
+          visited[ny * map.width + nx] = 1;
+          queue.push([nx, ny]);
+        }
+      }
+      onFloodFill(lt, activeLayer, updates);
+      return;
+    }
+
     if (activeTool === 'TILE_SELECT') {
       if (tx >= 0 && tx < map.width && ty >= 0 && ty < map.height) {
         isSelectingTile.current = true;
@@ -908,7 +935,7 @@ export default function MapCanvas({
   }, [map, activeTool, activeLayer, selectedTileId, canvasToTile, canvasToWorld, zoom, eraseLayerType,
       onTilePaint, onPlatformRemove, onActorPlace, onDragPlatformChange, onBeginPaint,
       selectedPlatformIdx, onPlatformSelect, onActorSelect, highlightActorIdx, snap,
-      pastePending, onTilePaste, onTileSelection]);
+      pastePending, onTilePaste, onTileSelection, onFloodFill]);
 
   // Right-click: actors take priority, fall through to tile property editor
   const handleContextMenu = useCallback((e: React.MouseEvent<HTMLCanvasElement>) => {
@@ -1129,6 +1156,7 @@ export default function MapCanvas({
     : (isPanning.current || isSpacePanning.current || isCtrlPanning.current)
       ? 'grab'
       : pastePending ? 'copy'
+      : activeTool === 'FLOOD_FILL' ? 'cell'
       : activeTool === 'SELECT' ? 'pointer'
       : activeTool === 'TILE_SELECT' ? 'crosshair'
       : activeTool === 'ERASE_TILE' ? 'crosshair'

--- a/web/admin/app/designer/MapCanvas.tsx
+++ b/web/admin/app/designer/MapCanvas.tsx
@@ -749,18 +749,22 @@ export default function MapCanvas({
         }
       }
 
-      // 2. Hit-test actors — priority over new platform selection
+      // 2. Hit-test actors — priority over new platform selection; cycle through stack on repeated clicks
       const HIT = 48 / zoom;
+      const hits: number[] = [];
       for (let i = map.actors.length - 1; i >= 0; i--) {
-        const a = map.actors[i];
-        const dist = Math.hypot(a.x - wx, a.y - wy);
-        if (dist < HIT) {
-          onActorSelect?.(i);
-          onPlatformSelect(null);
-          draggingActorRef.current = { idx: i, startWx: wx, startWy: wy, origX: a.x, origY: a.y, moved: false };
-          setDragActorPreview({ idx: i, wx: a.x, wy: a.y });
-          return;
-        }
+        if (Math.hypot(map.actors[i].x - wx, map.actors[i].y - wy) < HIT) hits.push(i);
+      }
+      if (hits.length > 0) {
+        // If the currently selected actor is already in this stack, cycle to the next
+        const stackPos = hits.indexOf(highlightActorIdx ?? -1);
+        const nextIdx = stackPos >= 0 ? hits[(stackPos + 1) % hits.length] : hits[0];
+        const a = map.actors[nextIdx];
+        onActorSelect?.(nextIdx);
+        onPlatformSelect(null);
+        draggingActorRef.current = { idx: nextIdx, startWx: wx, startWy: wy, origX: a.x, origY: a.y, moved: false };
+        setDragActorPreview({ idx: nextIdx, wx: a.x, wy: a.y });
+        return;
       }
 
       // 3. Hit-test all platforms for selection
@@ -779,7 +783,7 @@ export default function MapCanvas({
     }
   }, [map, activeTool, activeLayer, selectedTileId, canvasToTile, canvasToWorld, zoom, eraseLayerType,
       onTilePaint, onPlatformRemove, onActorPlace, onDragPlatformChange, onBeginPaint,
-      selectedPlatformIdx, onPlatformSelect, onActorSelect, snap]);
+      selectedPlatformIdx, onPlatformSelect, onActorSelect, highlightActorIdx, snap]);
 
   // Right-click: actors take priority, fall through to tile property editor
   const handleContextMenu = useCallback((e: React.MouseEvent<HTMLCanvasElement>) => {

--- a/web/admin/app/designer/MapCanvas.tsx
+++ b/web/admin/app/designer/MapCanvas.tsx
@@ -238,21 +238,16 @@ export default function MapCanvas({
       }
     }
 
-    // Draw parallax background tiled across the viewport
+    // Draw parallax background — exactly 20×12 tiles once at world origin
+    // (matches C++ DrawParallax which renders one screen-sized grid, no tiling)
     if (vis?.parallax !== false) {
       const parallaxIdx = map.header?.parallax ?? 0;
       const bgBank = spriteImages?.get(parallaxIdx);
       if (bgBank) {
         const BG_COLS = 20, BG_ROWS = 12;
-        const startCol = Math.floor(-pan.x / tileSize) - 1;
-        const endCol   = Math.ceil((W - pan.x) / tileSize) + 1;
-        const startRow = Math.floor(-pan.y / tileSize) - 1;
-        const endRow   = Math.ceil((H - pan.y) / tileSize) + 1;
-        for (let row = startRow; row < endRow; row++) {
-          for (let col = startCol; col < endCol; col++) {
-            const bgCol = ((col % BG_COLS) + BG_COLS) % BG_COLS;
-            const bgRow = ((row % BG_ROWS) + BG_ROWS) % BG_ROWS;
-            const spr = bgBank[bgRow * BG_COLS + bgCol];
+        for (let row = 0; row < BG_ROWS; row++) {
+          for (let col = 0; col < BG_COLS; col++) {
+            const spr = bgBank[row * BG_COLS + col];
             if (!spr) continue;
             const dx = col * tileSize + pan.x;
             const dy = row * tileSize + pan.y;

--- a/web/admin/app/designer/MapCanvas.tsx
+++ b/web/admin/app/designer/MapCanvas.tsx
@@ -727,6 +727,7 @@ export default function MapCanvas({
         ctx.save();
         ctx.globalAlpha = 0.55;
         const allLayers = [...bg, ...fg];
+        const ts = 64 * zoom;
         for (const layerCells of allLayers) {
           for (let dy = 0; dy < h; dy++) {
             for (let dx = 0; dx < w; dx++) {
@@ -737,7 +738,17 @@ export default function MapCanvas({
               const bitmaps = tileImages?.get(bank);
               const img = bitmaps?.[slot];
               if (!img) continue;
-              ctx.drawImage(img, (hx + dx) * 64 * zoom + pan.x, (hy + dy) * 64 * zoom + pan.y, 64 * zoom, 64 * zoom);
+              const px = (hx + dx) * ts + pan.x;
+              const py = (hy + dy) * ts + pan.y;
+              if (tile.flip) {
+                ctx.save();
+                ctx.translate(px + ts, py);
+                ctx.scale(-1, 1);
+                ctx.drawImage(img, 0, 0, ts, ts);
+                ctx.restore();
+              } else {
+                ctx.drawImage(img, px, py, ts, ts);
+              }
             }
           }
         }

--- a/web/admin/app/designer/MapCanvas.tsx
+++ b/web/admin/app/designer/MapCanvas.tsx
@@ -124,7 +124,11 @@ interface Props {
   gridSize: number;
   tileSelection?: { tx1: number; ty1: number; tx2: number; ty2: number; layerType: 'bg' | 'fg'; layerIdx: number } | null;
   onTileSelection?: (sel: { tx1: number; ty1: number; tx2: number; ty2: number; layerType: 'bg' | 'fg'; layerIdx: number } | null) => void;
-  tileCopyBuffer?: { w: number; h: number; layers: [Array<{ tile_id: number; flip: number; lum: number }>, Array<{ tile_id: number; flip: number; lum: number }>, Array<{ tile_id: number; flip: number; lum: number }>, Array<{ tile_id: number; flip: number; lum: number }>] } | null;
+  tileCopyBuffer?: {
+    w: number; h: number;
+    bg: [Array<{ tile_id: number; flip: number; lum: number }>, Array<{ tile_id: number; flip: number; lum: number }>, Array<{ tile_id: number; flip: number; lum: number }>, Array<{ tile_id: number; flip: number; lum: number }>];
+    fg: [Array<{ tile_id: number; flip: number; lum: number }>, Array<{ tile_id: number; flip: number; lum: number }>, Array<{ tile_id: number; flip: number; lum: number }>, Array<{ tile_id: number; flip: number; lum: number }>];
+  } | null;
   pastePending?: boolean;
   onTilePaste?: (tx: number, ty: number) => void;
 }
@@ -716,14 +720,14 @@ export default function MapCanvas({
         ctx.restore();
       }
 
-      // Paste preview at hover tile — render all 4 layers composited
+      // Paste preview at hover tile — render all 8 layers (bg[0..3] then fg[0..3]) composited
       if (hasPastePreview) {
         const { tx: hx, ty: hy } = hoverTileRef.current;
-        const { w, h, layers } = tileCopyBuffer!;
+        const { w, h, bg, fg } = tileCopyBuffer!;
         ctx.save();
         ctx.globalAlpha = 0.55;
-        for (let li = 0; li < 4; li++) {
-          const layerCells = layers[li];
+        const allLayers = [...bg, ...fg];
+        for (const layerCells of allLayers) {
           for (let dy = 0; dy < h; dy++) {
             for (let dx = 0; dx < w; dx++) {
               const tile = layerCells[dy * w + dx];

--- a/web/admin/app/designer/MapCanvas.tsx
+++ b/web/admin/app/designer/MapCanvas.tsx
@@ -240,20 +240,19 @@ export default function MapCanvas({
       }
     }
 
-    // Draw parallax background — exactly 20×12 tiles once at world origin
-    // (matches C++ DrawParallax which renders one screen-sized grid, no tiling)
+    // Draw parallax background stretched to cover the full map extent
     if (vis?.parallax !== false) {
       const parallaxIdx = map.header?.parallax ?? 0;
       const bgBank = spriteImages?.get(parallaxIdx);
       if (bgBank) {
         const BG_COLS = 20, BG_ROWS = 12;
+        const bw = (width  * tileSize) / BG_COLS;
+        const bh = (height * tileSize) / BG_ROWS;
         for (let row = 0; row < BG_ROWS; row++) {
           for (let col = 0; col < BG_COLS; col++) {
             const spr = bgBank[row * BG_COLS + col];
             if (!spr) continue;
-            const dx = col * tileSize + pan.x;
-            const dy = row * tileSize + pan.y;
-            ctx.drawImage(spr.bitmap, dx, dy, tileSize, tileSize);
+            ctx.drawImage(spr.bitmap, col * bw + pan.x, row * bh + pan.y, bw, bh);
           }
         }
       }

--- a/web/admin/app/designer/MapCanvas.tsx
+++ b/web/admin/app/designer/MapCanvas.tsx
@@ -120,6 +120,7 @@ interface Props {
   onPlatformSelect: (idx: number | null) => void;
   onPlatformUpdate: (idx: number, x1: number, y1: number, x2: number, y2: number) => void;
   onActorSelect?: (idx: number | null) => void;
+  onActorFlip?: (idx: number) => void;
   gridSize: number;
 }
 
@@ -136,6 +137,7 @@ export default function MapCanvas({
   highlightActorIdx,
   selectedPlatformIdx, onPlatformSelect, onPlatformUpdate,
   onActorSelect,
+  onActorFlip,
   gridSize,
 }: Props) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -439,11 +441,19 @@ export default function MapCanvas({
         const sprBank = bankNum != null ? spriteImages?.get(bankNum) : null;
         const spr = sprBank?.[def.frame ?? 0];
         if (spr) {
-          const sx = cx - spr.offsetX * zoom;
+          const mirrored = a.direction !== 0;
+          const sx = cx - (mirrored ? spr.width - spr.offsetX : spr.offsetX) * zoom;
           const sy = cy - spr.offsetY * zoom;
           const sw = spr.width * zoom;
           const sh = spr.height * zoom;
-          ctx.drawImage(spr.bitmap, sx, sy, sw, sh);
+          if (mirrored) {
+            ctx.save();
+            ctx.scale(-1, 1);
+            ctx.drawImage(spr.bitmap, -sx - sw, sy, sw, sh);
+            ctx.restore();
+          } else {
+            ctx.drawImage(spr.bitmap, sx, sy, sw, sh);
+          }
           if (zoom > 0.3) {
             ctx.fillStyle = def.color + 'cc';
             ctx.fillRect(cx - 12, cy + 2, 24, 11);
@@ -978,7 +988,11 @@ export default function MapCanvas({
   const handleKeyDown = useCallback((e: KeyboardEvent) => {
     if (e.code === 'Space') { isSpacePanning.current = true; e.preventDefault(); }
     if (e.code === 'ControlLeft' || e.code === 'ControlRight') isCtrlPanning.current = true;
-  }, []);
+    if (e.code === 'KeyF' && highlightActorIdx != null) {
+      onActorFlip?.(highlightActorIdx);
+      e.preventDefault();
+    }
+  }, [highlightActorIdx, onActorFlip]);
   const handleKeyUp = useCallback((e: KeyboardEvent) => {
     if (e.code === 'Space') isSpacePanning.current = false;
     if (e.code === 'ControlLeft' || e.code === 'ControlRight') isCtrlPanning.current = false;

--- a/web/admin/app/designer/MapCanvas.tsx
+++ b/web/admin/app/designer/MapCanvas.tsx
@@ -75,6 +75,7 @@ interface VisState {
   actors: boolean;
   grid: boolean;
   lighting: boolean;
+  parallax: boolean;
 }
 
 interface TileRightClickInfo {
@@ -234,6 +235,30 @@ export default function MapCanvas({
         ctx.restore();
       } else {
         ctx.drawImage(bmp, dx, dy, tileSize, tileSize);
+      }
+    }
+
+    // Draw parallax background tiled across the viewport
+    if (vis?.parallax !== false) {
+      const parallaxIdx = map.header?.parallax ?? 0;
+      const bgBank = spriteImages?.get(parallaxIdx);
+      if (bgBank) {
+        const BG_COLS = 20, BG_ROWS = 12;
+        const startCol = Math.floor(-pan.x / tileSize) - 1;
+        const endCol   = Math.ceil((W - pan.x) / tileSize) + 1;
+        const startRow = Math.floor(-pan.y / tileSize) - 1;
+        const endRow   = Math.ceil((H - pan.y) / tileSize) + 1;
+        for (let row = startRow; row < endRow; row++) {
+          for (let col = startCol; col < endCol; col++) {
+            const bgCol = ((col % BG_COLS) + BG_COLS) % BG_COLS;
+            const bgRow = ((row % BG_ROWS) + BG_ROWS) % BG_ROWS;
+            const spr = bgBank[bgRow * BG_COLS + bgCol];
+            if (!spr) continue;
+            const dx = col * tileSize + pan.x;
+            const dy = row * tileSize + pan.y;
+            ctx.drawImage(spr.bitmap, dx, dy, tileSize, tileSize);
+          }
+        }
       }
     }
 

--- a/web/admin/app/designer/MapCanvas.tsx
+++ b/web/admin/app/designer/MapCanvas.tsx
@@ -732,8 +732,10 @@ export default function MapCanvas({
             for (let dx = 0; dx < w; dx++) {
               const tile = layerCells[dy * w + dx];
               if (!tile || tile.tile_id === 0) continue;
-              const imgs = tileImages?.get(tile.tile_id);
-              const img = imgs?.[0];
+              const bank = (tile.tile_id >> 8) & 0xFF;
+              const slot = tile.tile_id & 0xFF;
+              const bitmaps = tileImages?.get(bank);
+              const img = bitmaps?.[slot];
               if (!img) continue;
               ctx.drawImage(img, (hx + dx) * 64 * zoom + pan.x, (hy + dy) * 64 * zoom + pan.y, 64 * zoom, 64 * zoom);
             }

--- a/web/admin/app/designer/MapCanvas.tsx
+++ b/web/admin/app/designer/MapCanvas.tsx
@@ -122,6 +122,13 @@ interface Props {
   onActorSelect?: (idx: number | null) => void;
   onActorFlip?: (idx: number) => void;
   gridSize: number;
+  tileSelection?: { tx1: number; ty1: number; tx2: number; ty2: number; layerType: 'bg' | 'fg'; layerIdx: number } | null;
+  onTileSelection?: (sel: { tx1: number; ty1: number; tx2: number; ty2: number; layerType: 'bg' | 'fg'; layerIdx: number } | null) => void;
+  tileCopyBuffer?: { w: number; h: number; tiles: Array<{ tile_id: number; flip: number; lum: number }> } | null;
+  pastePending?: boolean;
+  onTilePaste?: (tx: number, ty: number) => void;
+  copyLayerType?: 'bg' | 'fg';
+  copyLayerIdx?: number;
 }
 
 export default function MapCanvas({
@@ -139,6 +146,13 @@ export default function MapCanvas({
   onActorSelect,
   onActorFlip,
   gridSize,
+  tileSelection,
+  onTileSelection,
+  tileCopyBuffer,
+  pastePending,
+  onTilePaste,
+  copyLayerType,
+  copyLayerIdx,
 }: Props) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const overlayCanvasRef = useRef<HTMLCanvasElement>(null);
@@ -154,6 +168,11 @@ export default function MapCanvas({
   const platformDragRef = useRef<PlatformDragState | null>(null);
   // Current preview bounds during platform drag { wx1, wy1, wx2, wy2 }
   const platformPreviewRef = useRef<PlatformPreview | null>(null);
+  // Tile selection drag
+  const isSelectingTile = useRef(false);
+  const tileSelStartRef = useRef<{ tx: number; ty: number } | null>(null);
+  // Current hover tile (for paste preview — updated every mousemove, no re-render)
+  const hoverTileRef = useRef<{ tx: number; ty: number }>({ tx: 0, ty: 0 });
 
   // World → canvas coords
   const worldToCanvas = useCallback((wx: number, wy: number) => ({
@@ -514,7 +533,7 @@ export default function MapCanvas({
     return () => resizer.disconnect();
   }, []);
 
-  // Animated marching-ants selection highlight on overlay canvas
+  // Animated marching-ants selection highlight + tile selection + paste preview on overlay canvas
   useEffect(() => {
     const overlay = overlayCanvasRef.current;
     if (!overlay) return;
@@ -522,8 +541,10 @@ export default function MapCanvas({
 
     const hasActorHighlight = highlightActorIdx != null && map?.actors[highlightActorIdx];
     const hasPlatformHighlight = selectedPlatformIdx != null && map?.platforms[selectedPlatformIdx];
+    const hasTileSelection = tileSelection != null;
+    const hasPastePreview = !!(pastePending && tileCopyBuffer);
 
-    if (!hasActorHighlight && !hasPlatformHighlight) {
+    if (!hasActorHighlight && !hasPlatformHighlight && !hasTileSelection && !hasPastePreview) {
       ctx.clearRect(0, 0, overlay.width, overlay.height);
       if (rafRef.current) { cancelAnimationFrame(rafRef.current); rafRef.current = null; }
       return;
@@ -678,12 +699,58 @@ export default function MapCanvas({
         drawAxis((cx1 + cx2) / 2, (cy1 + cy2) / 2);
       }
 
+      // Tile selection rect
+      if (hasTileSelection) {
+        const { tx1, ty1, tx2, ty2 } = tileSelection!;
+        const sx = tx1 * 64 * zoom + pan.x;
+        const sy = ty1 * 64 * zoom + pan.y;
+        const sw = (tx2 - tx1 + 1) * 64 * zoom;
+        const sh = (ty2 - ty1 + 1) * 64 * zoom;
+        ctx.save();
+        ctx.fillStyle = 'rgba(80,150,255,0.12)';
+        ctx.fillRect(sx, sy, sw, sh);
+        ctx.lineWidth = 2;
+        ctx.setLineDash([6, 4]);
+        ctx.strokeStyle = 'rgba(130,190,255,0.9)';
+        ctx.lineDashOffset = -dashOffset;
+        ctx.strokeRect(sx, sy, sw, sh);
+        ctx.strokeStyle = 'rgba(255,255,255,0.5)';
+        ctx.lineDashOffset = -dashOffset + 5;
+        ctx.strokeRect(sx, sy, sw, sh);
+        ctx.restore();
+      }
+
+      // Paste preview at hover tile
+      if (hasPastePreview) {
+        const { tx: hx, ty: hy } = hoverTileRef.current;
+        const { w, h, tiles } = tileCopyBuffer!;
+        ctx.save();
+        ctx.globalAlpha = 0.55;
+        for (let dy = 0; dy < h; dy++) {
+          for (let dx = 0; dx < w; dx++) {
+            const tile = tiles[dy * w + dx];
+            if (!tile || tile.tile_id === 0) continue;
+            const imgs = tileImages?.get(tile.tile_id);
+            const img = imgs?.[0];
+            if (!img) continue;
+            ctx.drawImage(img, (hx + dx) * 64 * zoom + pan.x, (hy + dy) * 64 * zoom + pan.y, 64 * zoom, 64 * zoom);
+          }
+        }
+        ctx.globalAlpha = 1;
+        ctx.lineWidth = 2;
+        ctx.setLineDash([5, 3]);
+        ctx.strokeStyle = 'rgba(255,220,60,0.9)';
+        ctx.lineDashOffset = -dashOffset;
+        ctx.strokeRect(hx * 64 * zoom + pan.x, hy * 64 * zoom + pan.y, w * 64 * zoom, h * 64 * zoom);
+        ctx.restore();
+      }
+
       dashOffset = (dashOffset + 0.5) % 10;
       rafRef.current = requestAnimationFrame(draw);
     }
     rafRef.current = requestAnimationFrame(draw);
     return () => { if (rafRef.current) { cancelAnimationFrame(rafRef.current); rafRef.current = null; } };
-  }, [highlightActorIdx, selectedPlatformIdx, map, spriteImages, zoom, pan, dragActorPreview]);
+  }, [highlightActorIdx, selectedPlatformIdx, map, spriteImages, zoom, pan, dragActorPreview, tileSelection, tileCopyBuffer, pastePending, tileImages]);
 
   // Mouse event handlers
   const getCanvasPos = (e: { clientX: number; clientY: number }) => {
@@ -725,7 +792,19 @@ export default function MapCanvas({
     const { tx, ty } = canvasToTile(cx, cy);
     const { wx, wy } = canvasToWorld(cx, cy);
 
-    if (activeTool === 'TILE_BG' || activeTool === 'TILE_FG') {
+    // Paste intercept: left-click in bounds while paste is pending stamps the buffer
+    if (pastePending && tx >= 0 && tx < map.width && ty >= 0 && ty < map.height) {
+      onTilePaste?.(tx, ty);
+      return;
+    }
+
+    if (activeTool === 'TILE_SELECT') {
+      if (tx >= 0 && tx < map.width && ty >= 0 && ty < map.height) {
+        isSelectingTile.current = true;
+        tileSelStartRef.current = { tx, ty };
+        onTileSelection?.({ tx1: tx, ty1: ty, tx2: tx, ty2: ty, layerType: copyLayerType ?? 'bg', layerIdx: copyLayerIdx ?? activeLayer });
+      }
+    } else if (activeTool === 'TILE_BG' || activeTool === 'TILE_FG') {
       isPainting.current = true;
       onBeginPaint?.();
       if (selectedTileId && tx >= 0 && tx < map.width && ty >= 0 && ty < map.height) {
@@ -812,7 +891,8 @@ export default function MapCanvas({
     }
   }, [map, activeTool, activeLayer, selectedTileId, canvasToTile, canvasToWorld, zoom, eraseLayerType,
       onTilePaint, onPlatformRemove, onActorPlace, onDragPlatformChange, onBeginPaint,
-      selectedPlatformIdx, onPlatformSelect, onActorSelect, highlightActorIdx, snap]);
+      selectedPlatformIdx, onPlatformSelect, onActorSelect, highlightActorIdx, snap,
+      pastePending, onTilePaste, onTileSelection, copyLayerType, copyLayerIdx]);
 
   // Right-click: actors take priority, fall through to tile property editor
   const handleContextMenu = useCallback((e: React.MouseEvent<HTMLCanvasElement>) => {
@@ -862,6 +942,20 @@ export default function MapCanvas({
     const { tx, ty } = canvasToTile(cx, cy);
     const { wx, wy } = canvasToWorld(cx, cy);
     onCursorChange({ tx, ty, wx, wy });
+
+    // Always update hover tile for paste preview (no re-render)
+    hoverTileRef.current = { tx, ty };
+
+    // Live tile selection drag
+    if (isSelectingTile.current && tileSelStartRef.current) {
+      const { tx: stx, ty: sty } = tileSelStartRef.current;
+      onTileSelection?.({
+        tx1: Math.min(stx, tx), ty1: Math.min(sty, ty),
+        tx2: Math.max(stx, tx), ty2: Math.max(sty, ty),
+        layerType: copyLayerType ?? 'bg', layerIdx: copyLayerIdx ?? activeLayer,
+      });
+      return;
+    }
 
     // Platform drag (SELECT tool — handle or body move)
     if (platformDragRef.current) {
@@ -928,11 +1022,19 @@ export default function MapCanvas({
       }
     }
   }, [map, activeTool, activeLayer, selectedTileId, canvasToTile, canvasToWorld, eraseLayerType,
-      onTilePaint, onPanChange, onCursorChange, onDragPlatformChange, snap]);
+      onTilePaint, onPanChange, onCursorChange, onDragPlatformChange, snap,
+      onTileSelection, copyLayerType, copyLayerIdx]);
 
   const handleMouseUp = useCallback((e: React.MouseEvent<HTMLCanvasElement>) => {
     if (isPanning.current) {
       isPanning.current = false;
+      return;
+    }
+
+    // Finish tile selection drag
+    if (isSelectingTile.current) {
+      isSelectingTile.current = false;
+      tileSelStartRef.current = null;
       return;
     }
 
@@ -1010,7 +1112,9 @@ export default function MapCanvas({
     ? 'grabbing'
     : (isPanning.current || isSpacePanning.current || isCtrlPanning.current)
       ? 'grab'
+      : pastePending ? 'copy'
       : activeTool === 'SELECT' ? 'pointer'
+      : activeTool === 'TILE_SELECT' ? 'crosshair'
       : activeTool === 'ERASE_TILE' ? 'crosshair'
       : isPainting.current ? 'crosshair'
       : 'default';

--- a/web/admin/app/designer/MapCanvas.tsx
+++ b/web/admin/app/designer/MapCanvas.tsx
@@ -118,6 +118,7 @@ interface Props {
   selectedPlatformIdx: number | null;
   onPlatformSelect: (idx: number | null) => void;
   onPlatformUpdate: (idx: number, x1: number, y1: number, x2: number, y2: number) => void;
+  gridSize: number;
 }
 
 export default function MapCanvas({
@@ -132,6 +133,7 @@ export default function MapCanvas({
   eraseLayerType,
   highlightActorIdx,
   selectedPlatformIdx, onPlatformSelect, onPlatformUpdate,
+  gridSize,
 }: Props) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const overlayCanvasRef = useRef<HTMLCanvasElement>(null);
@@ -165,6 +167,12 @@ export default function MapCanvas({
     wx: (cx - pan.x) / zoom,
     wy: (cy - pan.y) / zoom,
   }), [zoom, pan]);
+
+  // Snap a world coordinate to the grid (no-op when grid is off or gridSize is 0)
+  const snap = useCallback((v: number) => {
+    if (!vis?.grid || gridSize <= 0) return v;
+    return Math.round(v / gridSize) * gridSize;
+  }, [vis?.grid, gridSize]);
 
   // Draw the map
   useEffect(() => {
@@ -647,7 +655,7 @@ export default function MapCanvas({
       }
     } else if (['RECT','STAIRSUP','STAIRSDOWN','LADDER','TRACK','OUTSIDEROOM','SPECIFICROOM'].includes(activeTool)) {
       isPainting.current = true;
-      onDragPlatformChange({ wx1: wx, wy1: wy, wx2: wx, wy2: wy, tool: activeTool });
+      onDragPlatformChange({ wx1: snap(wx), wy1: snap(wy), wx2: snap(wx), wy2: snap(wy), tool: activeTool });
     } else if (activeTool === 'ERASE_PLATFORM') {
       // Find platform under cursor and remove
       for (let i = map.platforms.length - 1; i >= 0; i--) {
@@ -658,7 +666,7 @@ export default function MapCanvas({
         }
       }
     } else if (activeTool === 'ACTOR') {
-      onActorPlace({ wx, wy });
+      onActorPlace({ wx: snap(wx), wy: snap(wy) });
     } else if (activeTool === 'SELECT') {
       const handleSize = 8 / zoom;
       const hs = handleSize / 2;
@@ -712,7 +720,7 @@ export default function MapCanvas({
     }
   }, [map, activeTool, activeLayer, selectedTileId, canvasToTile, canvasToWorld, zoom, eraseLayerType,
       onTilePaint, onPlatformRemove, onActorPlace, onDragPlatformChange, onBeginPaint,
-      selectedPlatformIdx, onPlatformSelect]);
+      selectedPlatformIdx, onPlatformSelect, snap]);
 
   // Right-click: actors take priority, fall through to tile property editor
   const handleContextMenu = useCallback((e: React.MouseEvent<HTMLCanvasElement>) => {
@@ -772,20 +780,22 @@ export default function MapCanvas({
       let { x1, y1, x2, y2 } = origPlatform;
 
       if (mode === 'body') {
-        x1 = origPlatform.x1 + dx;
-        y1 = origPlatform.y1 + dy;
-        x2 = origPlatform.x2 + dx;
-        y2 = origPlatform.y2 + dy;
+        const rawX1 = origPlatform.x1 + dx;
+        const rawY1 = origPlatform.y1 + dy;
+        x1 = snap(rawX1);
+        y1 = snap(rawY1);
+        x2 = x1 + (origPlatform.x2 - origPlatform.x1);
+        y2 = y1 + (origPlatform.y2 - origPlatform.y1);
       } else {
         switch (handle) {
-          case 'TL': x1 = origPlatform.x1 + dx; y1 = origPlatform.y1 + dy; break;
-          case 'TR': x2 = origPlatform.x2 + dx; y1 = origPlatform.y1 + dy; break;
-          case 'BL': x1 = origPlatform.x1 + dx; y2 = origPlatform.y2 + dy; break;
-          case 'BR': x2 = origPlatform.x2 + dx; y2 = origPlatform.y2 + dy; break;
-          case 'T':  y1 = origPlatform.y1 + dy; break;
-          case 'B':  y2 = origPlatform.y2 + dy; break;
-          case 'L':  x1 = origPlatform.x1 + dx; break;
-          case 'R':  x2 = origPlatform.x2 + dx; break;
+          case 'TL': x1 = snap(origPlatform.x1 + dx); y1 = snap(origPlatform.y1 + dy); break;
+          case 'TR': x2 = snap(origPlatform.x2 + dx); y1 = snap(origPlatform.y1 + dy); break;
+          case 'BL': x1 = snap(origPlatform.x1 + dx); y2 = snap(origPlatform.y2 + dy); break;
+          case 'BR': x2 = snap(origPlatform.x2 + dx); y2 = snap(origPlatform.y2 + dy); break;
+          case 'T':  y1 = snap(origPlatform.y1 + dy); break;
+          case 'B':  y2 = snap(origPlatform.y2 + dy); break;
+          case 'L':  x1 = snap(origPlatform.x1 + dx); break;
+          case 'R':  x2 = snap(origPlatform.x2 + dx); break;
         }
         if (x2 - x1 < MIN_SIZE) {
           if (handle === 'TL' || handle === 'BL' || handle === 'L') x1 = x2 - MIN_SIZE;
@@ -805,8 +815,8 @@ export default function MapCanvas({
     // Actor drag (SELECT tool)
     if (draggingActorRef.current) {
       const { startWx, startWy, origX, origY } = draggingActorRef.current;
-      const newWx = origX + (wx - startWx);
-      const newWy = origY + (wy - startWy);
+      const newWx = snap(origX + (wx - startWx));
+      const newWy = snap(origY + (wy - startWy));
       draggingActorRef.current.moved = Math.hypot(wx - startWx, wy - startWy) > 4;
       setDragActorPreview({ idx: draggingActorRef.current.idx, wx: newWx, wy: newWy });
       return;
@@ -822,11 +832,11 @@ export default function MapCanvas({
           onTilePaint((eraseLayerType ?? 'bg') as 'bg' | 'fg', activeLayer, tx, ty, 0);
         }
       } else if (['RECT','STAIRSUP','STAIRSDOWN','LADDER','TRACK','OUTSIDEROOM','SPECIFICROOM'].includes(activeTool)) {
-        onDragPlatformChange(prev => prev ? { ...prev, wx2: wx, wy2: wy } : null);
+        onDragPlatformChange(prev => prev ? { ...prev, wx2: snap(wx), wy2: snap(wy) } : null);
       }
     }
   }, [map, activeTool, activeLayer, selectedTileId, canvasToTile, canvasToWorld, eraseLayerType,
-      onTilePaint, onPanChange, onCursorChange, onDragPlatformChange]);
+      onTilePaint, onPanChange, onCursorChange, onDragPlatformChange, snap]);
 
   const handleMouseUp = useCallback((e: React.MouseEvent<HTMLCanvasElement>) => {
     if (isPanning.current) {
@@ -871,15 +881,16 @@ export default function MapCanvas({
         onCommitPaint?.();
       } else if (['RECT','STAIRSUP','STAIRSDOWN','LADDER','TRACK','OUTSIDEROOM','SPECIFICROOM'].includes(activeTool) && dragPlatform) {
         const { wx1, wy1 } = dragPlatform;
+        const snWx = snap(wx), snWy = snap(wy);
         const t = PLATFORM_TOOL_TYPES[activeTool];
-        const x1 = Math.min(wx1, wx), y1 = Math.min(wy1, wy);
-        const x2 = Math.max(wx1, wx), y2 = Math.max(wy1, wy);
+        const x1 = Math.min(wx1, snWx), y1 = Math.min(wy1, snWy);
+        const x2 = Math.max(wx1, snWx), y2 = Math.max(wy1, snWy);
         if (x2 - x1 > 2 && y2 - y1 > 2 && t) onPlatformDraw({ x1, y1, x2, y2, ...t });
         onDragPlatformChange(null);
       }
     }
     isPainting.current = false;
-  }, [map, activeTool, dragPlatform, dragActorPreview, canvasToWorld, onPlatformDraw, onDragPlatformChange, onCommitPaint, onActorMove, onPlatformUpdate, onPlatformSelect]);
+  }, [map, activeTool, dragPlatform, dragActorPreview, canvasToWorld, onPlatformDraw, onDragPlatformChange, onCommitPaint, onActorMove, onPlatformUpdate, onPlatformSelect, snap]);
 
   const handleKeyDown = useCallback((e: KeyboardEvent) => {
     if (e.code === 'Space') { isSpacePanning.current = true; e.preventDefault(); }

--- a/web/admin/app/designer/MapCanvas.tsx
+++ b/web/admin/app/designer/MapCanvas.tsx
@@ -521,11 +521,58 @@ export default function MapCanvas({
       return { circle: true, cx, cy, r: r + 3, x: 0, y: 0, w: 0, h: 0 };
     }
 
+    // Draw X/Y axis gizmo at a canvas-space origin point
+    function drawAxis(ocx: number, ocy: number) {
+      const SHAFT = 56;
+      const HEAD  = 9;
+      const W     = overlay!.width;
+      const H     = overlay!.height;
+      ctx.save();
+      ctx.setLineDash([]);
+
+      // Faint full-canvas crosshair guides
+      ctx.lineWidth = 0.75;
+      ctx.strokeStyle = 'rgba(210,60,60,0.18)';
+      ctx.beginPath(); ctx.moveTo(0, ocy); ctx.lineTo(W, ocy); ctx.stroke();
+      ctx.strokeStyle = 'rgba(60,200,60,0.18)';
+      ctx.beginPath(); ctx.moveTo(ocx, 0); ctx.lineTo(ocx, H); ctx.stroke();
+
+      // X+ arrow (right, red)
+      ctx.lineWidth = 2;
+      ctx.strokeStyle = 'rgba(230,60,60,0.95)';
+      ctx.fillStyle   = 'rgba(230,60,60,0.95)';
+      ctx.beginPath(); ctx.moveTo(ocx, ocy); ctx.lineTo(ocx + SHAFT, ocy); ctx.stroke();
+      ctx.beginPath();
+      ctx.moveTo(ocx + SHAFT, ocy);
+      ctx.lineTo(ocx + SHAFT - HEAD, ocy - HEAD / 2);
+      ctx.lineTo(ocx + SHAFT - HEAD, ocy + HEAD / 2);
+      ctx.closePath(); ctx.fill();
+      ctx.font = 'bold 10px monospace';
+      ctx.fillText('X', ocx + SHAFT + 4, ocy + 4);
+
+      // Y+ arrow (down — Y increases downward in game world coords, green)
+      ctx.strokeStyle = 'rgba(60,200,60,0.95)';
+      ctx.fillStyle   = 'rgba(60,200,60,0.95)';
+      ctx.beginPath(); ctx.moveTo(ocx, ocy); ctx.lineTo(ocx, ocy + SHAFT); ctx.stroke();
+      ctx.beginPath();
+      ctx.moveTo(ocx, ocy + SHAFT);
+      ctx.lineTo(ocx - HEAD / 2, ocy + SHAFT - HEAD);
+      ctx.lineTo(ocx + HEAD / 2, ocy + SHAFT - HEAD);
+      ctx.closePath(); ctx.fill();
+      ctx.fillText('Y', ocx + 4, ocy + SHAFT + 12);
+
+      // Origin dot
+      ctx.fillStyle = 'rgba(255,255,255,0.9)';
+      ctx.beginPath(); ctx.arc(ocx, ocy, 3, 0, Math.PI * 2); ctx.fill();
+
+      ctx.restore();
+    }
+
     let dashOffset = 0;
     function draw() {
       ctx.clearRect(0, 0, overlay!.width, overlay!.height);
 
-      // Actor marching-ants highlight
+      // Actor marching-ants highlight + axis gizmo
       if (hasActorHighlight) {
         const rect = getSpriteRect();
         if (rect) {
@@ -548,6 +595,7 @@ export default function MapCanvas({
           }
           ctx.restore();
         }
+        if (actor) drawAxis(actor.x * zoom + pan.x, actor.y * zoom + pan.y);
       }
 
       // Platform marching-ants highlight + resize handles
@@ -592,6 +640,8 @@ export default function MapCanvas({
           ctx.fillRect(hx - hs, hy - hs, HS, HS);
           ctx.strokeRect(hx - hs, hy - hs, HS, HS);
         }
+
+        drawAxis((cx1 + cx2) / 2, (cy1 + cy2) / 2);
       }
 
       dashOffset = (dashOffset + 0.5) % 10;

--- a/web/admin/app/designer/MapCanvas.tsx
+++ b/web/admin/app/designer/MapCanvas.tsx
@@ -118,6 +118,7 @@ interface Props {
   selectedPlatformIdx: number | null;
   onPlatformSelect: (idx: number | null) => void;
   onPlatformUpdate: (idx: number, x1: number, y1: number, x2: number, y2: number) => void;
+  onActorSelect?: (idx: number | null) => void;
   gridSize: number;
 }
 
@@ -133,6 +134,7 @@ export default function MapCanvas({
   eraseLayerType,
   highlightActorIdx,
   selectedPlatformIdx, onPlatformSelect, onPlatformUpdate,
+  onActorSelect,
   gridSize,
 }: Props) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -501,7 +503,7 @@ export default function MapCanvas({
     const actor = hasActorHighlight ? map!.actors[highlightActorIdx!] : null;
     const def = actor ? getActorDef(actor.id) : null;
 
-    function getSpriteRect() {
+    function getSpriteRect(overrideCx?: number, overrideCy?: number) {
       if (!actor || !def) return null;
       let bankNum = def.bank;
       if (actor.id === 54) bankNum = actor.type === 0 ? 183 : 184;
@@ -509,8 +511,8 @@ export default function MapCanvas({
       if (actor.id === 63) bankNum = actor.type === 0 ? 200 : actor.type === 2 ? 201 : 205;
       const sprBank = bankNum != null ? spriteImages?.get(bankNum) : null;
       const spr = sprBank?.[def.frame ?? 0];
-      const cx = actor.x * zoom + pan.x;
-      const cy = actor.y * zoom + pan.y;
+      const cx = overrideCx ?? actor.x * zoom + pan.x;
+      const cy = overrideCy ?? actor.y * zoom + pan.y;
       if (spr) {
         const pad = 3;
         return { x: cx - spr.offsetX * zoom - pad, y: cy - spr.offsetY * zoom - pad,
@@ -574,7 +576,10 @@ export default function MapCanvas({
 
       // Actor marching-ants highlight + axis gizmo
       if (hasActorHighlight) {
-        const rect = getSpriteRect();
+        const isDragging = dragActorPreview?.idx === highlightActorIdx;
+        const liveCx = isDragging ? dragActorPreview!.wx * zoom + pan.x : actor!.x * zoom + pan.x;
+        const liveCy = isDragging ? dragActorPreview!.wy * zoom + pan.y : actor!.y * zoom + pan.y;
+        const rect = getSpriteRect(liveCx, liveCy);
         if (rect) {
           ctx.save();
           ctx.lineWidth = 2;
@@ -595,7 +600,7 @@ export default function MapCanvas({
           }
           ctx.restore();
         }
-        if (actor) drawAxis(actor.x * zoom + pan.x, actor.y * zoom + pan.y);
+        if (actor) drawAxis(liveCx, liveCy);
       }
 
       // Platform marching-ants highlight + resize handles
@@ -649,7 +654,7 @@ export default function MapCanvas({
     }
     rafRef.current = requestAnimationFrame(draw);
     return () => { if (rafRef.current) { cancelAnimationFrame(rafRef.current); rafRef.current = null; } };
-  }, [highlightActorIdx, selectedPlatformIdx, map, spriteImages, zoom, pan]);
+  }, [highlightActorIdx, selectedPlatformIdx, map, spriteImages, zoom, pan, dragActorPreview]);
 
   // Mouse event handlers
   const getCanvasPos = (e: { clientX: number; clientY: number }) => {
@@ -744,33 +749,37 @@ export default function MapCanvas({
         }
       }
 
-      // 2. Hit-test all platforms for selection
-      for (let i = map.platforms.length - 1; i >= 0; i--) {
-        const p = map.platforms[i];
-        if (wx >= p.x1 && wx <= p.x2 && wy >= p.y1 && wy <= p.y2) {
-          onPlatformSelect(i);
-          return;
-        }
-      }
-
-      // 3. Hit-test actors (existing logic)
+      // 2. Hit-test actors — priority over new platform selection
       const HIT = 48 / zoom;
       for (let i = map.actors.length - 1; i >= 0; i--) {
         const a = map.actors[i];
         const dist = Math.hypot(a.x - wx, a.y - wy);
         if (dist < HIT) {
+          onActorSelect?.(i);
+          onPlatformSelect(null);
           draggingActorRef.current = { idx: i, startWx: wx, startWy: wy, origX: a.x, origY: a.y, moved: false };
           setDragActorPreview({ idx: i, wx: a.x, wy: a.y });
           return;
         }
       }
 
-      // 4. Click on empty → deselect
+      // 3. Hit-test all platforms for selection
+      for (let i = map.platforms.length - 1; i >= 0; i--) {
+        const p = map.platforms[i];
+        if (wx >= p.x1 && wx <= p.x2 && wy >= p.y1 && wy <= p.y2) {
+          onPlatformSelect(i);
+          onActorSelect?.(null);
+          return;
+        }
+      }
+
+      // 4. Click on empty → deselect all
       onPlatformSelect(null);
+      onActorSelect?.(null);
     }
   }, [map, activeTool, activeLayer, selectedTileId, canvasToTile, canvasToWorld, zoom, eraseLayerType,
       onTilePaint, onPlatformRemove, onActorPlace, onDragPlatformChange, onBeginPaint,
-      selectedPlatformIdx, onPlatformSelect, snap]);
+      selectedPlatformIdx, onPlatformSelect, onActorSelect, snap]);
 
   // Right-click: actors take priority, fall through to tile property editor
   const handleContextMenu = useCallback((e: React.MouseEvent<HTMLCanvasElement>) => {

--- a/web/admin/app/designer/MapPropertiesPanel.tsx
+++ b/web/admin/app/designer/MapPropertiesPanel.tsx
@@ -114,10 +114,17 @@ export default function MapPropertiesPanel({ header, onUpdate, onClose, spriteIm
           <input type="text" maxLength={127} value={fields.description}
             onChange={e => setFields(f => ({ ...f, description: e.target.value }))} className={inp} />
         </div>
-        <div className="w-28">
-          <div className={lbl}>Ambience (-128..127)</div>
-          <input type="number" min={-128} max={127} value={fields.ambience}
-            onChange={e => setFields(f => ({ ...f, ambience: e.target.value }))} className={inp} />
+        <div className="w-56">
+          <div className={lbl}>
+            Ambience — darkness&nbsp;
+            <span className="text-game-text">{fields.ambience}</span>
+            <span className="text-game-textDim text-[10px] ml-1">
+              ({Math.round(Math.max(0, Math.min(255, 128 + parseInt(fields.ambience||'0',10) * 4.5)))} brightness)
+            </span>
+          </div>
+          <input type="range" min={-128} max={127} value={fields.ambience}
+            onChange={e => setFields(f => ({ ...f, ambience: e.target.value }))}
+            className="w-full accent-game-primary" />
         </div>
         <div className="w-24">
           <div className={lbl}>Max Players</div>

--- a/web/admin/app/designer/MapPropertiesPanel.tsx
+++ b/web/admin/app/designer/MapPropertiesPanel.tsx
@@ -1,18 +1,69 @@
 'use client';
-import { useState, useEffect } from 'react';
-import type { MapHeader } from '../../lib/types';
+import { useState, useEffect, useRef } from 'react';
+import type { MapHeader, SpriteEntry } from '../../lib/types';
+
+const BG_NAMES = ['Forest', 'Desert', 'Snow', 'Night', 'Cave'];
+
+function BgThumb({ idx, spriteImages, selected, onSelect }: {
+  idx: number;
+  spriteImages: Map<number, (SpriteEntry | null)[]> | null | undefined;
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d')!;
+    const W = canvas.width, H = canvas.height;
+    ctx.fillStyle = '#0a0a0f';
+    ctx.fillRect(0, 0, W, H);
+    const bank = spriteImages?.get(idx);
+    if (!bank) {
+      ctx.fillStyle = '#1a1a2e';
+      ctx.fillRect(0, 0, W, H);
+      return;
+    }
+    const BG_COLS = 20, BG_ROWS = 12;
+    const tw = W / BG_COLS, th = H / BG_ROWS;
+    for (let r = 0; r < BG_ROWS; r++) {
+      for (let c = 0; c < BG_COLS; c++) {
+        const spr = bank[r * BG_COLS + c];
+        if (spr) ctx.drawImage(spr.bitmap, c * tw, r * th, tw, th);
+      }
+    }
+  }, [idx, spriteImages]);
+
+  return (
+    <button
+      onClick={onSelect}
+      title={`Background ${idx}: ${BG_NAMES[idx] ?? 'Unknown'}`}
+      className={`flex flex-col items-center gap-1 rounded border-2 p-1 transition-colors flex-shrink-0 ${
+        selected
+          ? 'border-game-primary bg-[#0d1a0d]'
+          : 'border-game-border/50 hover:border-game-border bg-transparent'
+      }`}
+    >
+      <canvas ref={canvasRef} width={100} height={60} className="rounded-sm block" />
+      <span className={`text-[10px] font-mono ${selected ? 'text-game-primary' : 'text-game-textDim'}`}>
+        BG {idx} · {BG_NAMES[idx] ?? ''}
+      </span>
+    </button>
+  );
+}
 
 interface Props {
   header: MapHeader | null;
   onUpdate: (patch: Partial<MapHeader>) => void;
   onClose: () => void;
+  spriteImages?: Map<number, (SpriteEntry | null)[]> | null;
 }
 
-export default function MapPropertiesPanel({ header, onUpdate, onClose }: Props) {
+export default function MapPropertiesPanel({ header, onUpdate, onClose, spriteImages }: Props) {
   const [fields, setFields] = useState({
     description: header?.description ?? '',
     ambience:    String(header?.ambience   ?? 0),
-    parallax:    String(header?.parallax   ?? 0),
     maxplayers:  String(header?.maxplayers ?? 8),
     maxteams:    String(header?.maxteams   ?? 2),
   });
@@ -21,7 +72,6 @@ export default function MapPropertiesPanel({ header, onUpdate, onClose }: Props)
     setFields({
       description: header?.description ?? '',
       ambience:    String(header?.ambience   ?? 0),
-      parallax:    String(header?.parallax   ?? 0),
       maxplayers:  String(header?.maxplayers ?? 8),
       maxteams:    String(header?.maxteams   ?? 2),
     });
@@ -31,51 +81,66 @@ export default function MapPropertiesPanel({ header, onUpdate, onClose }: Props)
     onUpdate({
       description: fields.description.slice(0, 127),
       ambience:    Math.max(-128, Math.min(127, parseInt(fields.ambience,   10) || 0)),
-      parallax:    Math.max(0,    Math.min(255, parseInt(fields.parallax,   10) || 0)),
       maxplayers:  Math.max(1,    Math.min(8,   parseInt(fields.maxplayers, 10) || 8)),
       maxteams:    Math.max(1,    Math.min(4,   parseInt(fields.maxteams,   10) || 2)),
     });
   };
 
+  const currentParallax = header?.parallax ?? 0;
+
   const inp = 'w-full bg-game-dark border border-game-border text-game-text text-xs px-2 py-1 rounded font-mono focus:outline-none focus:border-game-primary';
   const lbl = 'text-game-textDim text-xs font-mono mb-0.5';
 
   return (
-    <div className="bg-game-bgCard border-b border-game-border px-4 py-3 flex flex-wrap gap-4 items-end">
-      <div className="flex-1 min-w-[180px]">
-        <div className={lbl}>Description (max 127)</div>
-        <input type="text" maxLength={127} value={fields.description}
-          onChange={e => setFields(f => ({ ...f, description: e.target.value }))} className={inp} />
+    <div className="bg-game-bgCard border-b border-game-border px-4 py-3 flex flex-col gap-3">
+      {/* Background picker */}
+      <div>
+        <div className={`${lbl} mb-1`}>Background</div>
+        <div className="flex gap-2 overflow-x-auto pb-1">
+          {[0, 1, 2, 3, 4].map(i => (
+            <BgThumb
+              key={i}
+              idx={i}
+              spriteImages={spriteImages}
+              selected={currentParallax === i}
+              onSelect={() => onUpdate({ parallax: i })}
+            />
+          ))}
+        </div>
       </div>
-      <div className="w-28">
-        <div className={lbl}>Ambience (-128..127)</div>
-        <input type="number" min={-128} max={127} value={fields.ambience}
-          onChange={e => setFields(f => ({ ...f, ambience: e.target.value }))} className={inp} />
-      </div>
-      <div className="w-28">
-        <div className={lbl}>Parallax (0..255)</div>
-        <input type="number" min={0} max={255} value={fields.parallax}
-          onChange={e => setFields(f => ({ ...f, parallax: e.target.value }))} className={inp} />
-      </div>
-      <div className="w-24">
-        <div className={lbl}>Max Players</div>
-        <input type="number" min={1} max={8} value={fields.maxplayers}
-          onChange={e => setFields(f => ({ ...f, maxplayers: e.target.value }))} className={inp} />
-      </div>
-      <div className="w-24">
-        <div className={lbl}>Max Teams</div>
-        <input type="number" min={1} max={4} value={fields.maxteams}
-          onChange={e => setFields(f => ({ ...f, maxteams: e.target.value }))} className={inp} />
-      </div>
-      <div className="flex gap-2 flex-shrink-0">
-        <button onClick={apply}
-          className="px-3 py-1 text-xs font-mono border border-game-primary text-game-primary rounded hover:bg-game-dark transition-colors">
-          APPLY
-        </button>
-        <button onClick={onClose}
-          className="px-3 py-1 text-xs font-mono border border-game-border text-game-textDim rounded hover:border-game-primary transition-colors">
-          ✕
-        </button>
+
+      {/* Other map properties */}
+      <div className="flex flex-wrap gap-4 items-end">
+        <div className="flex-1 min-w-[180px]">
+          <div className={lbl}>Description (max 127)</div>
+          <input type="text" maxLength={127} value={fields.description}
+            onChange={e => setFields(f => ({ ...f, description: e.target.value }))} className={inp} />
+        </div>
+        <div className="w-28">
+          <div className={lbl}>Ambience (-128..127)</div>
+          <input type="number" min={-128} max={127} value={fields.ambience}
+            onChange={e => setFields(f => ({ ...f, ambience: e.target.value }))} className={inp} />
+        </div>
+        <div className="w-24">
+          <div className={lbl}>Max Players</div>
+          <input type="number" min={1} max={8} value={fields.maxplayers}
+            onChange={e => setFields(f => ({ ...f, maxplayers: e.target.value }))} className={inp} />
+        </div>
+        <div className="w-24">
+          <div className={lbl}>Max Teams</div>
+          <input type="number" min={1} max={4} value={fields.maxteams}
+            onChange={e => setFields(f => ({ ...f, maxteams: e.target.value }))} className={inp} />
+        </div>
+        <div className="flex gap-2 flex-shrink-0">
+          <button onClick={apply}
+            className="px-3 py-1 text-xs font-mono border border-game-primary text-game-primary rounded hover:bg-game-dark transition-colors">
+            APPLY
+          </button>
+          <button onClick={onClose}
+            className="px-3 py-1 text-xs font-mono border border-game-border text-game-textDim rounded hover:border-game-primary transition-colors">
+            ✕
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/web/admin/app/designer/MapPropertiesPanel.tsx
+++ b/web/admin/app/designer/MapPropertiesPanel.tsx
@@ -2,8 +2,6 @@
 import { useState, useEffect, useRef } from 'react';
 import type { MapHeader, SpriteEntry } from '../../lib/types';
 
-const BG_NAMES = ['Forest', 'Desert', 'Snow', 'Night', 'Cave'];
-
 function BgThumb({ idx, spriteImages, selected, onSelect }: {
   idx: number;
   spriteImages: Map<number, (SpriteEntry | null)[]> | null | undefined;
@@ -38,7 +36,7 @@ function BgThumb({ idx, spriteImages, selected, onSelect }: {
   return (
     <button
       onClick={onSelect}
-      title={`Background ${idx}: ${BG_NAMES[idx] ?? 'Unknown'}`}
+      title={`Background ${idx}`}
       className={`flex flex-col items-center gap-1 rounded border-2 p-1 transition-colors flex-shrink-0 ${
         selected
           ? 'border-game-primary bg-[#0d1a0d]'
@@ -47,7 +45,7 @@ function BgThumb({ idx, spriteImages, selected, onSelect }: {
     >
       <canvas ref={canvasRef} width={100} height={60} className="rounded-sm block" />
       <span className={`text-[10px] font-mono ${selected ? 'text-game-primary' : 'text-game-textDim'}`}>
-        BG {idx} · {BG_NAMES[idx] ?? ''}
+        BG {idx}
       </span>
     </button>
   );

--- a/web/admin/app/designer/Toolbar.tsx
+++ b/web/admin/app/designer/Toolbar.tsx
@@ -79,23 +79,24 @@ export const ACTOR_DEFS: ActorDefEntry[] = [
 ];
 
 export const ACTOR_TYPE_HINTS: Record<number, ActorTypeHint> = {
-  0:  { label: 'Weapon',  options: { 0:'Blaster', 1:'Laser', 2:'Rocket', 3:'Flamer', 4:'Plasma' } },
-  1:  { label: 'Variant', options: { 0:'Civilian A', 1:'Civilian B' } },
-  2:  { label: 'Weapon',  options: { 0:'Blaster', 1:'Laser', 2:'Rocket', 3:'Flamer', 4:'Plasma' } },
-  3:  { label: 'Weapon',  options: { 0:'Blaster', 1:'Laser', 2:'Rocket', 3:'Flamer', 4:'Plasma' } },
-  36: { label: 'Agency',  options: { 0:'Agency 0', 1:'Agency 1', 2:'Agency 2', 3:'Agency 3' } },
-  54: { label: 'Size',    options: { 0:'Small', 1:'Big' } },
-  63: { label: 'Powerup', options: {
+  0:  { label: 'Behavior', options: { 0:'Patrol', 1:'Guard (stationary)' } },
+  1:  { label: 'Variant',  options: { 0:'Civilian A', 1:'Civilian B' } },
+  2:  { label: 'Behavior', options: { 0:'Patrol', 1:'Guard (stationary)' } },
+  3:  { label: 'Behavior', options: { 0:'Patrol', 1:'Guard (stationary)', 2:"Magistrate's Laser", 3:"Magistrate's Rocket" } },
+  6:  { label: 'Behavior', options: { 0:'Patrol', 1:'Guard (stationary)' } },
+  36: { label: 'Agency',   options: { 0:'Agency 0', 1:'Agency 1', 2:'Agency 2', 3:'Agency 3' } },
+  54: { label: 'Size',     options: { 0:'Small', 1:'Big' } },
+  63: { label: 'Powerup',  options: {
     0:'Super Shield', 1:'Neutron Bomb', 2:'Jet Pack',
     3:'Invisible', 4:'Hacking Bonus', 5:'Radar', 6:'Depositor',
   } },
-  47: { label: 'Doodad',  options: {
+  47: { label: 'Doodad',   options: {
     0:'Small Candle', 1:'Large Candle', 2:'Small Canister', 3:'Large Canister',
     4:'Arrow Poster', 5:'Man in Tank', 6:'Doodad 6', 7:'Doodad 7', 8:'Doodad 8', 9:'Doodad 9',
   } },
-  50: { label: 'Size',    options: { 4:'Small', 5:'Small Alt', 6:'Large', 7:'Default' } },
-  65: { label: 'Side',    options: { 0:'Team A', 1:'Team B' } },
-  67: { label: 'Type',    options: { 0:'Base Defense', 1:'Guard Defense (Laser)' } },
+  50: { label: 'Size',     options: { 4:'Small', 5:'Small Alt', 6:'Large', 7:'Default' } },
+  65: { label: 'Side',     options: { 0:'Team A', 1:'Team B' } },
+  67: { label: 'Type',     options: { 0:'Base Defense', 1:'Guard Defense (Laser)' } },
 };
 
 interface ToolbarProps {

--- a/web/admin/app/designer/Toolbar.tsx
+++ b/web/admin/app/designer/Toolbar.tsx
@@ -31,6 +31,7 @@ export const TOOLS: ToolDef[] = [
   { id: 'TILE_BG',        label: 'TILE (BG)',  icon: '▦' },
   { id: 'TILE_FG',        label: 'TILE (FG)',  icon: '▧' },
   { id: 'ERASE_TILE',     label: 'ERASE',      icon: '⌫' },
+  { id: 'TILE_SELECT',    label: 'COPY SEL',   icon: '⬚' },
   { id: 'RECT',           label: 'RECT',       icon: '▭' },
   { id: 'STAIRSUP',       label: 'STAIRS↑',   icon: '↗' },
   { id: 'STAIRSDOWN',     label: 'STAIRS↓',   icon: '↘' },
@@ -116,7 +117,7 @@ export default function Toolbar({
   selectedActor, onActorChange, lumMode, onLumModeChange,
   eraseLayerType, onEraseLayerTypeChange,
 }: ToolbarProps) {
-  const tileTools     = TOOLS.filter(t => ['TILE_BG', 'TILE_FG', 'ERASE_TILE'].includes(t.id));
+  const tileTools     = TOOLS.filter(t => ['TILE_BG', 'TILE_FG', 'ERASE_TILE', 'TILE_SELECT'].includes(t.id));
   const platformTools = TOOLS.filter(t => ['RECT','STAIRSUP','STAIRSDOWN','LADDER','TRACK','OUTSIDEROOM','SPECIFICROOM','ERASE_PLATFORM'].includes(t.id));
   const otherTools    = TOOLS.filter(t => ['SELECT','ACTOR'].includes(t.id));
 

--- a/web/admin/app/designer/Toolbar.tsx
+++ b/web/admin/app/designer/Toolbar.tsx
@@ -66,7 +66,6 @@ export const ACTOR_DEFS: ActorDefEntry[] = [
   { id: 56, label: 'Inv. Station',    icon: 'IS', color: '#00a328', bank: 89,   frame: 0 },
   { id: 57, label: 'Heal Machine',    icon: 'HM', color: '#22d3ee', bank: 172,  frame: 0 },
   { id: 58, label: 'Secret Return',   icon: 'SR', color: '#a855f7', bank: 152,  frame: 0 },
-  { id: 60, label: 'Camera Focus',    icon: 'CF', color: '#22d3ee', bank: null, frame: 0 },
   { id: 61, label: 'Warper',          icon: 'WP', color: '#a855f7', bank: 85,   frame: 0 },
   { id: 63, label: 'Powerup',         icon: 'PU', color: '#f59e0b', bank: null, frame: 0 },
   { id: 64, label: 'Vent',            icon: 'VT', color: '#6b7280', bank: 179,  frame: 0 },
@@ -84,8 +83,8 @@ export const ACTOR_TYPE_HINTS: Record<number, ActorTypeHint> = {
   2:  { label: 'Behavior', options: { 0:'Patrol', 1:'Guard (stationary)' } },
   3:  { label: 'Behavior', options: { 0:'Patrol', 1:'Guard (stationary)', 2:"Magistrate's Laser", 3:"Magistrate's Rocket" } },
   6:  { label: 'Behavior', options: { 0:'Patrol', 1:'Guard (stationary)' } },
-  36: { label: 'Agency',   options: { 0:'Agency 0', 1:'Agency 1', 2:'Agency 2', 3:'Agency 3' } },
   54: { label: 'Size',     options: { 0:'Small', 1:'Big' } },
+  66: { label: 'Variant',  options: { 0:'Type A', 1:'Type B', 2:'Type C (surveillance-linked)' } },
   63: { label: 'Powerup',  options: {
     0:'Super Shield', 1:'Neutron Bomb', 2:'Jet Pack',
     3:'Invisible', 4:'Hacking Bonus', 5:'Radar', 6:'Depositor',

--- a/web/admin/app/designer/Toolbar.tsx
+++ b/web/admin/app/designer/Toolbar.tsx
@@ -32,6 +32,7 @@ export const TOOLS: ToolDef[] = [
   { id: 'TILE_FG',        label: 'TILE (FG)',  icon: '▧' },
   { id: 'ERASE_TILE',     label: 'ERASE',      icon: '⌫' },
   { id: 'TILE_SELECT',    label: 'COPY SEL',   icon: '⬚' },
+  { id: 'FLOOD_FILL',    label: 'FILL',        icon: '🪣' },
   { id: 'RECT',           label: 'RECT',       icon: '▭' },
   { id: 'STAIRSUP',       label: 'STAIRS↑',   icon: '↗' },
   { id: 'STAIRSDOWN',     label: 'STAIRS↓',   icon: '↘' },
@@ -117,7 +118,7 @@ export default function Toolbar({
   selectedActor, onActorChange, lumMode, onLumModeChange,
   eraseLayerType, onEraseLayerTypeChange,
 }: ToolbarProps) {
-  const tileTools     = TOOLS.filter(t => ['TILE_BG', 'TILE_FG', 'ERASE_TILE', 'TILE_SELECT'].includes(t.id));
+  const tileTools     = TOOLS.filter(t => ['TILE_BG', 'TILE_FG', 'ERASE_TILE', 'TILE_SELECT', 'FLOOD_FILL'].includes(t.id));
   const platformTools = TOOLS.filter(t => ['RECT','STAIRSUP','STAIRSDOWN','LADDER','TRACK','OUTSIDEROOM','SPECIFICROOM','ERASE_PLATFORM'].includes(t.id));
   const otherTools    = TOOLS.filter(t => ['SELECT','ACTOR'].includes(t.id));
 

--- a/web/admin/app/designer/page.tsx
+++ b/web/admin/app/designer/page.tsx
@@ -57,6 +57,7 @@ export default function DesignerPage() {
   const [selectedPlatformIdx, setSelectedPlatformIdx] = useState<number | null>(null);
   const [zoom, setZoom]   = useState(0.5);
   const [pan, setPan]     = useState({ x: 32, y: 32 });
+  const [fitTrigger, setFitTrigger] = useState(0);
   const [cursor, setCursor] = useState<{ tx: number; ty: number; wx: number; wy: number }>({ tx: 0, ty: 0, wx: 0, wy: 0 });
   const [dragPlatform, setDragPlatform] = useState<DragPlatform | null>(null);
   const [lumMode, setLumMode] = useState(false);
@@ -222,13 +223,7 @@ export default function DesignerPage() {
   const handleOpenSil = async (e: React.ChangeEvent<HTMLInputElement>) => {
     if (!e.target.files?.[0]) return;
     const loaded = await openMap(e.target.files[0]);
-    if (!loaded) return;
-    const container = document.getElementById('canvas-container');
-    if (!container) return;
-    const { width: cw, height: ch } = container.getBoundingClientRect();
-    const newZoom = Math.min(cw / (loaded.width * 64), ch / (loaded.height * 64)) * 0.95;
-    setZoom(newZoom);
-    setPan({ x: (cw - loaded.width * 64 * newZoom) / 2, y: (ch - loaded.height * 64 * newZoom) / 2 });
+    if (loaded) setFitTrigger(t => t + 1);
   };
 
   const handleTilePaint = useCallback((layerType: 'bg' | 'fg', layerIdx: number, tx: number, ty: number, tileId: number) => {
@@ -312,6 +307,12 @@ export default function DesignerPage() {
     setZoom(newZoom);
     setPan({ x: (cw - map.width * 64 * newZoom) / 2, y: (ch - map.height * 64 * newZoom) / 2 });
   };
+
+  // Run fitToScreen after React has committed the new map to the DOM
+  useEffect(() => {
+    if (fitTrigger > 0) fitToScreen();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fitTrigger]);
 
   const isLoading = progress.total > 0 && progress.done < progress.total;
 
@@ -404,7 +405,7 @@ export default function DesignerPage() {
                     if (!w || !h || w < 1 || h < 1 || w > 512 || h > 512) return;
                     createMap(w, h, newMapDesc);
                     setShowNewMap(false);
-                    requestAnimationFrame(fitToScreen);
+                    setFitTrigger(t => t + 1);
                   }}
                     className="flex-1 py-1 text-xs font-mono border border-game-primary text-game-primary rounded hover:bg-game-dark transition-colors">
                     CREATE

--- a/web/admin/app/designer/page.tsx
+++ b/web/admin/app/designer/page.tsx
@@ -57,7 +57,7 @@ export default function DesignerPage() {
   const [selectedPlatformIdx, setSelectedPlatformIdx] = useState<number | null>(null);
   const [zoom, setZoom]   = useState(0.5);
   const [pan, setPan]     = useState({ x: 32, y: 32 });
-  const [fitTrigger, setFitTrigger] = useState(0);
+  const fitPendingRef = useRef(false);
   const [cursor, setCursor] = useState<{ tx: number; ty: number; wx: number; wy: number }>({ tx: 0, ty: 0, wx: 0, wy: 0 });
   const [dragPlatform, setDragPlatform] = useState<DragPlatform | null>(null);
   const [lumMode, setLumMode] = useState(false);
@@ -222,8 +222,8 @@ export default function DesignerPage() {
 
   const handleOpenSil = async (e: React.ChangeEvent<HTMLInputElement>) => {
     if (!e.target.files?.[0]) return;
-    const loaded = await openMap(e.target.files[0]);
-    if (loaded) setFitTrigger(t => t + 1);
+    fitPendingRef.current = true;
+    await openMap(e.target.files[0]);
   };
 
   const handleTilePaint = useCallback((layerType: 'bg' | 'fg', layerIdx: number, tx: number, ty: number, tileId: number) => {
@@ -308,11 +308,20 @@ export default function DesignerPage() {
     setPan({ x: (cw - map.width * 64 * newZoom) / 2, y: (ch - map.height * 64 * newZoom) / 2 });
   };
 
-  // Run fitToScreen after React has committed the new map to the DOM
+  // Run fitToScreen after React commits a new map — rAF lets the browser paint first
   useEffect(() => {
-    if (fitTrigger > 0) fitToScreen();
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [fitTrigger]);
+    if (!fitPendingRef.current || !map) return;
+    fitPendingRef.current = false;
+    const { width, height } = map;
+    requestAnimationFrame(() => {
+      const container = document.getElementById('canvas-container');
+      if (!container) return;
+      const { width: cw, height: ch } = container.getBoundingClientRect();
+      const newZoom = Math.min(cw / (width * 64), ch / (height * 64)) * 0.95;
+      setZoom(newZoom);
+      setPan({ x: (cw - width * 64 * newZoom) / 2, y: (ch - height * 64 * newZoom) / 2 });
+    });
+  }, [map]);
 
   const isLoading = progress.total > 0 && progress.done < progress.total;
 
@@ -405,7 +414,7 @@ export default function DesignerPage() {
                     if (!w || !h || w < 1 || h < 1 || w > 512 || h > 512) return;
                     createMap(w, h, newMapDesc);
                     setShowNewMap(false);
-                    setFitTrigger(t => t + 1);
+                    fitPendingRef.current = true;
                   }}
                     className="flex-1 py-1 text-xs font-mono border border-game-primary text-game-primary rounded hover:bg-game-dark transition-colors">
                     CREATE

--- a/web/admin/app/designer/page.tsx
+++ b/web/admin/app/designer/page.tsx
@@ -79,6 +79,7 @@ export default function DesignerPage() {
     grid: true,
     lighting: true,
   });
+  const [gridSize, setGridSize] = useState(16);
   const toggleVis = (key: keyof VisState, idx: number | null = null) => setVis(v => {
     if (idx !== null) {
       const arr = [...(v[key] as boolean[])]; arr[idx] = !arr[idx]; return { ...v, [key]: arr };
@@ -695,6 +696,17 @@ export default function DesignerPage() {
                   {lbl}
                 </button>
               ))}
+              {vis.grid && (
+                <>
+                  <span className="text-[#1a3a1a] text-xs mx-0.5">⊞</span>
+                  {([8, 16, 32, 64] as const).map(sz => (
+                    <button key={sz} onClick={() => setGridSize(sz)}
+                      className={`px-1.5 py-0.5 text-xs font-mono rounded border ${gridSize === sz ? 'border-[#3a3a2a] text-[#c0c080] bg-[#1a1a0d]' : 'border-[#1a1a1a] text-[#3a3a3a] bg-transparent'}`}>
+                      {sz}
+                    </button>
+                  ))}
+                </>
+              )}
             </div>
 
             <div className="flex-1 relative min-h-0">
@@ -729,6 +741,7 @@ export default function DesignerPage() {
               selectedPlatformIdx={selectedPlatformIdx}
               onPlatformSelect={setSelectedPlatformIdx}
               onPlatformUpdate={updatePlatform}
+              gridSize={gridSize}
             />
             <Minimap
               map={map}
@@ -829,7 +842,7 @@ export default function DesignerPage() {
               <span className="text-game-primary">A</span><span>Actor tool</span>
               <span className="text-game-primary">S</span><span>Select / drag tool</span>
               <span className="text-game-primary">1–4</span><span>Layer 0–3</span>
-              <span className="text-game-primary">G</span><span>Toggle grid</span>
+              <span className="text-game-primary">G</span><span>Toggle grid snap</span>
               <span className="text-game-primary">L</span><span>Toggle lighting</span>
               <span className="text-game-primary">Ctrl+Z</span><span>Undo</span>
               <span className="text-game-primary">Ctrl+Y / Ctrl+Shift+Z</span><span>Redo</span>

--- a/web/admin/app/designer/page.tsx
+++ b/web/admin/app/designer/page.tsx
@@ -265,6 +265,7 @@ export default function DesignerPage() {
         case 'b': handleToolChange('TILE_BG');    break;
         case 'f': handleToolChange('TILE_FG');    break;
         case 'e': handleToolChange('ERASE_TILE'); break;
+        case 'i': handleToolChange('FLOOD_FILL'); break;
         case 'p': setActiveTool('RECT');       break;
         case 'a': setActiveTool('ACTOR');      break;
         case 's': setActiveTool('SELECT');     break;
@@ -830,6 +831,7 @@ export default function DesignerPage() {
               onZoomChange={setZoom}
               onPanChange={setPan}
               onTilePaint={handleTilePaint}
+              onFloodFill={applyTileBatch}
               onBeginPaint={beginPaint}
               onCommitPaint={commitPaint}
               onPlatformDraw={handlePlatformDraw}

--- a/web/admin/app/designer/page.tsx
+++ b/web/admin/app/designer/page.tsx
@@ -731,6 +731,7 @@ export default function DesignerPage() {
               onActorRemove={removeActor}
               onActorMove={handleActorMove}
               onActorRightClick={(idx, sx, sy) => { setActorMenu({ idx, screenX: sx, screenY: sy }); setHighlightActorIdx(idx); }}
+              onActorSelect={setHighlightActorIdx}
               onTileRightClick={(info) => { setActorMenu(null); setTileMenu(info); }}
               selectedActorId={selectedActorId}
               dragPlatform={dragPlatform}

--- a/web/admin/app/designer/page.tsx
+++ b/web/admin/app/designer/page.tsx
@@ -250,6 +250,12 @@ export default function DesignerPage() {
     moveActor(idx, x, y);
   }, [moveActor]);
 
+  const handleActorFlip = useCallback((idx: number) => {
+    const actor = map?.actors[idx];
+    if (!actor) return;
+    updateActor(idx, { direction: actor.direction ? 0 : 1 });
+  }, [map, updateActor]);
+
   const canvasContainerRef = useRef<HTMLDivElement>(null);
 
   const handleCenterOnActor = useCallback((actor: MapActor) => {
@@ -733,6 +739,7 @@ export default function DesignerPage() {
               onActorPlace={handleActorPlace}
               onActorRemove={removeActor}
               onActorMove={handleActorMove}
+              onActorFlip={handleActorFlip}
               onActorRightClick={(idx, sx, sy) => { setActorMenu({ idx, screenX: sx, screenY: sy }); setHighlightActorIdx(idx); }}
               onActorSelect={setHighlightActorIdx}
               onTileRightClick={(info) => { setActorMenu(null); setTileMenu(info); }}

--- a/web/admin/app/designer/page.tsx
+++ b/web/admin/app/designer/page.tsx
@@ -44,13 +44,15 @@ export default function DesignerPage() {
   const wsConnected = useSocket({});
 
   const { loaded, error, tileImages, spriteImages, tileBankCounts, progress, loadFiles } = useGameData();
-  const { map, openMap, saveMap, publishMap, createMap, updateTile, patchTile, applyTileBatch, beginPaint, commitPaint,
+  const { map, openMap, saveMap, publishMap, createMap, updateTile, patchTile, applyTileBatch, applyAllLayersBatch, beginPaint, commitPaint,
           addPlatform, removePlatform, addActor, removeActor, updateActor, moveActor,
           updateHeader, updatePlatform,
           undo, redo, canUndo, canRedo, resizeMap } = useSilMap();
 
   type TileSel = { tx1: number; ty1: number; tx2: number; ty2: number; layerType: 'bg' | 'fg'; layerIdx: number };
-  type TileCopyBuf = { w: number; h: number; layerType: 'bg' | 'fg'; layerIdx: number; tiles: Array<{ tile_id: number; flip: number; lum: number }> };
+  type TileCell = { tile_id: number; flip: number; lum: number };
+  // All 4 layers stored: bg[0], bg[1], fg[0], fg[1] — each is a flat w*h array
+  type TileCopyBuf = { w: number; h: number; layers: [TileCell[], TileCell[], TileCell[], TileCell[]] };
 
   const [activeTool, setActiveTool]     = useState('TILE_BG');
   const [activeLayer, setActiveLayer]   = useState(0);
@@ -204,19 +206,27 @@ export default function DesignerPage() {
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if ((e.ctrlKey || e.metaKey) && e.key === 'c') {
-        const { tileSelection: sel, map: m, tileLayerType: lt, activeLayer: li } = clipCtxRef.current;
+        const { tileSelection: sel, map: m } = clipCtxRef.current;
         if (!sel || !m) return;
         e.preventDefault();
-        const { tx1, ty1, tx2, ty2, layerType, layerIdx } = sel;
+        const { tx1, ty1, tx2, ty2 } = sel;
         const w = tx2 - tx1 + 1; const h = ty2 - ty1 + 1;
-        const layerArr = layerType === 'fg' ? m.layers.fg : m.layers.bg;
-        const tiles: TileCopyBuf['tiles'] = [];
-        for (let dy = 0; dy < h; dy++)
-          for (let dx = 0; dx < w; dx++) {
-            const cell = layerArr[layerIdx][(ty1 + dy) * m.width + (tx1 + dx)];
-            tiles.push(cell ?? { tile_id: 0, flip: 0, lum: 0 });
-          }
-        setTileCopyBuffer({ w, h, layerType, layerIdx, tiles });
+        const extractLayer = (arr: Array<{ tile_id: number; flip: number; lum: number } | null>) => {
+          const out: TileCell[] = [];
+          for (let dy = 0; dy < h; dy++)
+            for (let dx = 0; dx < w; dx++)
+              out.push(arr[(ty1 + dy) * m.width + (tx1 + dx)] ?? { tile_id: 0, flip: 0, lum: 0 });
+          return out;
+        };
+        setTileCopyBuffer({
+          w, h,
+          layers: [
+            extractLayer(m.layers.bg[0]),
+            extractLayer(m.layers.bg[1]),
+            extractLayer(m.layers.fg[0]),
+            extractLayer(m.layers.fg[1]),
+          ],
+        });
         setPastePending(false);
       } else if ((e.ctrlKey || e.metaKey) && e.key === 'v') {
         if (!clipCtxRef.current.tileCopyBuffer) return;
@@ -310,10 +320,19 @@ export default function DesignerPage() {
 
   const handleTilePaste = useCallback((tx: number, ty: number) => {
     if (!tileCopyBuffer || !map) return;
-    const { w, h, layerType, layerIdx, tiles } = tileCopyBuffer;
-    const updates = tiles.map((t, i) => ({ x: tx + (i % w), y: ty + Math.floor(i / w), ...t }));
-    applyTileBatch(layerType, layerIdx, updates);
-  }, [tileCopyBuffer, map, applyTileBatch]);
+    const { w, h, layers } = tileCopyBuffer;
+    const layerDefs: Array<{ layerType: 'bg' | 'fg'; layerIdx: number }> = [
+      { layerType: 'bg', layerIdx: 0 },
+      { layerType: 'bg', layerIdx: 1 },
+      { layerType: 'fg', layerIdx: 0 },
+      { layerType: 'fg', layerIdx: 1 },
+    ];
+    const patches = layerDefs.map(({ layerType, layerIdx }, li) => ({
+      layerType, layerIdx,
+      updates: layers[li].map((t, i) => ({ x: tx + (i % w), y: ty + Math.floor(i / w), ...t })),
+    }));
+    applyAllLayersBatch(patches);
+  }, [tileCopyBuffer, map, applyAllLayersBatch]);
 
   const canvasContainerRef = useRef<HTMLDivElement>(null);
 
@@ -833,8 +852,6 @@ export default function DesignerPage() {
               tileCopyBuffer={tileCopyBuffer}
               pastePending={pastePending}
               onTilePaste={handleTilePaste}
-              copyLayerType={tileLayerType}
-              copyLayerIdx={activeLayer}
             />
             <Minimap
               map={map}
@@ -886,7 +903,7 @@ export default function DesignerPage() {
           )}
           {tileCopyBuffer && (
             <span className="text-xs font-mono text-[#c0c040]">
-              📋 {tileCopyBuffer.w}×{tileCopyBuffer.h} {tileCopyBuffer.layerType.toUpperCase()}
+              📋 {tileCopyBuffer.w}×{tileCopyBuffer.h} ALL LAYERS
               {pastePending ? ' — PASTE MODE (click to stamp · Esc to cancel)' : ' — Ctrl+V to paste'}
             </span>
           )}

--- a/web/admin/app/designer/page.tsx
+++ b/web/admin/app/designer/page.tsx
@@ -44,10 +44,13 @@ export default function DesignerPage() {
   const wsConnected = useSocket({});
 
   const { loaded, error, tileImages, spriteImages, tileBankCounts, progress, loadFiles } = useGameData();
-  const { map, openMap, saveMap, publishMap, createMap, updateTile, patchTile, beginPaint, commitPaint,
+  const { map, openMap, saveMap, publishMap, createMap, updateTile, patchTile, applyTileBatch, beginPaint, commitPaint,
           addPlatform, removePlatform, addActor, removeActor, updateActor, moveActor,
           updateHeader, updatePlatform,
           undo, redo, canUndo, canRedo, resizeMap } = useSilMap();
+
+  type TileSel = { tx1: number; ty1: number; tx2: number; ty2: number; layerType: 'bg' | 'fg'; layerIdx: number };
+  type TileCopyBuf = { w: number; h: number; layerType: 'bg' | 'fg'; layerIdx: number; tiles: Array<{ tile_id: number; flip: number; lum: number }> };
 
   const [activeTool, setActiveTool]     = useState('TILE_BG');
   const [activeLayer, setActiveLayer]   = useState(0);
@@ -55,6 +58,10 @@ export default function DesignerPage() {
   const [selectedTileId, setSelectedTile] = useState(0);
   const [selectedActorId, setSelectedActor] = useState(36); // player start default
   const [selectedPlatformIdx, setSelectedPlatformIdx] = useState<number | null>(null);
+  const [tileLayerType, setTileLayerType] = useState<'bg' | 'fg'>('bg');
+  const [tileSelection, setTileSelection] = useState<TileSel | null>(null);
+  const [tileCopyBuffer, setTileCopyBuffer] = useState<TileCopyBuf | null>(null);
+  const [pastePending, setPastePending] = useState(false);
   const [zoom, setZoom]   = useState(0.5);
   const [pan, setPan]     = useState({ x: 32, y: 32 });
   const fitPendingRef = useRef(false);
@@ -181,6 +188,48 @@ export default function DesignerPage() {
   const dataDirRef   = useRef<HTMLInputElement>(null);
   const dataFilesRef = useRef<HTMLInputElement>(null);
 
+  // Tool change: track tile layer type and clear selection/paste on tool switch
+  const handleToolChange = useCallback((tool: string) => {
+    if (tool === 'TILE_BG') setTileLayerType('bg');
+    else if (tool === 'TILE_FG') setTileLayerType('fg');
+    if (tool !== 'TILE_SELECT') { setTileSelection(null); setPastePending(false); }
+    setActiveTool(tool);
+  }, []);
+
+  // Ref to access latest copy/paste context from stable keyboard handler
+  const clipCtxRef = useRef({ tileSelection, tileCopyBuffer, map, activeLayer, tileLayerType, pastePending });
+  useEffect(() => { clipCtxRef.current = { tileSelection, tileCopyBuffer, map, activeLayer, tileLayerType, pastePending }; });
+
+  // Copy/paste keyboard shortcuts (Ctrl/Cmd+C, Ctrl/Cmd+V, Escape)
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === 'c') {
+        const { tileSelection: sel, map: m, tileLayerType: lt, activeLayer: li } = clipCtxRef.current;
+        if (!sel || !m) return;
+        e.preventDefault();
+        const { tx1, ty1, tx2, ty2, layerType, layerIdx } = sel;
+        const w = tx2 - tx1 + 1; const h = ty2 - ty1 + 1;
+        const layerArr = layerType === 'fg' ? m.layers.fg : m.layers.bg;
+        const tiles: TileCopyBuf['tiles'] = [];
+        for (let dy = 0; dy < h; dy++)
+          for (let dx = 0; dx < w; dx++) {
+            const cell = layerArr[layerIdx][(ty1 + dy) * m.width + (tx1 + dx)];
+            tiles.push(cell ?? { tile_id: 0, flip: 0, lum: 0 });
+          }
+        setTileCopyBuffer({ w, h, layerType, layerIdx, tiles });
+        setPastePending(false);
+      } else if ((e.ctrlKey || e.metaKey) && e.key === 'v') {
+        if (!clipCtxRef.current.tileCopyBuffer) return;
+        e.preventDefault();
+        setPastePending(p => !p);
+      } else if (e.key === 'Escape') {
+        setPastePending(false);
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, []); // stable — reads via ref
+
   // Global keyboard shortcuts
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -193,9 +242,9 @@ export default function DesignerPage() {
       if (e.ctrlKey || e.metaKey || e.altKey) return;
 
       switch (e.key) {
-        case 'b': setActiveTool('TILE_BG');    break;
-        case 'f': setActiveTool('TILE_FG');    break;
-        case 'e': setActiveTool('ERASE_TILE'); break;
+        case 'b': handleToolChange('TILE_BG');    break;
+        case 'f': handleToolChange('TILE_FG');    break;
+        case 'e': handleToolChange('ERASE_TILE'); break;
         case 'p': setActiveTool('RECT');       break;
         case 'a': setActiveTool('ACTOR');      break;
         case 's': setActiveTool('SELECT');     break;
@@ -211,7 +260,7 @@ export default function DesignerPage() {
     };
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
-  }, [undo, redo]);
+  }, [undo, redo, handleToolChange]);
 
   const handleDataDir = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.target.files?.length) loadFiles(e.target.files);
@@ -258,6 +307,13 @@ export default function DesignerPage() {
     if (!actor) return;
     updateActor(idx, { direction: actor.direction ? 0 : 1 });
   }, [map, updateActor]);
+
+  const handleTilePaste = useCallback((tx: number, ty: number) => {
+    if (!tileCopyBuffer || !map) return;
+    const { w, h, layerType, layerIdx, tiles } = tileCopyBuffer;
+    const updates = tiles.map((t, i) => ({ x: tx + (i % w), y: ty + Math.floor(i / w), ...t }));
+    applyTileBatch(layerType, layerIdx, updates);
+  }, [tileCopyBuffer, map, applyTileBatch]);
 
   const canvasContainerRef = useRef<HTMLDivElement>(null);
 
@@ -675,7 +731,7 @@ export default function DesignerPage() {
         {/* Toolbar */}
         <Toolbar
           activeTool={activeTool}
-          onToolChange={setActiveTool}
+          onToolChange={handleToolChange}
           activeLayer={activeLayer}
           onLayerChange={setActiveLayer}
           selectedActor={selectedActorId}
@@ -772,6 +828,13 @@ export default function DesignerPage() {
               onPlatformSelect={setSelectedPlatformIdx}
               onPlatformUpdate={updatePlatform}
               gridSize={gridSize}
+              tileSelection={tileSelection}
+              onTileSelection={setTileSelection}
+              tileCopyBuffer={tileCopyBuffer}
+              pastePending={pastePending}
+              onTilePaste={handleTilePaste}
+              copyLayerType={tileLayerType}
+              copyLayerIdx={activeLayer}
             />
             <Minimap
               map={map}
@@ -821,9 +884,17 @@ export default function DesignerPage() {
               MAP {map.width}×{map.height} | {map.actors.length} actors | {map.platforms.length} platforms
             </span>
           )}
-          <span className="text-xs font-mono text-game-muted ml-auto">
-            CTRL/SPACE+DRAG or MMB to pan · SCROLL to zoom · CTRL+Z/Y to undo/redo
-          </span>
+          {tileCopyBuffer && (
+            <span className="text-xs font-mono text-[#c0c040]">
+              📋 {tileCopyBuffer.w}×{tileCopyBuffer.h} {tileCopyBuffer.layerType.toUpperCase()}
+              {pastePending ? ' — PASTE MODE (click to stamp · Esc to cancel)' : ' — Ctrl+V to paste'}
+            </span>
+          )}
+          {tileSelection && !tileCopyBuffer && (
+            <span className="text-xs font-mono text-[#80b0ff]">
+              ⬚ {tileSelection.tx2 - tileSelection.tx1 + 1}×{tileSelection.ty2 - tileSelection.ty1 + 1} sel — Ctrl+C to copy
+            </span>
+          )}
         </div>
       </div>
 

--- a/web/admin/app/designer/page.tsx
+++ b/web/admin/app/designer/page.tsx
@@ -219,8 +219,16 @@ export default function DesignerPage() {
     if (e.target.files?.length) loadFiles(e.target.files);
   };
 
-  const handleOpenSil = (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (e.target.files?.[0]) openMap(e.target.files[0]).then(() => requestAnimationFrame(fitToScreen));
+  const handleOpenSil = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (!e.target.files?.[0]) return;
+    const loaded = await openMap(e.target.files[0]);
+    if (!loaded) return;
+    const container = document.getElementById('canvas-container');
+    if (!container) return;
+    const { width: cw, height: ch } = container.getBoundingClientRect();
+    const newZoom = Math.min(cw / (loaded.width * 64), ch / (loaded.height * 64)) * 0.95;
+    setZoom(newZoom);
+    setPan({ x: (cw - loaded.width * 64 * newZoom) / 2, y: (ch - loaded.height * 64 * newZoom) / 2 });
   };
 
   const handleTilePaint = useCallback((layerType: 'bg' | 'fg', layerIdx: number, tx: number, ty: number, tileId: number) => {

--- a/web/admin/app/designer/page.tsx
+++ b/web/admin/app/designer/page.tsx
@@ -51,8 +51,12 @@ export default function DesignerPage() {
 
   type TileSel = { tx1: number; ty1: number; tx2: number; ty2: number; layerType: 'bg' | 'fg'; layerIdx: number };
   type TileCell = { tile_id: number; flip: number; lum: number };
-  // All 4 layers stored: bg[0], bg[1], fg[0], fg[1] — each is a flat w*h array
-  type TileCopyBuf = { w: number; h: number; layers: [TileCell[], TileCell[], TileCell[], TileCell[]] };
+  // All 8 layers: bg[0..3] and fg[0..3], each a flat w*h array
+  type TileCopyBuf = {
+    w: number; h: number;
+    bg: [TileCell[], TileCell[], TileCell[], TileCell[]];
+    fg: [TileCell[], TileCell[], TileCell[], TileCell[]];
+  };
 
   const [activeTool, setActiveTool]     = useState('TILE_BG');
   const [activeLayer, setActiveLayer]   = useState(0);
@@ -220,11 +224,17 @@ export default function DesignerPage() {
         };
         setTileCopyBuffer({
           w, h,
-          layers: [
+          bg: [
             extractLayer(m.layers.bg[0]),
             extractLayer(m.layers.bg[1]),
+            extractLayer(m.layers.bg[2]),
+            extractLayer(m.layers.bg[3]),
+          ],
+          fg: [
             extractLayer(m.layers.fg[0]),
             extractLayer(m.layers.fg[1]),
+            extractLayer(m.layers.fg[2]),
+            extractLayer(m.layers.fg[3]),
           ],
         });
         setPastePending(false);
@@ -320,17 +330,11 @@ export default function DesignerPage() {
 
   const handleTilePaste = useCallback((tx: number, ty: number) => {
     if (!tileCopyBuffer || !map) return;
-    const { w, h, layers } = tileCopyBuffer;
-    const layerDefs: Array<{ layerType: 'bg' | 'fg'; layerIdx: number }> = [
-      { layerType: 'bg', layerIdx: 0 },
-      { layerType: 'bg', layerIdx: 1 },
-      { layerType: 'fg', layerIdx: 0 },
-      { layerType: 'fg', layerIdx: 1 },
+    const { w, bg, fg } = tileCopyBuffer;
+    const patches = [
+      ...bg.map((cells, li) => ({ layerType: 'bg' as const, layerIdx: li, updates: cells.map((t, i) => ({ x: tx + (i % w), y: ty + Math.floor(i / w), ...t })) })),
+      ...fg.map((cells, li) => ({ layerType: 'fg' as const, layerIdx: li, updates: cells.map((t, i) => ({ x: tx + (i % w), y: ty + Math.floor(i / w), ...t })) })),
     ];
-    const patches = layerDefs.map(({ layerType, layerIdx }, li) => ({
-      layerType, layerIdx,
-      updates: layers[li].map((t, i) => ({ x: tx + (i % w), y: ty + Math.floor(i / w), ...t })),
-    }));
     applyAllLayersBatch(patches);
   }, [tileCopyBuffer, map, applyAllLayersBatch]);
 

--- a/web/admin/app/designer/page.tsx
+++ b/web/admin/app/designer/page.tsx
@@ -220,7 +220,7 @@ export default function DesignerPage() {
   };
 
   const handleOpenSil = (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (e.target.files?.[0]) openMap(e.target.files[0]);
+    if (e.target.files?.[0]) openMap(e.target.files[0]).then(() => requestAnimationFrame(fitToScreen));
   };
 
   const handleTilePaint = useCallback((layerType: 'bg' | 'fg', layerIdx: number, tx: number, ty: number, tileId: number) => {
@@ -396,6 +396,7 @@ export default function DesignerPage() {
                     if (!w || !h || w < 1 || h < 1 || w > 512 || h > 512) return;
                     createMap(w, h, newMapDesc);
                     setShowNewMap(false);
+                    requestAnimationFrame(fitToScreen);
                   }}
                     className="flex-1 py-1 text-xs font-mono border border-game-primary text-game-primary rounded hover:bg-game-dark transition-colors">
                     CREATE

--- a/web/admin/app/designer/page.tsx
+++ b/web/admin/app/designer/page.tsx
@@ -25,6 +25,7 @@ interface VisState {
   actors: boolean;
   grid: boolean;
   lighting: boolean;
+  parallax: boolean;
 }
 
 interface ActorMenu {
@@ -78,6 +79,7 @@ export default function DesignerPage() {
     actors: true,
     grid: true,
     lighting: true,
+    parallax: true,
   });
   const [gridSize, setGridSize] = useState(16);
   const toggleVis = (key: keyof VisState, idx: number | null = null) => setVis(v => {
@@ -665,6 +667,7 @@ export default function DesignerPage() {
             header={map.header}
             onUpdate={updateHeader}
             onClose={() => setShowProps(false)}
+            spriteImages={spriteImages}
           />
         )}
 
@@ -690,7 +693,7 @@ export default function DesignerPage() {
                 </button>
               ))}
               <span className="text-[#1a3a1a] text-xs mx-0.5">|</span>
-              {([['PLT','platforms'],['ACT','actors'],['GRID','grid'],['LIGHT','lighting']] as [string, keyof VisState][]).map(([lbl, key]) => (
+              {([['PLT','platforms'],['ACT','actors'],['PARA','parallax'],['GRID','grid'],['LIGHT','lighting']] as [string, keyof VisState][]).map(([lbl, key]) => (
                 <button key={key} onClick={() => toggleVis(key)}
                   className={`px-1.5 py-0.5 text-xs font-mono rounded border ${vis[key] ? 'border-[#3a3a2a] text-[#c0c080] bg-[#1a1a0d]' : 'border-[#1a1a1a] text-[#3a3a3a] bg-transparent line-through'}`}>
                   {lbl}

--- a/web/admin/app/designer/useGameData.ts
+++ b/web/admin/app/designer/useGameData.ts
@@ -22,13 +22,25 @@ function getPalette(palBytes: Uint8Array, palIndex: number): Uint8Array {
   return pal;
 }
 
+// Parallax palette index for banks 0-4 (matches C++ SetParallaxColors)
+const PARALLAX_PALETTE_IDX: Record<number, number> = { 0: 5, 1: 6, 2: 7, 3: 8, 4: 9 };
+
+// C++ SetParallaxColors only overrides the last 30 entries (226-255) of palette 0.
+// Replicate that: base = palette 0, override 226-255 with the parallax palette.
+function getParallaxHybridPalette(palBytes: Uint8Array, parallaxBank: number): Uint8Array {
+  const pal = getPalette(palBytes, 0);
+  const parallaxPalIdx = PARALLAX_PALETTE_IDX[parallaxBank];
+  const src = getPalette(palBytes, parallaxPalIdx);
+  for (let i = 226; i < 256; i++) {
+    pal[i * 3]     = src[i * 3];
+    pal[i * 3 + 1] = src[i * 3 + 1];
+    pal[i * 3 + 2] = src[i * 3 + 2];
+  }
+  return pal;
+}
+
 function spritePaletteIndex(bankNum: number): number {
   switch (bankNum) {
-    case 0: return 5;
-    case 1: return 6;
-    case 2: return 7;
-    case 3: return 8;
-    case 4: return 9;
     case 6: return 1;
     case 7: return 2;
     default: return 0;
@@ -247,8 +259,9 @@ async function processData(
     const spriteCount = binSprBytes![bankNum * 64 + 2];
     const handle = sprFileMap.get(bankNum)!;
     const bankData = await readFn(handle);
-    const palIdx = spritePaletteIndex(bankNum);
-    const pal = getPalette(palBytes, palIdx);
+    const pal = (bankNum in PARALLAX_PALETTE_IDX)
+      ? getParallaxHybridPalette(palBytes, bankNum)
+      : getPalette(palBytes, spritePaletteIndex(bankNum));
     const sprites = await loadSpriteBank(bankData, bankNum, spriteCount, pal);
     spriteImages.set(bankNum, sprites);
     setProgress({ total: totalSteps, done: tileBankNums.length + fi + 1 });

--- a/web/admin/app/designer/useGameData.ts
+++ b/web/admin/app/designer/useGameData.ts
@@ -4,6 +4,7 @@ import { ACTOR_DEFS } from './Toolbar';
 import type { SpriteEntry } from '../../lib/types';
 
 const NEEDED_SPRITE_BANKS = new Set([
+  0, 1, 2, 3, 4, // parallax backgrounds
   ...ACTOR_DEFS.map(a => a.bank).filter((b): b is number => b != null),
   184,
   200, 201, 205,
@@ -27,6 +28,7 @@ function spritePaletteIndex(bankNum: number): number {
     case 1: return 6;
     case 2: return 7;
     case 3: return 8;
+    case 4: return 9;
     case 6: return 1;
     case 7: return 2;
     default: return 0;

--- a/web/admin/app/designer/useSilMap.ts
+++ b/web/admin/app/designer/useSilMap.ts
@@ -134,6 +134,7 @@ export interface UseSilMapReturn {
   updateTile: (layerType: 'bg' | 'fg', layerIdx: number, x: number, y: number, tile_id: number, flip?: number, lum?: number) => void;
   patchTile: (layerType: 'bg' | 'fg', layerIdx: number, x: number, y: number, patch: Partial<TileCell>) => void;
   applyTileBatch: (layerType: 'bg' | 'fg', layerIdx: number, updates: Array<{ x: number; y: number; tile_id: number; flip: number; lum: number }>) => void;
+  applyAllLayersBatch: (patches: Array<{ layerType: 'bg' | 'fg'; layerIdx: number; updates: Array<{ x: number; y: number; tile_id: number; flip: number; lum: number }> }>) => void;
   beginPaint: () => void;
   commitPaint: () => void;
   addPlatform: (platform: MapPlatform) => void;
@@ -510,6 +511,27 @@ export function useSilMap(): UseSilMapReturn {
     });
   }, [pushHistory]);
 
+  const applyAllLayersBatch = useCallback((
+    patches: Array<{ layerType: 'bg' | 'fg'; layerIdx: number; updates: Array<{ x: number; y: number; tile_id: number; flip: number; lum: number }> }>
+  ) => {
+    setMapData(prev => {
+      if (!prev) return prev;
+      pushHistory(prev);
+      const { width, height } = prev;
+      let newBg = prev.layers.bg.map(l => l.slice());
+      let newFg = prev.layers.fg.map(l => l.slice());
+      for (const { layerType, layerIdx, updates } of patches) {
+        const arr = layerType === 'fg' ? newFg : newBg;
+        for (const { x, y, tile_id, flip, lum } of updates) {
+          if (x >= 0 && x < width && y >= 0 && y < height)
+            arr[layerIdx][y * width + x] = { tile_id, flip, lum };
+        }
+        if (layerType === 'fg') newFg = arr; else newBg = arr;
+      }
+      return { ...prev, layers: { bg: newBg as typeof prev.layers.bg, fg: newFg as typeof prev.layers.fg } };
+    });
+  }, [pushHistory]);
+
   const patchTile = useCallback((layerType: 'bg' | 'fg', layerIdx: number, x: number, y: number, patch: Partial<TileCell>) => {
     setMapData(prev => {
       if (!prev) return prev;
@@ -638,7 +660,7 @@ export function useSilMap(): UseSilMapReturn {
 
   return {
     map: mapData, openMap, saveMap, publishMap, createMap,
-    updateTile, patchTile, applyTileBatch, beginPaint, commitPaint,
+    updateTile, patchTile, applyTileBatch, applyAllLayersBatch, beginPaint, commitPaint,
     addPlatform, removePlatform, updatePlatform,
     addActor, removeActor, updateActor, moveActor,
     updateHeader,

--- a/web/admin/app/designer/useSilMap.ts
+++ b/web/admin/app/designer/useSilMap.ts
@@ -133,6 +133,7 @@ export interface UseSilMapReturn {
   createMap: (width: number, height: number, description: string) => void;
   updateTile: (layerType: 'bg' | 'fg', layerIdx: number, x: number, y: number, tile_id: number, flip?: number, lum?: number) => void;
   patchTile: (layerType: 'bg' | 'fg', layerIdx: number, x: number, y: number, patch: Partial<TileCell>) => void;
+  applyTileBatch: (layerType: 'bg' | 'fg', layerIdx: number, updates: Array<{ x: number; y: number; tile_id: number; flip: number; lum: number }>) => void;
   beginPaint: () => void;
   commitPaint: () => void;
   addPlatform: (platform: MapPlatform) => void;
@@ -489,6 +490,26 @@ export function useSilMap(): UseSilMapReturn {
     });
   }, [pushHistory]);
 
+  const applyTileBatch = useCallback((
+    layerType: 'bg' | 'fg', layerIdx: number,
+    updates: Array<{ x: number; y: number; tile_id: number; flip: number; lum: number }>
+  ) => {
+    setMapData(prev => {
+      if (!prev) return prev;
+      pushHistory(prev);
+      const { width, height, layers } = prev;
+      const srcArr = layerType === 'fg' ? layers.fg : layers.bg;
+      const newArr = srcArr.map((l, i) => i === layerIdx ? l.slice() : l);
+      for (const { x, y, tile_id, flip, lum } of updates) {
+        if (x >= 0 && x < width && y >= 0 && y < height)
+          newArr[layerIdx][y * width + x] = { tile_id, flip, lum };
+      }
+      return { ...prev, layers: layerType === 'fg'
+        ? { bg: layers.bg, fg: newArr }
+        : { bg: newArr, fg: layers.fg } };
+    });
+  }, [pushHistory]);
+
   const patchTile = useCallback((layerType: 'bg' | 'fg', layerIdx: number, x: number, y: number, patch: Partial<TileCell>) => {
     setMapData(prev => {
       if (!prev) return prev;
@@ -617,7 +638,7 @@ export function useSilMap(): UseSilMapReturn {
 
   return {
     map: mapData, openMap, saveMap, publishMap, createMap,
-    updateTile, patchTile, beginPaint, commitPaint,
+    updateTile, patchTile, applyTileBatch, beginPaint, commitPaint,
     addPlatform, removePlatform, updatePlatform,
     addActor, removeActor, updateActor, moveActor,
     updateHeader,

--- a/web/admin/app/designer/useSilMap.ts
+++ b/web/admin/app/designer/useSilMap.ts
@@ -127,7 +127,7 @@ export function platformTypeNums(typeName: string): [number, number] {
 
 export interface UseSilMapReturn {
   map: SilMapData | null;
-  openMap: (file: File) => Promise<void>;
+  openMap: (file: File) => Promise<SilMapData | null>;
   saveMap: () => Promise<void>;
   publishMap: (opts: { author: string; apiUrl: string; apiKey: string }) => Promise<{ ok: boolean; meta?: Record<string, unknown>; error?: string }>;
   createMap: (width: number, height: number, description: string) => void;
@@ -217,7 +217,7 @@ export function useSilMap(): UseSilMapReturn {
   }, []);
 
 
-  const openMap = useCallback(async (file: File) => {
+  const openMap = useCallback(async (file: File): Promise<SilMapData | null> => {
     try {
       const buf = await file.arrayBuffer();
       const bytes = new Uint8Array(buf);
@@ -239,10 +239,13 @@ export function useSilMap(): UseSilMapReturn {
       historyRef.current = [];
       futureRef.current = [];
       syncUndoRedo();
-      setMapData({ header, width, height, layers, actors, platforms, rawMinimap, minimapCompressedSize, fileName: file.name });
+      const loaded: SilMapData = { header, width, height, layers, actors, platforms, rawMinimap, minimapCompressedSize, fileName: file.name };
+      setMapData(loaded);
+      return loaded;
     } catch (e) {
       console.error('Failed to open SIL map:', e);
       alert('Failed to parse map: ' + (e as Error).message);
+      return null;
     }
   }, []);
 


### PR DESCRIPTION
## Summary

This PR started as snap-to-grid for actors/platforms but grew into a comprehensive map designer overhaul. Everything needed to create and edit maps for the game is now in the designer.

## Features Added

### Grid & Snap
- Snap-to-grid for actor and platform placement (configurable: 8/16/32/64 units)
- Grid size selector appears in the vis row when grid is enabled

### Background & Visuals
- Parallax background rendering with correct sprite bank + palette loading
- Background stretched to full map extent (no tiling)
- Visual background picker showing actual sprite preview
- X/Y axis gizmo on selected actors and platforms
- Marching-ants selection outline for actors

### Actor Editing
- Actor search/filter in the toolbar
- Cycle through stacked actors at the same position
- Facing direction: render flip + F key toggle
- All actor properties now match what the game actually reads:
  - Guard type, patrol/sleep/robot behavior, match ID, security ID
  - Tech Station types (0=A, 1=B, 2=C linked to surveillance monitor)
  - Removed unused fields (subplane, actor 60 camera focus)
  - Removed robot from facing direction (game never reads it)
  - Security ID dropdown with labels, ambience slider with live brightness

### Auto Fit on Map Load
- Map auto-fits to viewport on open and on new map create
- Fixed timing bug: uses `fitPendingRef` + `useEffect([map])` + `requestAnimationFrame` to guarantee correct container dimensions

### Tile Copy / Paste
- **TILE SELECT** tool: drag a rectangle to select a region
- **Ctrl+C** copies all 8 tile layers (bg[0..3] + fg[0..3]) for the selection
- **Ctrl+V** enters paste mode — hover shows composite preview with correct flip rendering, click to stamp (multi-stamp stays active, Esc cancels)
- Paste writes all 8 layers in a single undo entry (`applyAllLayersBatch`)
- Status bar shows selection size and paste mode hint

### Flood Fill Tool
- **FLOOD FILL** tool (🪣, shortcut: `i`): click any tile to BFS 4-connected fill all touching cells with the same tile ID on the active layer
- Entire fill is a single undo entry

## Files Changed

- `web/admin/app/designer/page.tsx` — orchestrator: all state, shortcuts, callbacks
- `web/admin/app/designer/MapCanvas.tsx` — canvas renderer: all mouse/draw/overlay logic
- `web/admin/app/designer/useSilMap.ts` — map state: `applyTileBatch`, `applyAllLayersBatch`, `patchTile`
- `web/admin/app/designer/Toolbar.tsx` — tool definitions, actor defs, type hints
- `web/admin/app/designer/ActorContextMenu.tsx` — actor property panel

## Build

`bun run build` passes clean with no type errors.