### PR TITLE
docs(plans): staging environment design

### DIFF
--- a/.github/workflows/CLAUDE.md
+++ b/.github/workflows/CLAUDE.md
@@ -35,6 +35,7 @@ these change): `services/`, `web/`, `infra/`, `docs/`, `designer/`,
 | `deploy.yml` (game client + lobby) | `workflow_run` after a successful `Release` on a `v*` tag, or manual dispatch |
 | `deploy-admin-api.yml` | push to `main` touching `services/admin-api/**`, `shared/assets/**`, root `package.json`, `bun.lock`, or this workflow; or manual |
 | `deploy-admin-web.yml` | push to `main` touching `web/admin/**`, `shared/gas-validation/**`, root `package.json`, `bun.lock`, or this workflow; or manual |
+| `deploy-staging.yml` (lobby + dedicated server + admin-api + admin-web → single-box staging) | every push to `main` (no path filter — staging mirrors the full stack); `concurrency.cancel-in-progress: false` coalesces queued runs to the newest commit |
 
 ## Release
 

--- a/.github/workflows/CLAUDE.md
+++ b/.github/workflows/CLAUDE.md
@@ -1,7 +1,7 @@
 # .github/workflows/ — GitHub Actions
 
 Six CI builds (five required by branch protection on `main`,
-`build-linux` optional until added), three deploys, one release.
+`build-linux` optional until added), four deploys, one release.
 Path filters for the CI builds live **inside the job**, not in
 `on:` — see "Required check trap" below.
 

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,228 @@
+name: Deploy staging
+
+# Redeploys the entire stack (lobby + dedicated server + admin-api +
+# admin-web) onto the single-box staging environment on every push to
+# main. Concurrency is the entire backpressure mechanism — see
+# docs/plans/2026-04-27-staging-environment.md for the truth-table.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-staging
+  cancel-in-progress: false
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 25
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Compute image refs
+        id: img
+        run: |
+          set -euo pipefail
+          OWNER="$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')"
+          SHORT="${GITHUB_SHA:0:8}"
+          API_IMAGE="ghcr.io/$OWNER/silencer-admin-api"
+          WEB_IMAGE="ghcr.io/$OWNER/silencer-admin-web"
+          # Staging tags are prefixed `staging-` so they never collide
+          # with prod's bare `<sha>` tags in the same registry.
+          echo "api_ref=$API_IMAGE:staging-$SHORT" >> "$GITHUB_OUTPUT"
+          echo "web_ref=$WEB_IMAGE:staging-$SHORT" >> "$GITHUB_OUTPUT"
+
+      # ---- Lobby + dedicated server (mirrors deploy.yml) ----------------
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+          cache-dependency-path: services/lobby/go.sum
+
+      - name: Install C++ build deps
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: cmake build-essential zlib1g-dev libcurl4-openssl-dev libminizip-dev patchelf
+          version: 2.0
+
+      - name: Install SDL3 + SDL3_mixer
+        id: setup-sdl
+        uses: libsdl-org/setup-sdl@main
+        with:
+          install-linux-dependencies: true
+          version: 3-latest
+          version-sdl-mixer: 3-latest
+
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1
+        with:
+          key: ${{ runner.os }}-${{ github.job }}-staging
+          max-size: 500M
+
+      - name: Build lobby server
+        working-directory: services/lobby
+        run: go build -trimpath -ldflags '-s -w' -o silencer-lobby .
+
+      - name: Build dedicated server (C++ / ARM64)
+        env:
+          # vars.STAGING_LOBBY_HOST is the DNS name (or EIP) devs build
+          # the client against. The same value is baked into the
+          # dedicated server so its self-reported address survives the
+          # client's inet_addr() handoff. Falls back to the public IP
+          # if the host variable isn't set yet.
+          LOBBY_HOST: ${{ vars.STAGING_LOBBY_HOST || vars.STAGING_LOBBY_PUBLIC_IP }}
+        run: |
+          set -euo pipefail
+          if [ -z "${LOBBY_HOST}" ]; then
+            echo "STAGING_LOBBY_HOST or STAGING_LOBBY_PUBLIC_IP repo variable must be set" >&2
+            exit 1
+          fi
+          mkdir -p build && cd build
+          cmake \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DSILENCER_UNITY_BUILD=ON \
+            -DSILENCER_LOBBY_HOST="${LOBBY_HOST}" \
+            ../clients/silencer
+          make -j"$(nproc)"
+
+      # Same SDL3 .so bundling pattern as deploy.yml — without this the
+      # dedicated-server subprocess fails to dlopen libSDL3_mixer.so.0
+      # at runtime and games never start.
+      - name: Bundle SDL3 libs with binary
+        env:
+          SDL3_ROOT: ${{ env.SDL3_ROOT }}
+          SDL3_MIXER_ROOT: ${{ env.SDL3_mixer_ROOT }}
+        run: |
+          set -euo pipefail
+          mkdir -p build/lib
+          cp -L "$SDL3_ROOT/lib/libSDL3.so.0" build/lib/
+          cp -L "$SDL3_MIXER_ROOT/lib/libSDL3_mixer.so.0" build/lib/
+          patchelf --set-rpath '$ORIGIN/lib' build/silencer
+          (cd build && LD_LIBRARY_PATH=lib ldd silencer | grep -E "SDL3|not found")
+
+      # ---- admin-api + admin-web Docker images (mirror deploy-admin-*.yml)
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build + push admin-api image (ARM64 native)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: services/admin-api/Dockerfile
+          push: true
+          platforms: linux/arm64
+          tags: ${{ steps.img.outputs.api_ref }}
+          cache-from: type=gha,scope=admin-api
+          cache-to: type=gha,scope=admin-api,mode=max
+
+      - name: Build + push admin-web image (ARM64 native)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: web/admin/Dockerfile
+          push: true
+          platforms: linux/arm64
+          tags: ${{ steps.img.outputs.web_ref }}
+          cache-from: type=gha,scope=admin-web
+          cache-to: type=gha,scope=admin-web,mode=max
+
+      # ---- Deploy ------------------------------------------------------
+
+      - name: Tailscale
+        run: |
+          curl -fsSL https://tailscale.com/install.sh | sh
+          sudo tailscale up \
+            --authkey='${{ secrets.TS_AUTHKEY }}' \
+            --hostname=gh-runner-${{ github.run_id }} \
+            --advertise-tags=tag:server
+
+      - name: Configure SSH
+        run: |
+          mkdir -p ~/.ssh
+          printf '%s\n' "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/deploy
+          chmod 600 ~/.ssh/deploy
+
+      - name: Deploy
+        env:
+          HOST: ${{ vars.STAGING_DEPLOY_HOST }}
+          SHA: ${{ github.sha }}
+          API_REF: ${{ steps.img.outputs.api_ref }}
+          WEB_REF: ${{ steps.img.outputs.web_ref }}
+        run: |
+          set -euo pipefail
+          if [ -z "${HOST}" ]; then
+            echo "STAGING_DEPLOY_HOST repo variable must be set" >&2
+            exit 1
+          fi
+          SHORT=${SHA:0:8}
+          STAGING_DIR=/tmp/silencer-$SHORT
+          RELEASE=/opt/silencer/releases/$SHORT
+          SSH_OPTS="-i ~/.ssh/deploy -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=~/.ssh/known_hosts"
+          SSH="ssh $SSH_OPTS ubuntu@$HOST"
+          SCP="scp $SSH_OPTS"
+
+          # 1. Lobby + dedicated server + assets via scp.
+          $SSH "mkdir -p $STAGING_DIR"
+          $SCP services/lobby/silencer-lobby ubuntu@$HOST:$STAGING_DIR/
+          $SCP build/silencer                ubuntu@$HOST:$STAGING_DIR/
+          $SCP -r build/lib                  ubuntu@$HOST:$STAGING_DIR/
+          $SCP -r shared/assets              ubuntu@$HOST:$STAGING_DIR/
+
+          # 2. Atomic swap + image-ref bumps + restart. The lobby unit's
+          #    ExecStart (including -public-addr) is already templated by
+          #    cloud-init from Terraform's `aws_eip.staging.public_ip`, so
+          #    no drop-in needed — the prod deploy.yml writes one because
+          #    its unit predates the templated -public-addr; we don't have
+          #    that baggage here.
+          $SSH bash -s "$API_REF" "$WEB_REF" "$SHORT" << 'REMOTE'
+          set -euo pipefail
+          API_REF="$1"
+          WEB_REF="$2"
+          SHORT="$3"
+          RELEASE=/opt/silencer/releases/$SHORT
+          STAGING_DIR=/tmp/silencer-$SHORT
+
+          sudo mkdir -p /opt/silencer/releases
+          sudo rm -rf "$RELEASE"
+          sudo mv "$STAGING_DIR" "$RELEASE"
+          sudo chmod +x "$RELEASE/silencer-lobby" "$RELEASE/silencer"
+          sudo ln -sfn "$RELEASE" /opt/silencer/current
+          sudo ln -sfn /opt/silencer/current/assets /usr/local/share/silencer
+
+          # Sync runtime assets dir for admin-api's /assets mount.
+          sudo mkdir -p /var/lib/silencer/assets
+          sudo cp -RL "$RELEASE/assets/." /var/lib/silencer/assets/
+
+          # Image refs.
+          echo "IMAGE=$API_REF" | sudo tee /etc/silencer/admin-api.image > /dev/null
+          echo "IMAGE=$WEB_REF" | sudo tee /etc/silencer/admin-web.image > /dev/null
+
+          sudo systemctl daemon-reload
+          sudo systemctl restart silencer-lobby silencer-admin-api silencer-admin-web
+
+          # Smoke checks. Lobby comes up first; admin units pull their
+          # images on first start so give them more time.
+          sleep 3
+          sudo systemctl is-active silencer-lobby
+          sleep 15
+          sudo systemctl is-active silencer-admin-api
+          sudo systemctl is-active silencer-admin-web
+          curl -sf http://127.0.0.1:24080/api/sprites/121/0 > /dev/null
+
+          # Prune to last 3 releases.
+          cd /opt/silencer/releases
+          ls -1t | tail -n +4 | xargs -r sudo rm -rf
+          REMOTE

