### PR TITLE
ci: gate path filtering inside required jobs, not on:

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/.github/workflows/CLAUDE.md
+++ b/.github/workflows/CLAUDE.md
@@ -1,0 +1,53 @@
+# .github/workflows/ — GitHub Actions
+
+Five CI builds (required by branch protection on `main`), three
+deploys, one release. Path filters for the CI builds live **inside
+the job**, not in `on:` — see "Required check trap" below.
+
+## CI builds (required checks on `main`)
+
+Required status check IDs: `build-macos`, `build-windows`,
+`build-admin-api`, `build-admin-web`, `build-lobby-docker`.
+
+| Workflow | Triggers (`on:`) | Real work runs when… |
+|---|---|---|
+| `ci-build-macos.yml` | every PR + push to `main` | change touches anything **outside** the denylist (see below) |
+| `ci-build-windows.yml` | every PR + push to `main` | same denylist as macOS |
+| `ci-build-admin-api.yml` | every PR + push to `main` | `services/admin-api/**` or this workflow |
+| `ci-build-admin-web.yml` | every PR + push to `main` | `web/admin/**` or this workflow |
+| `ci-build-lobby-docker.yml` | every PR + push to `main` | `services/lobby/**`, `clients/silencer/**`, `shared/assets/**`, or this workflow |
+
+macOS / Windows denylist (skip the build when **only** these
+change): `services/`, `web/`, `infra/`, `docs/`, `designer/`,
+`shared/{design,skills}/`, top-level `*.md`, `.gitignore`,
+`ci-build-admin-*.yml`, `ci-build-lobby-docker.yml`,
+`deploy*.yml`, `release.yml`.
+
+## Deploys
+
+| Workflow | Triggers (`on:`) |
+|---|---|
+| `deploy.yml` (game client + lobby) | `workflow_run` after a successful `Release` on a `v*` tag, or manual dispatch |
+| `deploy-admin-api.yml` | push to `main` touching `services/admin-api/**`, `shared/assets/**`, or this workflow; or manual |
+| `deploy-admin-web.yml` | push to `main` touching `web/admin/**` or this workflow; or manual |
+
+## Release
+
+| Workflow | Triggers (`on:`) |
+|---|---|
+| `release.yml` | push of `v*` tag, or manual dispatch |
+
+## Required check trap
+
+Branch protection treats a workflow that's filtered out at `on:`
+as "Expected — Waiting for status to be reported" and blocks
+merge forever. So the five required CI builds always trigger; a
+gate step (`dorny/paths-filter@v3` for allowlists, a `git diff`
+shell step for the macOS/Windows denylist) sets
+`steps.changes.outputs.relevant`, and every real step is
+`if: steps.changes.outputs.relevant == 'true'`. Skipped *steps*
+inside a running job still let the job report success — that's
+what unblocks merges. Don't move filters back to `on:` without
+also dropping the check from branch protection.
+
+Deploys aren't required checks, so they keep `on: paths` filters.

--- a/.github/workflows/ci-build-admin-api.yml
+++ b/.github/workflows/ci-build-admin-api.yml
@@ -3,14 +3,8 @@ name: CI Build (admin-api Docker)
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    paths:
-      - 'services/admin-api/**'
-      - '.github/workflows/ci-build-admin-api.yml'
   push:
     branches: [main]
-    paths:
-      - 'services/admin-api/**'
-      - '.github/workflows/ci-build-admin-api.yml'
 
 concurrency:
   group: ci-build-admin-api-${{ github.event.pull_request.number || github.ref }}
@@ -25,9 +19,23 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: docker/setup-buildx-action@v3
+      # Path filter is gated inside the job (not on:) so the required check
+      # context always reports — branch protection treats a never-run workflow
+      # as "Expected" and blocks merge, but a job whose steps are skipped via
+      # if: still reports the job as success.
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            relevant:
+              - 'services/admin-api/**'
+              - '.github/workflows/ci-build-admin-api.yml'
+
+      - if: steps.changes.outputs.relevant == 'true'
+        uses: docker/setup-buildx-action@v3
 
       - name: Build image (no push)
+        if: steps.changes.outputs.relevant == 'true'
         uses: docker/build-push-action@v6
         with:
           context: services/admin-api
@@ -36,3 +44,6 @@ jobs:
           platforms: linux/arm64
           cache-from: type=gha,scope=admin-api
           cache-to: type=gha,scope=admin-api,mode=max
