### PR TITLE
fix(website): use system monospace + bright text on mobile

### DIFF
--- a/web/website/styles.css
+++ b/web/website/styles.css
@@ -201,11 +201,22 @@ blockquote footer a:focus-visible {
 
 /* --- Responsive Polish --- */
 @media (max-width: 800px) {
+  /* Drop the custom OT-SVG fonts on mobile: iOS Safari renders them dim
+     (currentColor isn't honored, so text and underlines fade to grey or
+     vanish). Fall back to the system monospace stack. */
+  body,
+  blockquote,
+  blockquote footer,
+  .links {
+    font-family: 'Courier New', Courier, monospace;
+  }
+
   body {
     align-items: start;
     padding: 0;
+    color: #c5e1c5;
   }
-  
+
   main {
     grid-template-columns: 100%;
     gap: 1.5rem;
@@ -215,7 +226,7 @@ blockquote footer a:focus-visible {
     box-sizing: border-box;
     overflow-wrap: break-word;
   }
-  
+
   .logo {
     height: auto;
     width: 100%;
@@ -223,18 +234,28 @@ blockquote footer a:focus-visible {
     margin: 0 auto;
     display: block;
   }
-  
+
   blockquote {
     grid-column: 1 / -1;
     padding-left: 0;
     margin: 0;
+    color: #c5e1c5;
   }
-  
+
   blockquote p {
     font-size: 16px;
     margin-bottom: 1rem;
   }
-  
+
+  blockquote footer {
+    color: #c5e1c5;
+    opacity: 1;
+  }
+
+  blockquote footer a {
+    color: #c5e1c5;
+  }
+
   .links {
     grid-column: 1 / -1;
     display: flex;
@@ -254,6 +275,7 @@ blockquote footer a:focus-visible {
   }
 
   .links a {
+    color: #c5e1c5;
     padding: 0.5rem 0;
     width: auto;
   }


### PR DESCRIPTION
The OT-SVG font orientation bug is fixed, but iOS Safari still renders
the custom Silencer fonts dim — currentColor isn't honored, so body
copy looks washed-out grey and the Mind Control footer hyperlink
underline/text essentially disappear against the dark background.

Inside the existing mobile media query, fall back to the Courier New /
monospace stack and bump body, blockquote, footer, and .links text to
the brighter #c5e1c5 used elsewhere. Desktop rendering is untouched.

https://claude.ai/code/session_01HWcw5z4uWeyRGQStr2x9J4
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/arsia-mons/silencer/pull/103" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