--- a/docs/plans/2026-04-27-staging-environment.md
+++ b/docs/plans/2026-04-27-staging-environment.md
@@ -1,7 +1,7 @@
 # Staging Environment
 
-**Status:** Proposed
-**Date:** 2026-04-27
+**Status:** Approved
+**Date:** 2026-04-27 (revised 2026-05-03)
 
 ## Goal
 
@@ -23,34 +23,41 @@ of tag-driven prod releases.
 
 ## Architecture
 
-Single `t4g.micro` ARM64 box (`silencer-staging`) running every
-component as a systemd unit. No containers, no Cloudflare Tunnel, no
-separate stateful EBS volumes.
+Single `t4g.small` ARM64 box (`silencer-staging`) running every
+component on one host. **Same deployment shape as prod** — admin-api
+and admin-web run as `docker run --network host` from GHCR, lobby runs
+as a native systemd unit. The only structural simplifications versus
+prod are: one box instead of two, no separate stateful EBS volumes, no
+DLM snapshots, no Cloudflare Tunnel.
 
 | Component | Unit | Notes |
 |---|---|---|
 | `silencer-lobby` (Go) | systemd | Same binary as prod; spawns `silencer -s` per game |
-| `mongod` | apt | Default `cacheSizeGB: 0.25`, localhost-only |
+| `mongod` | apt | `cacheSizeGB: 0.25`, `bindIp: 127.0.0.1` (localhost only) |
 | `lavinmq` | apt | localhost-only |
-| `silencer-admin-api` | systemd (`bun run …`) | Native Bun, no Docker |
-| `silencer-admin-web` | systemd (`bun run …`) | Next.js standalone under Bun, no Docker |
-| `tailscaled` | apt | SSH for humans + GH Actions runner |
+| `silencer-admin-api` | systemd (`docker run`) | Same GHCR image flow as prod |
+| `silencer-admin-web` | systemd (`docker run`) | Same GHCR image flow as prod |
+| `tailscaled` | apt | SSH for humans + GH Actions runner; only path to admin-web :24000 |
 
 Mongo + LavinMQ data dirs live on the root volume — wiped on instance
-replacement, which is the intended recovery path. Realistic peak RAM
-with one active game ≈ ~650 MB on ~850 MB usable; no special tuning
-required (analysis in `docs/plans/2026-04-25-production-deployment-architecture.md`
-§ Sizing decisions, applied at staging traffic levels).
+replacement, which is the intended recovery path.
 
-An EIP is **required** (not optional) — see Developer access below.
-The lobby's `-public-addr` flag, which it hands clients during the
-dedicated-server handoff, must be a dotted-decimal IP because the C++
-join path uses `inet_addr()` not `getaddrinfo()` (`deploy.yml:223-225`
-documents the constraint). Without a stable IP, every instance
-replacement re-bakes every client binary built against staging.
+**Sizing rationale.** Prod's per-component RSS analysis (in
+`docs/plans/2026-04-25-production-deployment-architecture.md`) sums to
+~1.7 GB across the two prod boxes; collapsing both onto one staging box
+plus the lobby + dedicated subprocess lands ~1.0 GB resident, fitting
+comfortably on `t4g.small` (2 GB) but not `t4g.micro` (1 GB).
 
-Estimated monthly cost: **~$10.60** (t4g.micro $6 + ~16 GB gp3 root
-$1.30 + EIP $3.60, no snapshots, no second box).
+An EIP is **required** (not optional). The lobby's `-public-addr`
+flag, which it hands clients during the dedicated-server handoff, must
+be a dotted-decimal IP because the C++ join path uses `inet_addr()`
+not `getaddrinfo()` (`deploy.yml:222-227` documents the same
+constraint for prod). Without a stable IP, every instance replacement
+would re-bake every client binary built against staging.
+
+Estimated monthly cost: **~$18.30**
+(t4g.small $13.40 + ~16 GB gp3 root $1.30 + EIP $3.60, no snapshots,
+no second box).
 
 ## Deploy flow
 
@@ -92,59 +99,86 @@ Mirrors the shape of `deploy.yml` + `deploy-admin-api.yml` +
 `deploy-admin-web.yml`, collapsed into one job since staging has all
 four artifacts on one box:
 