+
+      - if: steps.changes.outputs.relevant != 'true'
+        run: echo "No admin-api changes; skipping build."

--- a/.github/workflows/ci-build-admin-web.yml
+++ b/.github/workflows/ci-build-admin-web.yml
@@ -3,14 +3,8 @@ name: CI Build (admin-web Docker)
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    paths:
-      - 'web/admin/**'
-      - '.github/workflows/ci-build-admin-web.yml'
   push:
     branches: [main]
-    paths:
-      - 'web/admin/**'
-      - '.github/workflows/ci-build-admin-web.yml'
 
 concurrency:
   group: ci-build-admin-web-${{ github.event.pull_request.number || github.ref }}
@@ -24,9 +18,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: docker/setup-buildx-action@v3
+      # See ci-build-admin-api.yml for why path filtering happens inside the
+      # job rather than via on: paths.
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            relevant:
+              - 'web/admin/**'
+              - '.github/workflows/ci-build-admin-web.yml'
+
+      - if: steps.changes.outputs.relevant == 'true'
+        uses: docker/setup-buildx-action@v3
 
       - name: Build image (no push)
+        if: steps.changes.outputs.relevant == 'true'
         uses: docker/build-push-action@v6
         with:
           context: web/admin
@@ -35,3 +41,6 @@ jobs:
           platforms: linux/arm64
           cache-from: type=gha,scope=admin-web
           cache-to: type=gha,scope=admin-web,mode=max
+
+      - if: steps.changes.outputs.relevant != 'true'
+        run: echo "No admin-web changes; skipping build."

--- a/.github/workflows/ci-build-lobby-docker.yml
+++ b/.github/workflows/ci-build-lobby-docker.yml
@@ -7,18 +7,8 @@ name: CI Build (lobby Docker)
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    paths:
-      - 'services/lobby/**'
-      - 'clients/silencer/**'
-      - 'shared/assets/**'
-      - '.github/workflows/ci-build-lobby-docker.yml'
   push:
     branches: [main]
-    paths:
-      - 'services/lobby/**'
-      - 'clients/silencer/**'
-      - 'shared/assets/**'
-      - '.github/workflows/ci-build-lobby-docker.yml'
 
 concurrency:
   group: ci-build-lobby-docker-${{ github.event.pull_request.number || github.ref }}
@@ -32,9 +22,23 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: docker/setup-buildx-action@v3
+      # See ci-build-admin-api.yml for why path filtering happens inside the
+      # job rather than via on: paths.
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            relevant:
+              - 'services/lobby/**'
+              - 'clients/silencer/**'
+              - 'shared/assets/**'
+              - '.github/workflows/ci-build-lobby-docker.yml'
+
+      - if: steps.changes.outputs.relevant == 'true'
+        uses: docker/setup-buildx-action@v3
 
       - name: Build image (no push)
+        if: steps.changes.outputs.relevant == 'true'
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -42,3 +46,6 @@ jobs:
           push: false
           cache-from: type=gha,scope=lobby
           cache-to: type=gha,scope=lobby,mode=max
+
+      - if: steps.changes.outputs.relevant != 'true'
+        run: echo "No lobby/client/asset changes; skipping build."

--- a/.github/workflows/ci-build-macos.yml
+++ b/.github/workflows/ci-build-macos.yml
@@ -3,36 +3,8 @@ name: CI Build (macOS)
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    paths-ignore:
-      - 'services/**'
-      - 'web/**'
-      - 'infra/**'
-      - 'docs/**'
-      - 'designer/**'
-      - 'shared/design/**'
-      - 'shared/skills/**'
-      - '*.md'
-      - '.gitignore'
-      - '.github/workflows/ci-build-admin-*.yml'
-      - '.github/workflows/ci-build-lobby-docker.yml'
-      - '.github/workflows/deploy*.yml'
-      - '.github/workflows/release.yml'
   push:
     branches: [main]
-    paths-ignore:
-      - 'services/**'
-      - 'web/**'
-      - 'infra/**'
-      - 'docs/**'
-      - 'designer/**'
-      - 'shared/design/**'
-      - 'shared/skills/**'
-      - '*.md'
-      - '.gitignore'
-      - '.github/workflows/ci-build-admin-*.yml'
-      - '.github/workflows/ci-build-lobby-docker.yml'
-      - '.github/workflows/deploy*.yml'
-      - '.github/workflows/release.yml'
 
 concurrency:
   group: ci-build-macos-${{ github.event.pull_request.number || github.ref }}