-1. Build lobby (Go) and dedicated server (C++ / ARM64) — same as
-   prod's `deploy.yml`, but with `LOBBY_HOST=staging.<domain>` (or the
-   staging IP) baked into the dedicated-server build.
-2. Build admin-api and admin-web — `bun install --frozen-lockfile`,
-   `bun run build` for the Next.js app, tar the output trees. No
-   GHCR push (no Docker on staging).
-3. Tailscale up, SSH to `silencer-staging`, scp tarballs into
-   `/opt/silencer-staging/releases/<sha>/`, swap `current` symlink,
-   `systemctl restart silencer-lobby silencer-admin-api silencer-admin-web`.
-4. Prune to last 3 releases.
+1. **Build lobby** (Go) and **dedicated server** (C++ / ARM64) — same
+   as `deploy.yml`, but with `LOBBY_HOST=${{ vars.STAGING_LOBBY_HOST }}`
+   baked into the dedicated-server cmake invocation. SDL3 .so bundling
+   via `patchelf --set-rpath` is identical to prod.
+2. **Build + push admin-api** image to GHCR as
+   `ghcr.io/.../silencer-admin-api:staging-<sha>` (separate tag from
+   prod's `<sha>` so the registry stays untangled).
+3. **Build + push admin-web** image to GHCR as
+   `ghcr.io/.../silencer-admin-web:staging-<sha>`.
+4. **Deploy.** Tailscale up, SSH to `silencer-staging`, scp lobby +
+   dedicated server + assets, write `/etc/silencer/admin-api.image` and
+   `/etc/silencer/admin-web.image` with the new tags, restart all three
+   units, smoke-test.
+5. Prune to last 3 release directories on the box.
 
 No macOS / Windows client build — staging doesn't ship to end users.
 Tag-driven `release.yml` + `deploy.yml` remain prod's release path,
 unchanged.
 
-Total runtime estimate: ~5–8 min per deploy.
+**EIP plumbing.** The staging lobby's `-public-addr` is sourced from
+`vars.STAGING_LOBBY_PUBLIC_IP` (a GitHub repo variable populated from
+the `staging_lobby_ip` Terraform output after first apply). Prod
+hardcodes its EIP in `deploy.yml:227`'s systemd drop-in; staging keeps
+the value out of YAML so a different account / region can use the same
+workflow.
+
+Total runtime estimate: ~6–9 min per deploy (admin-api/web Docker
+builds dominate).
 
 ## Terraform
 
-Add a `single_box = true` mode to the existing `infra/terraform/`
-module that:
+Implemented as a **separate module** at `infra/terraform/staging/` —
+not a workspace + flag on the existing module. Two reasons:
 
-- Creates one `t4g.micro` instance instead of the prod two-box pair.
-- Skips `dlm.tf` (no snapshots).
-- Skips the separate Mongo / LavinMQ EBS volumes (root volume only).
-- Skips Cloudflare Tunnel ingress and the `cloudflared` install in
-  cloud-init.
-- Skips the GitHub-backed Mongo backup wiring.
+- The cloud-init template is meaningfully different (single box, all
+  services local, env vars point at `127.0.0.1` not internal DNS, no
+  Cloudflare Tunnel, no separate EBS mounts). Squeezing this into the
+  prod template via conditional logic would make every future prod
+  edit reason about staging side-effects.
+- Prod has `prevent_destroy = true` on the Mongo and LavinMQ EBS
+  volumes; flipping `single_box = true` on the prod state would make
+  apply refuse. Separate modules → zero shared state → zero
+  cross-contamination risk.
 
-State separated via `terraform workspace new staging`, same module.
+What the staging module contains:
 
-A new `cloud-init-staging.yaml.tftpl` borrows from the prod admin
-template but: installs everything on root, runs admin-api / admin-web
-as native `bun run` systemd units (not Docker), and puts the lobby on
-the same box.
+- `main.tf` — provider + VPC/subnet/AMI data sources (mirrors prod) +
+  one EC2 + EIP + SG + Route 53 A record (`staging.<domain>`, if
+  zone configured).
+- `iam.tf` — single instance role with read access to
+  `/silencer-staging/*` SSM params.
+- `ssm.tf` — apply-time data sources for one-shot values
+  (Tailscale auth key, deploy SSH pubkey, GHCR pull token).
+- `cloud-init-staging.yaml.tftpl` — bootstraps Mongo, LavinMQ, Docker,
+  the two admin systemd units, the lobby unit, and Tailscale.
+- `outputs.tf` — `staging_lobby_ip` (the EIP that goes into
+  `vars.STAGING_LOBBY_PUBLIC_IP`).
+- `backend.tf` + `backend.hcl.example` — its own S3 state key
+  (`staging.tfstate` in the same bucket bootstrapped for prod).
 
-Secrets namespaced under `/silencer-staging/*` in SSM — JWT secret,
-Mongo / LavinMQ passwords, Tailscale auth key all distinct from prod.
-SSH pubkeys can be shared.
+Secrets namespaced under `/silencer-staging/*` in SSM. SSH pubkeys
+(`/silencer/shared/{ssh_admin,deploy_ssh}_pubkey`) and GHCR pull token
+(`/silencer/admin/ghcr_pull_token`) are reused; everything else
+(Mongo/LavinMQ passwords, JWT secret, Tailscale auth key) is staging-
+specific and seeded by `seed-ssm.sh`.
 
 ## Data lifecycle
 
 Staging starts fresh on every instance replacement. `mongod`, `lavinmq`,
-and `lobby.json` all live on the root volume. Default admin seed
-(`admin/admin`) is recreated each rebuild. No backups.
+`lobby.json`, and the `/var/lib/silencer/assets/` tree all live on the
+root volume. Default admin seed (`admin/admin`) is recreated each
+rebuild. No backups, no `BACKUP_CRON`.
 
 ## Developer access
 
+### Game client
+
 `LOBBY_HOST` is baked into the client binary at build time
 (`clients/silencer` cmake variable `SILENCER_LOBBY_HOST`), so a stock
-prod client cannot reach staging. Two paths:
-
-**Default — local build.** Devs who already have the toolchain run:
+prod client cannot reach staging.
 
 ```sh
 cd clients/silencer
@@ -157,20 +191,17 @@ dedicated-server handoff still flows through the EIP directly (per the
 `inet_addr()` constraint in Architecture above), so DNS only matters
 for the lobby connection itself.
 
-**Opt-in — CI-built artifacts.** `deploy-staging.yml` accepts a
-`build_clients: true` `workflow_dispatch` input that adds Mac + Windows
-build jobs (mirroring `release.yml`'s shape but with
-`LOBBY_HOST=staging.<domain>`) and uploads the zips via
-`actions/upload-artifact`. Useful when a non-builder needs to playtest
-staging — adds ~10–15 min to the run, so it's off by default. macOS
-zips are unsigned; users `xattr -d com.apple.quarantine` before
-launching.
+### Admin dashboard
 
-The day-to-day staging loop (push → "did the lobby boot, do admin
-routes still work") is covered by Tailscale-only access to the admin
-dashboard plus the deploy workflow's own health checks; rebuilding the
-client only matters when validating real protocol or game-logic
-changes.
+admin-web binds `:24000` and admin-api binds `:24080`, both bound to
+`0.0.0.0`. Neither is reachable from the public internet — the SG only
+opens 22/517/30000-61000 — but both are reachable from anyone on the
+tailnet. Devs hit `http://<staging-tailscale-name>:24000` for the
+dashboard.
+
+This is plain HTTP. Auth flows that depend on `Secure`-only cookies
+will not work on staging; that's acceptable for a smoke-test
+environment, and matches how dev loops already work.
 
 ## Required checks / branch protection
 
@@ -178,9 +209,9 @@ changes.
 existing five (`build-macos`, `build-windows`, `build-admin-api`,
 `build-admin-web`, `build-lobby-docker`) remain the merge gates.
 
-## Open questions
+## Resolved questions
 
-1. **`lobby_version_string` for staging?** Setting a distinct value
-   (e.g. `"staging-<sha>"`) prevents a prod client from accidentally
-   connecting to the staging lobby. Worth doing if the staging lobby
-   is publicly reachable.
+- **`lobby_version_string` for staging?** No. The staging EIP isn't
+  published anywhere a prod client would discover (no DNS bootstrap
+  pointing at it, no `update.json` referencing it). The lockout adds
+  rebuild churn for negligible safety gain.

--- a/docs/plans/2026-04-27-staging-environment.md
+++ b/docs/plans/2026-04-27-staging-environment.md
@@ -42,8 +42,15 @@ with one active game ≈ ~650 MB on ~850 MB usable; no special tuning
 required (analysis in `docs/plans/2026-04-25-production-deployment-architecture.md`
 § Sizing decisions, applied at staging traffic levels).
 
-Estimated monthly cost: **~$7** (t4g.micro $6 + ~16 GB gp3 root $1.30,
-no EIP, no snapshots, no second box).
+An EIP is **required** (not optional) — see Developer access below.
+The lobby's `-public-addr` flag, which it hands clients during the
+dedicated-server handoff, must be a dotted-decimal IP because the C++
+join path uses `inet_addr()` not `getaddrinfo()` (`deploy.yml:223-225`
+documents the constraint). Without a stable IP, every instance
+replacement re-bakes every client binary built against staging.
+
+Estimated monthly cost: **~$10.60** (t4g.micro $6 + ~16 GB gp3 root
+$1.30 + EIP $3.60, no snapshots, no second box).
 
 ## Deploy flow
 
@@ -131,6 +138,40 @@ Staging starts fresh on every instance replacement. `mongod`, `lavinmq`,
 and `lobby.json` all live on the root volume. Default admin seed
 (`admin/admin`) is recreated each rebuild. No backups.
 
+## Developer access
+
+`LOBBY_HOST` is baked into the client binary at build time
+(`clients/silencer` cmake variable `SILENCER_LOBBY_HOST`), so a stock
+prod client cannot reach staging. Two paths:
+
+**Default — local build.** Devs who already have the toolchain run:
+
+```sh
+cd clients/silencer
+cmake -B build-staging -DSILENCER_LOBBY_HOST=staging.<domain>
+cmake --build build-staging -j
+```
+
+The `staging.<domain>` form resolves to the EIP via Route 53. The
+dedicated-server handoff still flows through the EIP directly (per the
+`inet_addr()` constraint in Architecture above), so DNS only matters
+for the lobby connection itself.
+
+**Opt-in — CI-built artifacts.** `deploy-staging.yml` accepts a
+`build_clients: true` `workflow_dispatch` input that adds Mac + Windows
+build jobs (mirroring `release.yml`'s shape but with
+`LOBBY_HOST=staging.<domain>`) and uploads the zips via
+`actions/upload-artifact`. Useful when a non-builder needs to playtest
+staging — adds ~10–15 min to the run, so it's off by default. macOS
+zips are unsigned; users `xattr -d com.apple.quarantine` before
+launching.
+
+The day-to-day staging loop (push → "did the lobby boot, do admin
+routes still work") is covered by Tailscale-only access to the admin
+dashboard plus the deploy workflow's own health checks; rebuilding the
+client only matters when validating real protocol or game-logic
+changes.
+
 ## Required checks / branch protection
 
 `deploy-staging.yml` is **not** added to required status checks. The
@@ -139,11 +180,7 @@ existing five (`build-macos`, `build-windows`, `build-admin-api`,
 
 ## Open questions
 
-1. **Domain name?** `staging.<domain>` (Route 53 A record) requires an
-   EIP (~$3.60/mo) for stable DNS across instance replacement.
-   Alternative: no DNS, use the bare public IP; rotates on rebuild but
-   fine for a small dev team that connects via Tailscale anyway.
-2. **`lobby_version_string` for staging?** Setting a distinct value
+1. **`lobby_version_string` for staging?** Setting a distinct value
    (e.g. `"staging-<sha>"`) prevents a prod client from accidentally
    connecting to the staging lobby. Worth doing if the staging lobby
    is publicly reachable.

--- a/docs/plans/2026-04-27-staging-environment.md
+++ b/docs/plans/2026-04-27-staging-environment.md
@@ -1,0 +1,149 @@
+# Staging Environment
+
+**Status:** Proposed
+**Date:** 2026-04-27
+
+## Goal
+
+A staging environment that mirrors the production stack (lobby +
+dedicated game servers + admin-api + admin-web + Mongo + LavinMQ) on one
+cheap box, redeployed automatically on every push to `main`. Validates
+that the full stack still builds, boots, and serves traffic — independent
+of tag-driven prod releases.
+
+## Non-goals
+
+- **Not load-tested.** 1 concurrent game is the assumed ceiling.
+- **Not durable.** Data is disposable; no backups, no DLM snapshots, no
+  separate EBS data volumes. A bad deploy is recovered by `terraform
+  taint`, not by restoring state.
+- **Not a merge gate.** Staging deploy failures don't block PRs; the
+  five existing CI builds remain the only required checks on `main`.
+- **Not for end users.** Game clients still point at prod's `LOBBY_HOST`.
+
+## Architecture
+
+Single `t4g.micro` ARM64 box (`silencer-staging`) running every
+component as a systemd unit. No containers, no Cloudflare Tunnel, no
+separate stateful EBS volumes.
+
+| Component | Unit | Notes |
+|---|---|---|
+| `silencer-lobby` (Go) | systemd | Same binary as prod; spawns `silencer -s` per game |
+| `mongod` | apt | Default `cacheSizeGB: 0.25`, localhost-only |
+| `lavinmq` | apt | localhost-only |
+| `silencer-admin-api` | systemd (`bun run …`) | Native Bun, no Docker |
+| `silencer-admin-web` | systemd (`bun run …`) | Next.js standalone under Bun, no Docker |
+| `tailscaled` | apt | SSH for humans + GH Actions runner |
+
+Mongo + LavinMQ data dirs live on the root volume — wiped on instance
+replacement, which is the intended recovery path. Realistic peak RAM
+with one active game ≈ ~650 MB on ~850 MB usable; no special tuning
+required (analysis in `docs/plans/2026-04-25-production-deployment-architecture.md`
+§ Sizing decisions, applied at staging traffic levels).
+
+Estimated monthly cost: **~$7** (t4g.micro $6 + ~16 GB gp3 root $1.30,
+no EIP, no snapshots, no second box).
+
+## Deploy flow
+
+One new workflow: `.github/workflows/deploy-staging.yml`.
+
+```yaml
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-staging
+  cancel-in-progress: false
+```
+
+That single concurrency block satisfies all three requirements:
+
+| Requirement | How it's met |
+|---|---|
+| Push to `main` triggers a deploy | `on.push.branches: [main]` |
+| New commits don't cancel an active deploy | `cancel-in-progress: false` |
+| Only the newest pending commit deploys after the active run | Built into GH Actions: when a run is queued behind an in-progress run, any *previously pending* run in the same group is canceled |
+
+Resulting behavior:
+
+- Commit A starts deploying.
+- Commit B lands → queued behind A.
+- Commit C lands → B is canceled in queue, C is now pending.
+- Commit D lands → C is canceled, D is pending.
+- A finishes → D starts. B and C are skipped entirely.
+
+No polling, no debounce script, no external queue — declared concurrency
+group is the entire mechanism.
+
+### What the workflow does
+
+Mirrors the shape of `deploy.yml` + `deploy-admin-api.yml` +
+`deploy-admin-web.yml`, collapsed into one job since staging has all
+four artifacts on one box:
+
+1. Build lobby (Go) and dedicated server (C++ / ARM64) — same as
+   prod's `deploy.yml`, but with `LOBBY_HOST=staging.<domain>` (or the
+   staging IP) baked into the dedicated-server build.
+2. Build admin-api and admin-web — `bun install --frozen-lockfile`,
+   `bun run build` for the Next.js app, tar the output trees. No
+   GHCR push (no Docker on staging).
+3. Tailscale up, SSH to `silencer-staging`, scp tarballs into
+   `/opt/silencer-staging/releases/<sha>/`, swap `current` symlink,
+   `systemctl restart silencer-lobby silencer-admin-api silencer-admin-web`.
+4. Prune to last 3 releases.
+
+No macOS / Windows client build — staging doesn't ship to end users.
+Tag-driven `release.yml` + `deploy.yml` remain prod's release path,
+unchanged.
+
+Total runtime estimate: ~5–8 min per deploy.
+
+## Terraform
+
+Add a `single_box = true` mode to the existing `infra/terraform/`
+module that:
+
+- Creates one `t4g.micro` instance instead of the prod two-box pair.
+- Skips `dlm.tf` (no snapshots).
+- Skips the separate Mongo / LavinMQ EBS volumes (root volume only).
+- Skips Cloudflare Tunnel ingress and the `cloudflared` install in
+  cloud-init.
+- Skips the GitHub-backed Mongo backup wiring.
+
+State separated via `terraform workspace new staging`, same module.
+
+A new `cloud-init-staging.yaml.tftpl` borrows from the prod admin
+template but: installs everything on root, runs admin-api / admin-web
+as native `bun run` systemd units (not Docker), and puts the lobby on
+the same box.
+
+Secrets namespaced under `/silencer-staging/*` in SSM — JWT secret,
+Mongo / LavinMQ passwords, Tailscale auth key all distinct from prod.
+SSH pubkeys can be shared.
+
+## Data lifecycle
+
+Staging starts fresh on every instance replacement. `mongod`, `lavinmq`,
+and `lobby.json` all live on the root volume. Default admin seed
+(`admin/admin`) is recreated each rebuild. No backups.
+
+## Required checks / branch protection
+
+`deploy-staging.yml` is **not** added to required status checks. The
+existing five (`build-macos`, `build-windows`, `build-admin-api`,
+`build-admin-web`, `build-lobby-docker`) remain the merge gates.
+
+## Open questions
+
+1. **Domain name?** `staging.<domain>` (Route 53 A record) requires an
+   EIP (~$3.60/mo) for stable DNS across instance replacement.
+   Alternative: no DNS, use the bare public IP; rotates on rebuild but
+   fine for a small dev team that connects via Tailscale anyway.
+2. **`lobby_version_string` for staging?** Setting a distinct value
+   (e.g. `"staging-<sha>"`) prevents a prod client from accidentally
+   connecting to the staging lobby. Worth doing if the staging lobby
+   is publicly reachable.

--- a/infra/scripts/seed-ssm.sh
+++ b/infra/scripts/seed-ssm.sh
@@ -166,6 +166,28 @@ if ! aws ssm get-parameter --region "$REGION" \
   put_param /silencer/admin/github_backup_token SecureString "${token:-}"
 fi
 
+# --- staging ----------------------------------------------------------
+# Single-box staging stack. Distinct passwords + JWT secret + Tailscale
+# auth key from prod so a leaked staging value can't reach into prod.
+# SSH pubkeys (/silencer/shared/*) and the GHCR pull token
+# (/silencer/admin/ghcr_pull_token) are reused from prod above.
+
+echo "==> /silencer-staging/*"
+
+put_param /silencer-staging/mongo_silencer_password   SecureString "$(gen_secret)"
+put_param /silencer-staging/lavinmq_silencer_password SecureString "$(gen_secret)"
+put_param /silencer-staging/jwt_secret                SecureString "$(gen_secret)"
+
+if ! aws ssm get-parameter --region "$REGION" \
+       --name /silencer-staging/tailscale_auth_key >/dev/null 2>&1 \
+   || [ "$OVERWRITE" -eq 1 ]; then
+  put_param /silencer-staging/tailscale_auth_key SecureString \
+    "$(prompt_secret 'staging Tailscale auth key (tag:server, reusable=no, ephemeral=no)')"
+else
+  put_param /silencer-staging/tailscale_auth_key SecureString "(unused)"
+fi
+
 echo
 echo "Done. Verify with:"
 echo "  aws ssm get-parameters-by-path --region $REGION --path /silencer --recursive --query 'Parameters[].Name'"
+echo "  aws ssm get-parameters-by-path --region $REGION --path /silencer-staging --recursive --query 'Parameters[].Name'"

--- a/infra/terraform/CLAUDE.md
+++ b/infra/terraform/CLAUDE.md
@@ -20,6 +20,15 @@ across instance replacement.
 > `docs/production.md`. This file covers the *why* of the Terraform
 > code; `docs/production.md` covers the *how* of running it.
 
+> **Staging** is a separate sibling module at `staging/` — one
+> `t4g.small` running everything as a single-box smoke-test
+> environment, redeployed on every push to `main`. See `staging/CLAUDE.md`
+> and `docs/plans/2026-04-27-staging-environment.md`. The two modules
+> share the same S3 state bucket / DynamoDB lock table (only the
+> state-file `key` differs) and the same SSH pubkeys + GHCR pull token;
+> everything else (Mongo / LavinMQ / JWT / Tailscale auth keys) is
+> separately namespaced under `/silencer-staging/*`.
+
 ## File layout
 
 - `bootstrap/` — creates the S3 bucket + DynamoDB lock table that hold

--- a/infra/terraform/staging/.terraform.lock.hcl
+++ b/infra/terraform/staging/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/infra/terraform/staging/AGENTS.md
+++ b/infra/terraform/staging/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/infra/terraform/staging/CLAUDE.md
+++ b/infra/terraform/staging/CLAUDE.md
@@ -1,0 +1,103 @@
+# infra/terraform/staging — single-box staging environment
+
+One `t4g.small` ARM64 box (`silencer-staging`) running every Silencer
+component on the same host. Redeploys on every push to `main` via
+`.github/workflows/deploy-staging.yml`. **Disposable** — no backups,
+no DLM snapshots, no separate stateful EBS volumes.
+
+Design and rationale: `docs/plans/2026-04-27-staging-environment.md`.
+Prod sibling: `../` (the parent directory).
+
+## Why a separate module instead of a workspace flag
+
+Two reasons. The cloud-init template is meaningfully different from
+prod's two-box layout (everything talks to `127.0.0.1`, no separate
+EBS volumes to wait for, no Cloudflare Tunnel) — squeezing it into the
+prod template behind a `single_box ?` ternary makes every prod edit
+reason about a code path that doesn't apply to it. And prod's
+`aws_ebs_volume.admin_{mongo,lavinmq}` have `prevent_destroy = true`,
+so a workspace flip would refuse to apply. Separate modules → zero
+shared state → zero cross-contamination risk.
+
+## Layout
+
+- `main.tf` — provider + VPC/subnet/AMI data + EC2 + EIP + SG + Route 53
+  A record (when `domain_name` + `route53_zone_id` set).
+- `iam.tf` — single instance role with read access to
+  `/silencer-staging/*` (Mongo / LavinMQ / JWT) and the prod-shared
+  `/silencer/admin/ghcr_pull_token`.
+- `ssm.tf` — apply-time data sources for the SSH pubkeys (shared with
+  prod) and the staging-specific Tailscale auth key.
+- `outputs.tf` — `staging_lobby_ip` (paste into `vars.STAGING_LOBBY_PUBLIC_IP`).
+- `cloud-init-staging.yaml.tftpl` — the substantive file. Installs
+  Mongo + LavinMQ + Docker, writes the three systemd units (lobby,
+  admin-api, admin-web), bootstraps the Mongo + LavinMQ users,
+  fetches secrets from SSM, joins Tailscale.
+- `backend.tf` + `backend.hcl.example` — uses the same S3 bucket /
+  DynamoDB lock table that prod's `bootstrap/` created; only the
+  state-file `key` differs (`silencer/staging.tfstate`).
+
+## First-time setup
+
+```sh
+cd infra/terraform/staging
+cp backend.hcl.example backend.hcl   # edit bucket name → matches prod
+cp terraform.tfvars.example terraform.tfvars  # set ssh_allowed_cidr
+terraform init -backend-config=backend.hcl
+terraform apply
+```
+
+After apply:
+
+1. Copy the `staging_lobby_ip` output into the GitHub repo variable
+   `STAGING_LOBBY_PUBLIC_IP` (the dedicated-server cmake build needs
+   it baked in; `inet_addr()` constraint on the C++ join path).
+2. Set `STAGING_DEPLOY_HOST` to the Tailscale name (default
+   `silencer-staging`).
+3. Optionally set `STAGING_LOBBY_HOST` to a DNS name pointing at the
+   EIP (the value devs will use with `cmake -DSILENCER_LOBBY_HOST=`).
+   If empty, the deploy workflow uses the EIP directly.
+4. First deploy: push to `main` (or run `deploy-staging.yml` manually).
+   Until it lands, the three units crash-loop quietly — same pattern
+   as prod's pre-first-deploy state.
+
+## Sharing with prod
+
+| Resource | Shared? | Why |
+|---|---|---|
+| S3 state bucket + DynamoDB lock table | yes | Bootstrapped once; only the state key differs |
+| `aws_key_pair.admin` | per-module | Same SSH pubkey, but distinct AWS key pair (different name prefix) so a `terraform destroy` here can't unmake the prod one |
+| SSH pubkeys (`/silencer/shared/{ssh_admin,deploy_ssh}_pubkey`) | yes | Same humans, same GH Actions deploy key |
+| Mongo / LavinMQ passwords | per-stage | Distinct so a leaked staging password can't authenticate to prod |
+| JWT secret | per-stage | Distinct so a forged staging token isn't accepted by prod |
+| Tailscale auth key | per-stage | Distinct so a leaked staging key can't enroll into prod's tailnet |
+| GHCR pull token (`/silencer/admin/ghcr_pull_token`) | yes | Read-only, repo-scoped — staging pulls the same images prod pulls (just a different tag prefix) |
+| Route 53 zones | independent | Staging gets `staging.<domain>` if configured; no shared internal zone |
+
+## What's intentionally NOT here
+
+- **No separate EBS volumes.** mongod, lavinmq, lobby.json, and
+  shared/assets all live on the root volume. Recovery from data
+  corruption = `terraform taint aws_instance.staging && terraform apply`.
+- **No DLM.** Staging has no snapshots — wiping is the recovery path.
+- **No Cloudflare Tunnel / public HTTPS.** admin-api/admin-web bind
+  `:24080`/`:24000` and are reachable from the tailnet only.
+- **No private Route 53 zone.** Single box, everything is `127.0.0.1`.
+
+## Day-to-day
+
+`terraform plan` after editing the cloud-init template will show
+`user_data` drift; that's expected (`ignore_changes = [user_data]` on
+the instance). To re-bootstrap, `terraform taint aws_instance.staging`
++ apply. The EIP is preserved across taints, so the
+`STAGING_LOBBY_PUBLIC_IP` repo variable doesn't need updating.
+
+## Adding a new SSM-backed secret
+
+1. `infra/scripts/seed-ssm.sh` — add a `put_param` line under
+   `/silencer-staging/*`.
+2. **Runtime-fetched?** Append the ARN to `local.staging_runtime_param_arns`
+   in `iam.tf`, then add a `get` call in `silencer-fetch-secrets`
+   inside the cloud-init template.
+3. **Apply-time?** Add a `data "aws_ssm_parameter"` to `ssm.tf`,
+   reference `.value` in the `templatefile()` map.

--- a/infra/terraform/staging/backend.hcl.example
+++ b/infra/terraform/staging/backend.hcl.example
@@ -1,0 +1,4 @@
+bucket         = "silencer-tfstate-CHANGEME"
+key            = "silencer/staging.tfstate"
+region         = "us-west-1"
+dynamodb_table = "silencer-tfstate-lock"

--- a/infra/terraform/staging/backend.tf
+++ b/infra/terraform/staging/backend.tf
@@ -3,7 +3,7 @@ terraform {
     # Values supplied via: terraform init -backend-config=backend.hcl
     # See backend.hcl.example for the shape. backend.hcl is gitignored.
     # Uses the same S3 bucket + DynamoDB lock table that prod's bootstrap
-    # created — only the state-file `key` differs (silencer-staging.tfstate).
+    # created — only the state-file `key` differs (silencer/staging.tfstate).
     encrypt = true
   }
 }

--- a/infra/terraform/staging/backend.tf
+++ b/infra/terraform/staging/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    # Values supplied via: terraform init -backend-config=backend.hcl
+    # See backend.hcl.example for the shape. backend.hcl is gitignored.
+    # Uses the same S3 bucket + DynamoDB lock table that prod's bootstrap
+    # created — only the state-file `key` differs (silencer-staging.tfstate).
+    encrypt = true
+  }
+}