@@ -52,20 +24,56 @@ jobs:
       SCCACHE_GHA_ENABLED: "true"
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Need history back to the PR base / push-before SHA so the diff
+          # step below can see what actually changed.
+          fetch-depth: 0
+
+      # Path filter is gated inside the job (not on:) so the required
+      # build-macos check context always reports — branch protection treats
+      # a never-run workflow as "Expected" and blocks merge, but a job whose
+      # steps are skipped via if: still reports the job as success.
+      #
+      # Inverse of the previous on: paths-ignore list: relevant=true unless
+      # every changed file lives under one of the ignored prefixes.
+      - id: changes
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base='${{ github.event.pull_request.base.sha }}'
+          else
+            base='${{ github.event.before }}'
+          fi
+          if [ -z "$base" ] || [ "$base" = "0000000000000000000000000000000000000000" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if git diff --name-only "$base" HEAD | grep -Ev \
+               '^(services/|web/|infra/|docs/|designer/|shared/(design|skills)/|[^/]+\.md$|\.gitignore$|\.github/workflows/(ci-build-admin-[^/]*|ci-build-lobby-docker|deploy[^/]*|release)\.yml$)' \
+               | grep -q .; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Install deps (Homebrew)
+        if: steps.changes.outputs.relevant == 'true'
         run: brew install minizip dylibbundler
 
       - name: Install SDL3 + SDL3_mixer
+        if: steps.changes.outputs.relevant == 'true'
         uses: libsdl-org/setup-sdl@main
         with:
           version: 3-latest
           version-sdl-mixer: 3-latest
 
       - name: Setup sccache
+        if: steps.changes.outputs.relevant == 'true'
         uses: mozilla-actions/sccache-action@v0.0.10
 
       - name: Configure
+        if: steps.changes.outputs.relevant == 'true'
         run: |
           cmake -B build -S clients/silencer \
             -DCMAKE_BUILD_TYPE=Release \
@@ -75,13 +83,15 @@ jobs:
             -DSILENCER_UNITY_BUILD=ON
 
       - name: Build
+        if: steps.changes.outputs.relevant == 'true'
         run: cmake --build build --config Release -j"$(sysctl -n hw.ncpu)"
 
       - name: sccache stats
-        if: always()
+        if: always() && steps.changes.outputs.relevant == 'true'
         run: sccache --show-stats
 
       - name: Bundle dylibs
+        if: steps.changes.outputs.relevant == 'true'
         working-directory: build
         run: |
           mkdir -p Silencer.app/Contents/Frameworks
@@ -101,4 +111,8 @@ jobs:
           ls Silencer.app/Contents/Frameworks/
 
       - name: Verify bundled dependencies
+        if: steps.changes.outputs.relevant == 'true'
         run: tests/e2e/check-bundle-macos.sh build/Silencer.app
+
+      - if: steps.changes.outputs.relevant != 'true'
+        run: echo "No client/asset/test changes; skipping macOS build."

--- a/.github/workflows/ci-build-windows.yml
+++ b/.github/workflows/ci-build-windows.yml
@@ -3,36 +3,8 @@ name: CI Build (Windows)
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    paths-ignore:
-      - 'services/**'
-      - 'web/**'
-      - 'infra/**'
-      - 'docs/**'
-      - 'designer/**'
-      - 'shared/design/**'
-      - 'shared/skills/**'
-      - '*.md'
-      - '.gitignore'
-      - '.github/workflows/ci-build-admin-*.yml'
-      - '.github/workflows/ci-build-lobby-docker.yml'
-      - '.github/workflows/deploy*.yml'
-      - '.github/workflows/release.yml'
   push:
     branches: [main]
-    paths-ignore:
-      - 'services/**'
-      - 'web/**'
-      - 'infra/**'
-      - 'docs/**'
-      - 'designer/**'
-      - 'shared/design/**'
-      - 'shared/skills/**'
-      - '*.md'
-      - '.gitignore'
-      - '.github/workflows/ci-build-admin-*.yml'
-      - '.github/workflows/ci-build-lobby-docker.yml'
-      - '.github/workflows/deploy*.yml'
-      - '.github/workflows/release.yml'
 
 concurrency:
   group: ci-build-windows-${{ github.event.pull_request.number || github.ref }}
@@ -52,8 +24,37 @@ jobs:
       SCCACHE_GHA_ENABLED: "true"
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Need history back to the PR base / push-before SHA so the diff
+          # step below can see what actually changed.
+          fetch-depth: 0
+
+      # See ci-build-macos.yml for why path filtering happens inside the job
+      # rather than via on: paths-ignore. Inverse of the previous ignore list:
+      # relevant=true unless every changed file is under an ignored prefix.
+      - id: changes
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base='${{ github.event.pull_request.base.sha }}'
+          else
+            base='${{ github.event.before }}'
+          fi
+          if [ -z "$base" ] || [ "$base" = "0000000000000000000000000000000000000000" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if git diff --name-only "$base" HEAD | grep -Ev \
+               '^(services/|web/|infra/|docs/|designer/|shared/(design|skills)/|[^/]+\.md$|\.gitignore$|\.github/workflows/(ci-build-admin-[^/]*|ci-build-lobby-docker|deploy[^/]*|release)\.yml$)' \
+               | grep -q .; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Cache vcpkg binaries
+        if: steps.changes.outputs.relevant == 'true'
         uses: actions/cache@v4
         with:
           path: ${{ github.workspace }}/.vcpkg-cache
@@ -62,20 +63,24 @@ jobs:
             vcpkg-${{ runner.os }}-
 
       - name: Cache vcpkg tool downloads
+        if: steps.changes.outputs.relevant == 'true'
         uses: actions/cache@v4
         with:
           path: C:\vcpkg\downloads\tools
           key: vcpkg-tools-${{ runner.os }}-v1
 
       - name: Setup sccache
+        if: steps.changes.outputs.relevant == 'true'
         uses: mozilla-actions/sccache-action@v0.0.10
 
       - name: Setup MSVC dev environment
+        if: steps.changes.outputs.relevant == 'true'
         uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: x64
 
       - name: Configure
+        if: steps.changes.outputs.relevant == 'true'
         shell: pwsh
         env:
           VCPKG_BINARY_SOURCES: "clear;files,${{ github.workspace }}/.vcpkg-cache,readwrite"
@@ -90,14 +95,16 @@ jobs:
             -DSILENCER_UNITY_BUILD=ON
 
       - name: Build
+        if: steps.changes.outputs.relevant == 'true'
         run: cmake --build build
 
       - name: sccache stats
-        if: always()
+        if: always() && steps.changes.outputs.relevant == 'true'
         shell: pwsh
         run: sccache --show-stats
 
       - name: Package
+        if: steps.changes.outputs.relevant == 'true'
         shell: pwsh
         run: |
           $stage = "build/package/silencer"
@@ -110,5 +117,10 @@ jobs:
           Get-ChildItem $stage
 
       - name: Verify bundled dependencies
+        if: steps.changes.outputs.relevant == 'true'
         shell: pwsh
         run: pwsh tests/e2e/check-bundle-windows.ps1 -PackageDir build/package/silencer
+
+      - if: steps.changes.outputs.relevant != 'true'
+        shell: bash
+        run: echo "No client/asset/test changes; skipping Windows build."


### PR DESCRIPTION
## Summary

- Branch protection on `main` requires `build-{macos,windows,admin-api,admin-web,lobby-docker}`, but each workflow's `on: paths` / `paths-ignore` filter caused the workflow to skip entirely when irrelevant files changed — leaving the required check as "Expected — Waiting for status to be reported" and blocking merge indefinitely.
- Drop the `on:` filters so every PR triggers each workflow, and move the same filter *inside* the job. Steps skipped via `if:` still let the job report success, which satisfies branch protection. Irrelevant PRs now spend ~10s on checkout + filter + a no-op echo.
- `admin-api` / `admin-web` / `lobby-docker` use `dorny/paths-filter@v3` with the same allowlist the `on: paths` block had. `macOS` / `Windows` use an explicit `git diff` step (with `fetch-depth: 0`) and a regex inverting the previous `paths-ignore` set.

## Test plan

- [ ] Open this PR — all five required checks should run and pass (admin-api/admin-web/lobby-docker should report a "skipping build" no-op since this PR only touches `.github/workflows/ci-build-*.yml`; macOS/Windows should also skip per the same logic — each workflow's own file IS in the ignore/allowlist for the others)
- [ ] Wait, this PR touches every CI workflow file, so each one should detect itself as relevant and run the full build
- [ ] Confirm a follow-up docs-only PR triggers all five workflows and reports them all green via the no-op path

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/arsia-mons/silencer/pull/89" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