--- a/infra/terraform/staging/cloud-init-staging.yaml.tftpl
+++ b/infra/terraform/staging/cloud-init-staging.yaml.tftpl
@@ -1,0 +1,310 @@
+#cloud-config
+# Bootstraps the Silencer staging single-box. Runs all of:
+#   - mongod (apt) + lavinmq (apt), data on root volume, localhost-bound
+#   - silencer-lobby (systemd, native binary; spawns dedicated server subprocesses)
+#   - silencer-admin-api + silencer-admin-web (systemd, docker run from GHCR)
+#   - tailscaled
+#
+# Same deployment shape as prod's admin box (Docker for the admin
+# services), collapsed onto one host. The two structural differences vs
+# `cloud-init-admin.yaml.tftpl`:
+#   1. No EBS volume waits / mkfs / mount — staging keeps everything on
+#      the root volume.
+#   2. The lobby binary lives here too (systemd unit at the bottom),
+#      and the admin services point at 127.0.0.1 for Mongo / LavinMQ /
+#      LOBBY_* instead of the prod private DNS zone.
+
+users:
+  - default
+  - name: silencer
+    system: true
+    shell: /usr/sbin/nologin
+    home: /var/lib/silencer
+
+ssh_authorized_keys:
+  - ${deploy_ssh_public_key}
+
+packages:
+  - docker.io
+  - jq
+  - curl
+  - gnupg
+  # Lobby's runtime shared libs — silencer-lobby itself only needs
+  # libcurl + libminizip; SDL3 .so files arrive bundled alongside the
+  # dedicated-server binary via patchelf rpath (see deploy-staging.yml).
+  - libcurl4t64
+  - libminizip1t64
+
+write_files:
+  # Pulls runtime secrets from SSM and writes /etc/silencer/{lobby,admin-api}.env.
+  # Idempotent — overwrites both files on every run, so this also doubles
+  # as the rotation tool.
+  - path: /usr/local/sbin/silencer-fetch-secrets
+    permissions: '0755'
+    owner: root:root
+    content: |
+      #!/bin/bash
+      set -euo pipefail
+      REGION=${aws_region}
+      get() {
+        aws ssm get-parameter --region "$REGION" --name "$1" \
+          --with-decryption --query Parameter.Value --output text
+      }
+      MONGO_PWD=$(get /silencer-staging/mongo_silencer_password)
+      LAVINMQ_PWD=$(get /silencer-staging/lavinmq_silencer_password)
+      JWT=$(get /silencer-staging/jwt_secret)
+      GHCR_TOKEN=$(get /silencer/admin/ghcr_pull_token)
+      umask 077
+      mkdir -p /etc/silencer
+
+      # Lobby env. Mongo + LavinMQ talk via localhost — single box.
+      cat > /etc/silencer/lobby.env <<EOF
+      MONGO_URL=mongodb://silencer:$MONGO_PWD@127.0.0.1:27017/silencer?authSource=silencer
+      AMQP_URL=amqp://silencer:$LAVINMQ_PWD@127.0.0.1:5672/
+      EOF
+      chmod 0600 /etc/silencer/lobby.env
+
+      # admin-api env. LOBBY_* point at localhost; no GitHub-backed
+      # backups (BACKUP_KEEP=0 disables the cron in services/admin-api).
+      cat > /etc/silencer/admin-api.env <<EOF
+      PORT=24080
+      MONGO_URL=mongodb://silencer:$MONGO_PWD@127.0.0.1:27017/silencer?authSource=silencer
+      AMQP_URL=amqp://silencer:$LAVINMQ_PWD@127.0.0.1:5672/
+      JWT_SECRET=$JWT
+      LOBBY_PLAYER_AUTH_URL=http://127.0.0.1:15171
+      LOBBY_MAP_API_URL=http://127.0.0.1:15172
+      BACKUP_DIR=/var/lib/silencer-backups
+      BACKUP_KEEP=0
+      ASSETS_DIR=/assets
+      EOF
+      chmod 0600 /etc/silencer/admin-api.env
+
+      # docker login to ghcr.io so the admin units can pull their images.
+      echo "$GHCR_TOKEN" | docker login ghcr.io -u silencer --password-stdin
+
+  - path: /etc/silencer/admin-web.env
+    permissions: '0600'
+    owner: root:root
+    content: |
+      PORT=24000
+      HOSTNAME=0.0.0.0
+      NODE_ENV=production
+      NEXT_TELEMETRY_DISABLED=1
+
+  # Image refs updated by deploy-staging.yml. EnvironmentFile-shape so
+  # systemd $${IMAGE} substitution works in ExecStart.
+  - path: /etc/silencer/admin-api.image
+    permissions: '0644'
+    owner: root:root
+    content: |
+      IMAGE=${admin_image_admin_api}
+
+  - path: /etc/silencer/admin-web.image
+    permissions: '0644'
+    owner: root:root
+    content: |
+      IMAGE=${admin_image_admin_web}
+
+  # MongoDB override: enable auth + bind localhost only. Single-box
+  # staging has no remote consumers — everything talks to mongod over
+  # 127.0.0.1.
+  - path: /etc/silencer/mongod-overrides.conf
+    permissions: '0644'
+    owner: root:root
+    content: |
+      security:
+        authorization: enabled
+
+  - path: /etc/systemd/system/silencer-lobby.service
+    permissions: '0644'
+    content: |
+      [Unit]
+      Description=Silencer lobby server (staging)
+      After=network-online.target mongod.service lavinmq.service
+      Wants=network-online.target
+      Requires=mongod.service lavinmq.service
+
+      [Service]
+      Type=simple
+      User=silencer
+      Group=silencer
+      WorkingDirectory=/opt/silencer/current
+      # Dedicated-server subprocess writes PALETTECALC*.BIN under $HOME.
+      Environment=HOME=/var/lib/silencer
+      EnvironmentFile=-/etc/silencer/lobby.env
+      ExecStart=/opt/silencer/current/silencer-lobby \
+        -addr :517 \
+        -db /var/lib/silencer/lobby.json \
+        -maps-dir /var/lib/silencer/maps \
+        -map-api-addr :15172 \
+        -update-manifest /opt/silencer/update.json \
+        -public-addr ${public_ip} \
+        -game-binary /opt/silencer/current/silencer
+      Restart=always
+      RestartSec=2
+      AmbientCapabilities=CAP_NET_BIND_SERVICE
+      CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+      NoNewPrivileges=true
+      ProtectSystem=strict
+      ProtectHome=true
+      ReadWritePaths=/var/lib/silencer
+      LimitNOFILE=65535
+
+      [Install]
+      WantedBy=multi-user.target
+
+  - path: /etc/systemd/system/silencer-admin-api.service
+    permissions: '0644'
+    owner: root:root
+    content: |
+      [Unit]
+      Description=Silencer admin API (staging)
+      After=docker.service network-online.target mongod.service lavinmq.service
+      Wants=docker.service network-online.target
+      Requires=docker.service
+
+      [Service]
+      Type=simple
+      EnvironmentFile=/etc/silencer/admin-api.image
+      ExecStartPre=-/usr/bin/docker rm -f silencer-admin-api
+      ExecStartPre=/bin/sh -c '[ -n "$${IMAGE}" ] && /usr/bin/docker pull "$${IMAGE}"'
+      ExecStart=/usr/bin/docker run --rm --name silencer-admin-api \
+        --network host \
+        --env-file /etc/silencer/admin-api.env \
+        -v /var/lib/silencer-backups:/backups \
+        -v /var/lib/silencer/assets:/assets \
+        $${IMAGE}
+      ExecStop=/usr/bin/docker stop silencer-admin-api
+      Restart=always
+      RestartSec=5
+      LimitNOFILE=65535
+
+      [Install]
+      WantedBy=multi-user.target
+
+  - path: /etc/systemd/system/silencer-admin-web.service
+    permissions: '0644'
+    owner: root:root
+    content: |
+      [Unit]
+      Description=Silencer admin web (staging)
+      After=docker.service network-online.target
+      Wants=docker.service network-online.target
+      Requires=docker.service
+
+      [Service]
+      Type=simple
+      EnvironmentFile=/etc/silencer/admin-web.image
+      ExecStartPre=-/usr/bin/docker rm -f silencer-admin-web
+      ExecStartPre=/bin/sh -c '[ -n "$${IMAGE}" ] && /usr/bin/docker pull "$${IMAGE}"'
+      ExecStart=/usr/bin/docker run --rm --name silencer-admin-web \
+        --network host \
+        --env-file /etc/silencer/admin-web.env \
+        $${IMAGE}
+      ExecStop=/usr/bin/docker stop silencer-admin-web
+      Restart=always
+      RestartSec=5
+
+      [Install]
+      WantedBy=multi-user.target
+
+runcmd:
+  - mkdir -p /opt/silencer/releases /var/lib/silencer/maps /var/lib/silencer/assets /var/lib/silencer-backups
+
+  # Install AWS CLI v2. The `awscli` apt package is gone from Ubuntu
+  # Noble; the official installer is small, current, and arch-correct.
+  - |
+    set -e
+    for i in 1 2 3 4 5; do
+      DEBIAN_FRONTEND=noninteractive apt-get install -y unzip && break
+      sleep 10
+    done
+    curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o /tmp/awscliv2.zip
+    unzip -q /tmp/awscliv2.zip -d /tmp
+    /tmp/aws/install
+    rm -rf /tmp/aws /tmp/awscliv2.zip
+
+  # Add MongoDB 8.0 + LavinMQ apt repos, then install both.
+  - install -d -m 0755 /etc/apt/keyrings
+  - curl -fsSL https://www.mongodb.org/static/pgp/server-8.0.asc | gpg --dearmor -o /etc/apt/keyrings/mongodb-server-8.0.gpg
+  - |
+    echo "deb [arch=arm64 signed-by=/etc/apt/keyrings/mongodb-server-8.0.gpg] https://repo.mongodb.org/apt/ubuntu noble/mongodb-org/8.0 multiverse" \
+      > /etc/apt/sources.list.d/mongodb-org-8.0.list
+  - curl -fsSL https://packagecloud.io/cloudamqp/lavinmq/gpgkey | gpg --dearmor -o /etc/apt/keyrings/lavinmq.gpg
+  - |
+    . /etc/os-release
+    echo "deb [signed-by=/etc/apt/keyrings/lavinmq.gpg] https://packagecloud.io/cloudamqp/lavinmq/$ID $VERSION_CODENAME main" \
+      > /etc/apt/sources.list.d/lavinmq.list
+  - apt-get update
+  - DEBIAN_FRONTEND=noninteractive apt-get install -y mongodb-org lavinmq
+
+  # mongod config: cap WT cache + bind localhost. Same three-mechanism
+  # pattern as prod (sed to overwrite bindIp, awk to inject cacheSizeGB
+  # under storage:, cat-append for the security: top-level key).
+  - |
+    sed -i "s|^  bindIp:.*|  bindIp: 127.0.0.1|" /etc/mongod.conf
+    awk '/^storage:$/{print; print "  wiredTiger:"; print "    engineConfig:"; print "      cacheSizeGB: 0.25"; next} {print}' /etc/mongod.conf > /etc/mongod.conf.new
+    mv /etc/mongod.conf.new /etc/mongod.conf
+    cat /etc/silencer/mongod-overrides.conf >> /etc/mongod.conf
+
+  # Render /etc/silencer/{lobby,admin-api}.env from SSM and docker-login GHCR.
+  - /usr/local/sbin/silencer-fetch-secrets
+
+  # Bootstrap the silencer Mongo user with auth temporarily disabled,
+  # then re-enable. Same shape as prod-admin.
+  - "sed -i 's|^  authorization: enabled|  authorization: disabled|' /etc/mongod.conf"
+  - chown -R mongodb:mongodb /var/lib/mongodb
+  - systemctl daemon-reload
+  - systemctl enable --now mongod
+  - sleep 5
+  - |
+    MONGO_PWD=$(aws ssm get-parameter --region ${aws_region} \
+      --name /silencer-staging/mongo_silencer_password \
+      --with-decryption --query Parameter.Value --output text)
+    TMPF=$(mktemp); chmod 0600 "$TMPF"
+    cat > "$TMPF" <<EOF
+    try { db.dropUser("silencer"); } catch (e) {}
+    db.createUser({user: "silencer", pwd: "$MONGO_PWD", roles: [ { role: "readWrite", db: "silencer" } ]});
+    EOF
+    mongosh "mongodb://127.0.0.1:27017/silencer" --quiet --file "$TMPF"
+    rm -f "$TMPF"
+    unset MONGO_PWD
+  - "sed -i 's|^  authorization: disabled|  authorization: enabled|' /etc/mongod.conf"
+  - systemctl restart mongod
+
+  # LavinMQ user with full perms on / vhost.
+  - chown -R lavinmq:lavinmq /var/lib/lavinmq
+  - systemctl enable --now lavinmq
+  - sleep 3
+  - |
+    LAVINMQ_PWD=$(aws ssm get-parameter --region ${aws_region} \
+      --name /silencer-staging/lavinmq_silencer_password \
+      --with-decryption --query Parameter.Value --output text)
+    lavinmqctl add_user silencer "$LAVINMQ_PWD"
+    lavinmqctl set_permissions -p / silencer '.*' '.*' '.*'
+    unset LAVINMQ_PWD
+
+  # /opt/silencer is ubuntu-owned so GH Actions can scp releases without sudo.
+  - chown -R ubuntu:ubuntu /opt/silencer
+  - chown -R silencer:silencer /var/lib/silencer
+
+  # Tailscale: tag:server (same ACL as prod) so GH Actions runners can
+  # SSH in. --accept-dns=false prevents MagicDNS from interfering with
+  # AWS internal DNS resolution.
+  - curl -fsSL https://tailscale.com/install.sh | sh
+  - systemctl enable --now tailscaled
+  - tailscale up --authkey=${tailscale_auth_key} --hostname=${tailscale_hostname} --advertise-tags=tag:server --accept-dns=false --ssh=false
+
+  # Symlink shared/assets dir into the path the dedicated-server expects.
+  # The deploy workflow scps assets into /opt/silencer/current/assets;
+  # this just creates the destination link so the binary finds them.
+  - ln -sfn /opt/silencer/current/assets /usr/local/share/silencer || true
+
+  # Enable docker + the three app units. All three crash-loop until the
+  # deploy workflow lands the lobby binary and writes real image refs to
+  # /etc/silencer/{admin-api,admin-web}.image — same pattern as prod.
+  - systemctl enable --now docker
+  - usermod -aG docker ubuntu
+  - systemctl daemon-reload
+  - systemctl enable silencer-lobby silencer-admin-api silencer-admin-web
+  - systemctl start silencer-lobby silencer-admin-api silencer-admin-web || true

--- a/infra/terraform/staging/iam.tf
+++ b/infra/terraform/staging/iam.tf
@@ -1,0 +1,51 @@
+# Single instance role for the staging box. Reads runtime secrets from
+# /silencer-staging/* (and the shared Mongo/LavinMQ creds — same pattern
+# as prod, since seeding two parallel passwords adds no security and one
+# more thing to rotate). GHCR pull token is shared with prod (read-only,
+# repo-scoped).
+#
+# Same KMS posture as prod: the AWS-managed `alias/aws/ssm` key grants
+# implicit decrypt to anyone with `ssm:GetParameter` on the param.
+
+data "aws_caller_identity" "current" {}
+
+locals {
+  ssm_arn_prefix = "arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:parameter"
+
+  staging_runtime_param_arns = [
+    "${local.ssm_arn_prefix}/silencer-staging/mongo_silencer_password",
+    "${local.ssm_arn_prefix}/silencer-staging/lavinmq_silencer_password",
+    "${local.ssm_arn_prefix}/silencer-staging/jwt_secret",
+    "${local.ssm_arn_prefix}/silencer/admin/ghcr_pull_token",
+  ]
+}
+
+resource "aws_iam_role" "staging" {
+  name = var.project_name
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Action    = "sts:AssumeRole"
+      Principal = { Service = "ec2.amazonaws.com" }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "staging_ssm_read" {
+  name = "ssm-read"
+  role = aws_iam_role.staging.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["ssm:GetParameter", "ssm:GetParameters"]
+      Resource = local.staging_runtime_param_arns
+    }]
+  })
+}
+
+resource "aws_iam_instance_profile" "staging" {
+  name = var.project_name
+  role = aws_iam_role.staging.name
+}

--- a/infra/terraform/staging/main.tf
+++ b/infra/terraform/staging/main.tf
@@ -1,0 +1,163 @@
+terraform {
+  required_version = ">= 1.14.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+  default_tags {
+    tags = {
+      Project   = var.project_name
+      ManagedBy = "terraform"
+      Stage     = "staging"
+    }
+  }
+}
+
+data "aws_vpc" "default" {
+  default = true
+}
+
+data "aws_subnets" "default" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default.id]
+  }
+}
+
+data "aws_subnet" "selected" {
+  id = data.aws_subnets.default.ids[0]
+}
+
+data "aws_ami" "ubuntu_arm64" {
+  most_recent = true
+  owners      = ["099720109477"] # Canonical
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+# Reuse the same SSH admin pubkey prod uses — staging is a single-box
+# variant of the same fleet, not a separate ownership domain.
+resource "aws_key_pair" "admin" {
+  key_name   = "${var.project_name}-admin"
+  public_key = data.aws_ssm_parameter.ssh_admin_pubkey.value
+}
+
+resource "aws_security_group" "staging" {
+  name        = var.project_name
+  description = "Silencer staging single-box (lobby + dedicated servers + admin-api + admin-web + Mongo + LavinMQ)"
+  vpc_id      = data.aws_vpc.default.id
+
+  ingress {
+    description = "SSH (break-glass; day-to-day via Tailscale)"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = [var.ssh_allowed_cidr]
+  }
+
+  ingress {
+    description = "Lobby TCP"
+    from_port   = 517
+    to_port     = 517
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "Lobby UDP (dedicated-server heartbeats)"
+    from_port   = 517
+    to_port     = 517
+    protocol    = "udp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "Dedicated servers (client-to-server UDP, ephemeral range)"
+    from_port   = 30000
+    to_port     = 61000
+    protocol    = "udp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # admin-api (:24080) and admin-web (:24000) are NOT exposed to the
+  # public internet. They bind 0.0.0.0 inside the box, but the SG only
+  # opens the lobby ports. Reach them via Tailscale.
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_eip" "staging" {
+  domain = "vpc"
+  tags = {
+    Name = var.project_name
+  }
+}
+
+resource "aws_instance" "staging" {
+  ami                    = data.aws_ami.ubuntu_arm64.id
+  instance_type          = var.instance_type
+  subnet_id              = data.aws_subnets.default.ids[0]
+  key_name               = aws_key_pair.admin.key_name
+  vpc_security_group_ids = [aws_security_group.staging.id]
+  iam_instance_profile   = aws_iam_instance_profile.staging.name
+
+  user_data = templatefile("${path.module}/cloud-init-staging.yaml.tftpl", {
+    aws_region            = var.aws_region
+    public_ip             = aws_eip.staging.public_ip
+    tailscale_hostname    = var.tailscale_hostname
+    deploy_ssh_public_key = data.aws_ssm_parameter.deploy_ssh_pubkey.value
+    tailscale_auth_key    = data.aws_ssm_parameter.tailscale_auth_key.value
+    admin_image_admin_api = var.admin_image_admin_api
+    admin_image_admin_web = var.admin_image_admin_web
+  })
+
+  root_block_device {
+    volume_size = var.root_volume_size
+    volume_type = "gp3"
+    encrypted   = true
+  }
+
+  tags = {
+    Name = var.project_name
+  }
+
+  # Same posture as prod — re-running terraform apply must not pick up
+  # a newer AMI or notice user_data drift and force-replace the box.
+  # Explicit `terraform taint` is the only path to a re-bootstrap.
+  lifecycle {
+    ignore_changes = [ami, user_data]
+  }
+}
+
+resource "aws_eip_association" "staging" {
+  instance_id   = aws_instance.staging.id
+  allocation_id = aws_eip.staging.id
+}
+
+resource "aws_route53_record" "staging" {
+  count   = var.route53_zone_id != "" && var.domain_name != "" ? 1 : 0
+  zone_id = var.route53_zone_id
+  name    = var.domain_name
+  type    = "A"
+  ttl     = 300
+  records = [aws_eip.staging.public_ip]
+}

--- a/infra/terraform/staging/outputs.tf
+++ b/infra/terraform/staging/outputs.tf
@@ -1,0 +1,23 @@
+output "staging_lobby_ip" {
+  description = "Elastic IP of the staging box. Set this as `vars.STAGING_LOBBY_PUBLIC_IP` in GitHub repo settings — deploy-staging.yml bakes it into the dedicated server's -public-addr (mandatory; the C++ join path resolves with inet_addr())."
+  value       = aws_eip.staging.public_ip
+}
+
+output "staging_host" {
+  description = "Host devs build the client against — domain_name if set, otherwise the EIP. Use with: cmake -DSILENCER_LOBBY_HOST=<this>"
+  value       = var.domain_name != "" ? var.domain_name : aws_eip.staging.public_ip
+}
+
+output "staging_ssh_command" {
+  description = "Break-glass SSH (Tailscale-down). Day-to-day: ssh ubuntu@<tailscale_hostname>"
+  value       = "ssh ubuntu@${aws_eip.staging.public_ip}"
+}
+
+output "staging_instance_id" {
+  value = aws_instance.staging.id
+}
+
+output "staging_tailscale_host" {
+  description = "Tailscale MagicDNS name. Devs hit http://<this>:24000 for the admin dashboard."
+  value       = var.tailscale_hostname
+}

--- a/infra/terraform/staging/ssm.tf
+++ b/infra/terraform/staging/ssm.tf
@@ -1,0 +1,21 @@
+# Apply-time secret reads. Templated into resources at plan time, so
+# they end up in tfstate (encrypted at rest in the S3 backend). Same
+# trade-off as prod: only one-shot values live here; rotating creds are
+# fetched at runtime by the EC2 instance via its IAM role.
+#
+# Seed the params with infra/scripts/seed-ssm.sh.
+
+# Shared with prod — same human, same GH Actions deploy key.
+data "aws_ssm_parameter" "ssh_admin_pubkey" {
+  name = "/silencer/shared/ssh_admin_pubkey"
+}
+
+data "aws_ssm_parameter" "deploy_ssh_pubkey" {
+  name = "/silencer/shared/deploy_ssh_pubkey"
+}
+
+# Staging-specific Tailscale auth key — distinct one-shot from prod's
+# so a leaked staging key can't enroll into prod's tailnet device list.
+data "aws_ssm_parameter" "tailscale_auth_key" {
+  name = "/silencer-staging/tailscale_auth_key"
+}

--- a/infra/terraform/staging/terraform.tfvars.example
+++ b/infra/terraform/staging/terraform.tfvars.example
@@ -1,0 +1,25 @@
+# Copy to terraform.tfvars (gitignored) and override only the knobs you
+# need. All secrets live in AWS SSM Parameter Store under
+# /silencer-staging/* and /silencer/shared/* — seed them with:
+#
+#     ./infra/scripts/seed-ssm.sh
+#
+# Restricts public-internet SSH (break-glass only — day-to-day SSH goes
+# through Tailscale). Set to your laptop's /32:
+ssh_allowed_cidr = "1.2.3.4/32"  # check with: curl ifconfig.me
+
+# Optional DNS — set both to make `staging.example.com` an A-record at
+# the staging EIP:
+# domain_name     = "staging.example.com"
+# route53_zone_id = "Z0123456789ABCDEFGHIJ"
+
+# Optional overrides:
+# aws_region            = "us-west-1"
+# instance_type         = "t4g.small"
+# root_volume_size      = 16
+# tailscale_hostname    = "silencer-staging"
+#
+# Initial OCI image refs — leave empty for first apply; deploy-staging.yml
+# updates /etc/silencer/<svc>.image at run time.
+# admin_image_admin_api = ""
+# admin_image_admin_web = ""

--- a/infra/terraform/staging/variables.tf
+++ b/infra/terraform/staging/variables.tf
@@ -1,0 +1,59 @@
+variable "aws_region" {
+  description = "AWS region. Defaults to the same region as prod so the SSM params seeded once are reachable from both stacks."
+  type        = string
+  default     = "us-west-1"
+}
+
+variable "project_name" {
+  description = "Resource-name prefix. Distinct from prod's `silencer` so SGs / EIPs / IAM roles don't collide."
+  type        = string
+  default     = "silencer-staging"
+}
+
+variable "instance_type" {
+  description = "EC2 instance type. t4g.small is the floor — t4g.micro is too tight for mongod + lavinmq + lobby + dedicated-server + admin-api + admin-web on one box."
+  type        = string
+  default     = "t4g.small"
+}
+
+variable "ssh_allowed_cidr" {
+  description = "CIDR block allowed to SSH (break-glass). Day-to-day SSH for humans + GH Actions goes via Tailscale."
+  type        = string
+  default     = "0.0.0.0/0"
+}
+
+variable "domain_name" {
+  description = "DNS name for the staging lobby (e.g. staging.example.com). Empty = use the EIP directly. Devs build clients with cmake -DSILENCER_LOBBY_HOST=<this>."
+  type        = string
+  default     = ""
+}
+
+variable "route53_zone_id" {
+  description = "Route 53 hosted zone ID for domain_name. Empty = don't manage DNS here."
+  type        = string
+  default     = ""
+}
+
+variable "root_volume_size" {
+  description = "Root volume in GB. Holds OS, docker engine, container images, app binaries, mongod data, lavinmq data, lobby.json, and shared/assets — staging has no separate stateful EBS."
+  type        = number
+  default     = 16
+}
+
+variable "tailscale_hostname" {
+  description = "Tailscale MagicDNS hostname for the staging box. GitHub Actions deploys to ubuntu@<this>; devs hit http://<this>:24000 for the admin dashboard."
+  type        = string
+  default     = "silencer-staging"
+}
+
+variable "admin_image_admin_api" {
+  description = "Initial OCI image ref for silencer-admin-api on first boot. Empty = unit crash-loops quietly until the deploy workflow writes /etc/silencer/admin-api.image."
+  type        = string
+  default     = ""
+}
+
+variable "admin_image_admin_web" {
+  description = "Initial OCI image ref for silencer-admin-web on first boot. See admin_image_admin_api."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
## Summary

Design doc for a staging environment that mirrors the prod stack on one cheap box and redeploys on every push to `main`.

- **Shape:** single `t4g.micro` running lobby + dedicated game servers + admin-api + admin-web + Mongo + LavinMQ as native systemd units (no Docker, no Cloudflare Tunnel, no DLM, no separate stateful EBS volumes). ~\$7/mo.
- **Deploy:** new `deploy-staging.yml` workflow on push-to-main. The three concurrency requirements (deploy on push / don't cancel active runs / coalesce queued runs to newest commit) are all satisfied by GH Actions' built-in `concurrency.cancel-in-progress: false` semantics — no scripting.
- **Open questions** in the doc: EIP-for-stable-DNS vs bare IP (~\$3.60/mo), and whether to pin a staging-specific `lobby_version_string` to keep prod clients off staging.

Doc lives at `docs/plans/2026-04-27-staging-environment.md` alongside the existing prod-architecture and monorepo-restructure plans.

## Test plan

- [ ] Review the architecture trade-offs (single box, root-volume-only data, no backups).
- [ ] Confirm the concurrency semantics match the desired behavior.
- [ ] Decide the two open questions before implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/arsia-mons/silencer/pull/91" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
