### PR TITLE
feat(cli): lobby namespace — multiplexed fake-player daemon

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,13 +9,23 @@
       "name": "silencer-cli",
       "bin": {
         "silencer-cli": "./index.ts",
+        "silencer-lobbyd": "./src/lobby/daemon.ts",
       },
       "dependencies": {
         "@silencer/gas-validation": "workspace:*",
+        "@silencer/lobby-sdk": "workspace:*",
       },
       "devDependencies": {
         "@types/bun": "^1.3.13",
         "typescript": "^5.4.0",
+      },
+    },
+    "clients/lobby-sdk/ts": {
+      "name": "@silencer/lobby-sdk",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/bun": "latest",
+        "typescript": "^5.6.0",
       },
     },
     "services/admin-api": {
@@ -265,6 +275,8 @@
     "@reactflow/node-toolbar": ["@reactflow/node-toolbar@1.3.14", "", { "dependencies": { "@reactflow/core": "11.11.4", "classcat": "^5.0.3", "zustand": "^4.4.1" }, "peerDependencies": { "react": ">=17", "react-dom": ">=17" } }, "sha512-rbynXQnH/xFNu4P9H+hVqlEUafDCkEoCy0Dg9mG22Sg+rY/0ck6KkrAQrYrTgXusd+cEJOMK0uOOFCK2/5rSGQ=="],
 
     "@silencer/gas-validation": ["@silencer/gas-validation@workspace:shared/gas-validation"],
+
+    "@silencer/lobby-sdk": ["@silencer/lobby-sdk@workspace:clients/lobby-sdk/ts"],
 
     "@sindresorhus/is": ["@sindresorhus/is@7.2.0", "", {}, "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw=="],
 

--- a/clients/cli/CLAUDE.md
+++ b/clients/cli/CLAUDE.md
@@ -31,6 +31,24 @@ silencer-cli ping
 - `1` — `ok:false`; `[CODE] error` to stderr.
 - `2` — transport failure (connect refused / closed prematurely / etc).
 
+## Lobby fake players
+
+`lobby` namespace spawns persistent authenticated lobby presences in a
+shared supervisor daemon. See [`src/lobby/CLAUDE.md`](src/lobby/CLAUDE.md).
+
+```bash
+silencer-cli lobby spawn --as alice --host LOBBY_HOST --port 15170 \
+                         --version 1.2.3 --user alice --pass hunter2
+silencer-cli lobby chat  --as alice --channel main --text "hi"
+silencer-cli lobby tail  --as alice    # streams events until SIGINT
+silencer-cli lobby kill  --as alice
+```
+
+Defaults co-locate socket+log at `$SILENCER_LOBBYD_DIR` (override) or
+the platform default (`$XDG_RUNTIME_DIR/silencer/` on Linux,
+`$TMPDIR/silencer/` on macOS, `%LOCALAPPDATA%\Silencer\lobbyd\` on
+Windows).
+
 ## Wire protocol
 
 See `docs/superpowers/specs/2026-04-26-cli-agent-control-design.md`.

--- a/clients/cli/index.ts
+++ b/clients/cli/index.ts
@@ -136,9 +136,9 @@ function parseArgs(argv: string[]): {
   let subop: string | null = null;
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i]!;
-    if (a === "--host") {
+    if (a === "--host" && op === null) {
       host = argv[++i] ?? usage();
-    } else if (a === "--port") {
+    } else if (a === "--port" && op === null) {
       port = Number.parseInt(argv[++i] ?? usage(), 10);
     } else if (a.startsWith("--")) {
       const key = a.slice(2).replace(/-/g, "_");

--- a/clients/cli/index.ts
+++ b/clients/cli/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 
 import { connect } from "node:net";
+import { LOBBY_HANDLERS } from "./src/lobby/commands.ts";
 
 type Reply = {
   id: number;
@@ -41,6 +42,14 @@ function usage(): never {
       `         (runs locally; no daemon required. Exit 1 if errors[] non-empty.)\n` +
       `       silencer-cli gas reload\n` +
       `         (re-runs the daemon's GAS loader; only safe from NONE/MAINMENU/LOBBY/MISSIONSUMMARY)\n` +
+      `       silencer-cli lobby spawn --as alice --host H --port P --version V --user U --pass P\n` +
+      `       silencer-cli lobby ls\n` +
+      `       silencer-cli lobby chat --as alice --channel main --text "hi"\n` +
+      `       silencer-cli lobby game create --as alice --name TEST [--map M --max-players 8]\n` +
+      `       silencer-cli lobby game join   --as alice --id 12345\n` +
+      `       silencer-cli lobby tail --as alice\n` +
+      `       silencer-cli lobby kill --as alice | --all\n` +
+      `       silencer-cli lobby join_channel --as alice --channel main\n` +
       `\n` +
       `Env: SILENCER_CONTROL_HOST (default 127.0.0.1)\n` +
       `     SILENCER_CONTROL_PORT (default 5170)`,
@@ -52,7 +61,7 @@ function usage(): never {
 // The wrapper recognizes the first positional as the op, the second as
 // args.subop. The pattern is centralized so future namespaces (e.g.
 // `profile`, `audio`) can opt in without touching the parser.
-const NOUN_FIRST_OPS = new Set(["keybind", "gas"]);
+const NOUN_FIRST_OPS = new Set(["keybind", "gas", "lobby"]);
 
 // (op, subop) pairs that run entirely in this process and never touch
 // the daemon. Each handler returns a JSON-serializable result and a
@@ -71,6 +80,7 @@ const LOCAL_OPS: Record<string, Record<string, LocalHandler>> = {
       return { clean: res.ok, result: res };
     },
   },
+  lobby: LOBBY_HANDLERS,
 };
 // Per (op,subop) pair: which flag accepts a list of values rather than
 // a single value. `--bindings KEY:A PAD:south` consumes both.
@@ -94,6 +104,14 @@ const STRING_FLAGS: Record<string, Record<string, Set<string>>> = {
   },
   gas: {
     validate: new Set(["dir"]),
+  },
+  lobby: {
+    spawn: new Set(["as", "user", "pass", "version", "host"]),
+    chat: new Set(["as", "channel", "text"]),
+    join_channel: new Set(["as", "channel"]),
+    kill: new Set(["as"]),
+    game: new Set(["as", "name", "map", "password"]),
+    tail: new Set(["as"]),
   },
 };
 // Bindings within VARIADIC_FLAGS that accept comma-separated chord syntax:
@@ -182,6 +200,10 @@ function parseArgs(argv: string[]): {
       // `silencer-cli gas validate shared/assets/gas/` w/o --dir).
       else if (op === "gas" && subop === "validate" && args["dir"] === undefined) {
         args["dir"] = a;
+      }
+      // lobby game <create|join>: third positional is the sub-subcommand.
+      else if (op === "lobby" && subop === "game" && args["_subgame"] === undefined) {
+        args["_subgame"] = a;
       }
     }
   }

--- a/clients/cli/index.ts
+++ b/clients/cli/index.ts
@@ -219,7 +219,9 @@ async function main() {
   const local = subop ? LOCAL_OPS[op]?.[subop] : undefined;
   if (local) {
     const { clean, result } = await local(args);
-    process.stdout.write(JSON.stringify(result) + "\n");
+    // Streaming handlers (e.g. lobby tail) already wrote line-per-event to stdout
+    // and signal "no trailing summary" by returning result === null.
+    if (result !== null) process.stdout.write(JSON.stringify(result) + "\n");
     process.exit(clean ? 0 : 1);
   }
 

--- a/clients/cli/index.ts
+++ b/clients/cli/index.ts
@@ -62,8 +62,10 @@ type LocalHandler = (args: Record<string, unknown>) => Promise<{ clean: boolean;
 const LOCAL_OPS: Record<string, Record<string, LocalHandler>> = {
   gas: {
     validate: async (args) => {
-      const dir = (args["dir"] as string | undefined) ?? (args["_positional"] as string | undefined);
-      if (!dir) throw new Error("gas validate requires a directory: silencer-cli gas validate <dir>");
+      const dir =
+        (args["dir"] as string | undefined) ?? (args["_positional"] as string | undefined);
+      if (!dir)
+        throw new Error("gas validate requires a directory: silencer-cli gas validate <dir>");
       const { validateDirectory } = await import("@silencer/gas-validation/node");
       const res = await validateDirectory(dir);
       return { clean: res.ok, result: res };
@@ -83,11 +85,11 @@ const VARIADIC_FLAGS: Record<string, Record<string, Set<string>>> = {
 // (silent operation on the wrong profile).
 const STRING_FLAGS: Record<string, Record<string, Set<string>>> = {
   keybind: {
-    get:    new Set(["profile", "action"]),
-    put:    new Set(["profile", "action"]),
-    unset:  new Set(["profile", "action"]),
-    use:    new Set(["profile"]),
-    new:    new Set(["profile", "from"]),
+    get: new Set(["profile", "action"]),
+    put: new Set(["profile", "action"]),
+    unset: new Set(["profile", "action"]),
+    use: new Set(["profile"]),
+    new: new Set(["profile", "from"]),
     delete: new Set(["profile"]),
   },
   gas: {
@@ -103,7 +105,12 @@ const CHORD_SPLIT_FLAGS: Record<string, Record<string, Set<string>>> = {
   },
 };
 
-function parseArgs(argv: string[]): { host: string; port: number; op: string; args: Record<string, unknown> } {
+function parseArgs(argv: string[]): {
+  host: string;
+  port: number;
+  op: string;
+  args: Record<string, unknown>;
+} {
   let host = process.env.SILENCER_CONTROL_HOST ?? "127.0.0.1";
   let port = Number.parseInt(process.env.SILENCER_CONTROL_PORT ?? "5170", 10);
   const args: Record<string, unknown> = {};
@@ -155,7 +162,8 @@ function parseArgs(argv: string[]): { host: string; port: number; op: string; ar
     } else {
       // positional after op → treat as shorthand for the most common arg.
       if (op === "click" && args["label"] === undefined) args["label"] = a;
-      else if ((op === "set_text" || op === "select") && args["label"] === undefined) args["label"] = a;
+      else if ((op === "set_text" || op === "select") && args["label"] === undefined)
+        args["label"] = a;
       else if (op === "set_text" && args["text"] === undefined) args["text"] = a;
       else if (op === "select" && args["index"] === undefined) {
         const num = Number(a);
@@ -163,7 +171,11 @@ function parseArgs(argv: string[]): { host: string; port: number; op: string; ar
       }
       // keybind: third positional (after `keybind <subop>`) is the profile name
       // for `use` / `delete` (the most common single-positional shape).
-      else if (op === "keybind" && (subop === "use" || subop === "delete") && args["profile"] === undefined) {
+      else if (
+        op === "keybind" &&
+        (subop === "use" || subop === "delete") &&
+        args["profile"] === undefined
+      ) {
         args["profile"] = a;
       }
       // gas validate: third positional is the directory (allows

--- a/clients/cli/package.json
+++ b/clients/cli/package.json
@@ -1,11 +1,11 @@
 {
   "name": "silencer-cli",
   "private": true,
-  "type": "module",
   "bin": {
     "silencer-cli": "./index.ts",
     "silencer-lobbyd": "./src/lobby/daemon.ts"
   },
+  "type": "module",
   "scripts": {
     "fmt": "oxfmt --write .",
     "typecheck": "tsc --noEmit",

--- a/clients/cli/package.json
+++ b/clients/cli/package.json
@@ -3,14 +3,17 @@
   "private": true,
   "type": "module",
   "bin": {
-    "silencer-cli": "./index.ts"
+    "silencer-cli": "./index.ts",
+    "silencer-lobbyd": "./src/lobby/daemon.ts"
   },
   "scripts": {
     "fmt": "oxfmt --write .",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "bun test"
   },
   "dependencies": {
-    "@silencer/gas-validation": "workspace:*"
+    "@silencer/gas-validation": "workspace:*",
+    "@silencer/lobby-sdk": "workspace:*"
   },
   "devDependencies": {
     "@types/bun": "^1.3.13",

--- a/clients/cli/src/lobby/AGENTS.md
+++ b/clients/cli/src/lobby/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/clients/cli/src/lobby/CLAUDE.md
+++ b/clients/cli/src/lobby/CLAUDE.md
@@ -1,0 +1,69 @@
+# clients/cli/src/lobby — agent-driven fake lobby presences
+
+Single supervisor daemon (`silencer-lobbyd`) holds N `@silencer/lobby-sdk`
+`LobbyClient` instances keyed by session name. CLI subcommands are thin
+clients: open the unix socket, send one JSON-lines request, exit.
+
+## Files
+
+- `paths.ts` — co-located dir resolution
+  (`SILENCER_LOBBYD_DIR` overrides; defaults: `$XDG_RUNTIME_DIR/silencer/`
+  on Linux, `$TMPDIR/silencer/` on macOS, `%LOCALAPPDATA%\Silencer\lobbyd\`
+  on Windows). Both `lobbyd.sock` and `lobbyd.log` live here. Caps the
+  resolved socket path at `MAX_SOCKET_PATH` (100) and throws a clear error
+  on macOS if that limit is exceeded (sun_path is 104 bytes; 100 leaves a
+  3-byte cushion for the trailing NUL).
+- `protocol.ts` — `Request` / `Reply` JSON-lines frames.
+- `session-manager.ts` — in-memory session map; takes a `LobbyLike`
+  factory so tests can inject fakes. Defines `NoSessionError` for the
+  daemon's `NO_SESSION` error code.
+- `rpc-server.ts` — `Bun.listen({ unix })`; dispatches to the manager.
+  Streaming `tail` op emits a `{event: "registered"}` ack frame after
+  listener registration so clients can sync without polling.
+- `rpc-client.ts` — `Bun.connect({ unix })`; one-shot (`rpcCall`) and
+  streaming (`rpcStream`).
+- `spawn.ts` — auto-spawn detached `silencer-lobbyd`, poll the socket.
+- `daemon.ts` — entry point. Idempotent `shutdown` guard. Auto-exits
+  when sessions=0 AND conns=0.
+- `commands.ts` — handlers wired into `index.ts`'s `LOCAL_OPS.lobby`.
+  Streaming handlers return `result: null` so `main()` skips the
+  trailing JSON-summary line.
+
+## Lifecycle
+
+1. First `lobby spawn` → `ensureDaemon` probes the socket. Refused →
+   forks detached `bun src/lobby/daemon.ts` and polls until it accepts.
+2. Daemon serves until `kill_all` or until `kill` removes the last
+   session AND the last connection drops (`onIdle` callback).
+3. Stale socket file (crashed daemon) is unlinked on the next bind.
+
+## Invariants
+
+- Creds (`--user`, `--pass`) are passed once to `spawn`; subsequent
+  calls use only `--as <name>`. Passwords never touch disk.
+- macOS sun_path is 104 bytes; `paths.ts` caps the resolved socket
+  path at `MAX_SOCKET_PATH` (100) and throws a clear error otherwise.
+- One process, N sessions: per-player overhead is just a `LobbyClient`
+  instance + its TCP socket. The Bun runtime cost is amortized once.
+- The `tail` op subscribes a connection to `chat`/`presence`/
+  `channel`/`newGame`/`delGame`/`stateChanged` events. Final frame
+  fires on session disconnect or socket close (idempotent via
+  `tailEnded` flag).
+
+## Known limitations
+
+- `lobby game create` constructs a `LobbyGame` with `mapHash: <20
+zero bytes>` and `port: 0`. This is fine for emitting test traffic
+  to a local lobby server, but a production lobby may reject games
+  without a real map hash and listening port. If you need a joinable
+  game from the CLI, extend `commands.ts::game` with `--map-hash`
+  and `--listen-port` flags (or compute them from `--map`).
+
+## When NOT to touch this dir
+
+- If you're changing the wire protocol (adding lobby opcodes), edit
+  `services/lobby/protocol.go` first, then `clients/lobby-sdk/ts`,
+  then `shared/lobby-protocol/vectors.json`. This module consumes
+  the SDK and shouldn't grow protocol knowledge of its own.
+- If you're adding non-lobby CLI features, they don't belong here.
+  The `lobby` namespace is the only thing in this dir.

--- a/clients/cli/src/lobby/commands.ts
+++ b/clients/cli/src/lobby/commands.ts
@@ -73,7 +73,10 @@ export const LOBBY_HANDLERS: Record<string, Handler> = {
           state: 0,
           accountId: 0,
           hostname: "",
-          mapHash: new Uint8Array(20),
+          // 20-byte map hash; sent as number[] because Uint8Array
+          // doesn't survive JSON.stringify (becomes {"0":0,...} not [0,...]).
+          // The SDK's encodeLobbyGame iterates by index, so number[] works.
+          mapHash: new Array(20).fill(0),
           port: 0,
         },
       });

--- a/clients/cli/src/lobby/commands.ts
+++ b/clients/cli/src/lobby/commands.ts
@@ -1,0 +1,104 @@
+// CLI subcommand handlers for the `lobby` namespace. Each handler returns
+// { clean, result } in the same shape as LOCAL_OPS in index.ts. Anything
+// stateful goes through the daemon; we ensure it's running first.
+
+import { rpcCall, rpcStream } from "./rpc-client.ts";
+import { ensureDaemon } from "./spawn.ts";
+
+type Handler = (args: Record<string, unknown>) => Promise<{ clean: boolean; result: unknown }>;
+
+let nextId = 1;
+function reqId(): number {
+  return nextId++;
+}
+
+async function call(
+  op: string,
+  args: Record<string, unknown>,
+): Promise<{ clean: boolean; result: unknown }> {
+  const sock = await ensureDaemon();
+  const r = await rpcCall(sock, { id: reqId(), op, args });
+  if (!r.ok) {
+    process.stderr.write(`[${r.code ?? "ERR"}] ${r.error ?? ""}\n`);
+    return { clean: false, result: { error: r.error, code: r.code } };
+  }
+  return { clean: true, result: r.result ?? {} };
+}
+
+export const LOBBY_HANDLERS: Record<string, Handler> = {
+  spawn: async (args) => {
+    const required = ["as", "user", "pass", "version", "host", "port"] as const;
+    for (const k of required) if (args[k] === undefined) throw new Error(`missing --${k}`);
+    return call("spawn", {
+      name: args["as"],
+      user: args["user"],
+      pass: args["pass"],
+      version: args["version"],
+      host: args["host"],
+      port: Number(args["port"]),
+      platform: Number(args["platform"] ?? 0),
+    });
+  },
+  ls: async (_args) => call("ls", {}),
+  kill: async (args) => {
+    if (args["all"]) return call("kill_all", {});
+    if (!args["as"]) throw new Error("kill requires --as <name> or --all");
+    return call("kill", { name: args["as"] });
+  },
+  chat: async (args) => {
+    if (!args["as"] || !args["channel"] || args["text"] === undefined) {
+      throw new Error("chat requires --as --channel --text");
+    }
+    return call("chat", { name: args["as"], channel: args["channel"], text: args["text"] });
+  },
+  join_channel: async (args) => {
+    if (!args["as"] || !args["channel"]) throw new Error("join_channel requires --as --channel");
+    return call("join_channel", { name: args["as"], channel: args["channel"] });
+  },
+  game: async (args) => {
+    const sub = args["_subgame"] as string | undefined;
+    if (sub === "create") {
+      if (!args["as"] || !args["name"]) throw new Error("game create requires --as and --name");
+      return call("game_create", {
+        name: args["as"],
+        game: {
+          id: 0,
+          name: args["name"],
+          password: args["password"] ?? "",
+          mapName: args["map"] ?? "",
+          maxPlayers: Number(args["max_players"] ?? 8),
+          maxTeams: Number(args["max_teams"] ?? 2),
+          minLevel: 0,
+          maxLevel: 0,
+          securityLevel: 0,
+          extra: 0,
+          players: 0,
+          state: 0,
+          accountId: 0,
+          hostname: "",
+          mapHash: new Uint8Array(20),
+          port: 0,
+        },
+      });
+    }
+    if (sub === "join") {
+      if (!args["as"] || args["id"] === undefined) throw new Error("game join requires --as --id");
+      return call("game_join", { name: args["as"], gameId: Number(args["id"]) });
+    }
+    throw new Error(`unknown game subcommand: ${sub}`);
+  },
+  tail: async (args) => {
+    if (!args["as"]) throw new Error("tail requires --as <name>");
+    const sock = await ensureDaemon();
+    for await (const r of rpcStream(sock, {
+      id: reqId(),
+      op: "tail",
+      args: { name: args["as"] },
+      stream: true,
+    })) {
+      if (r.final) break;
+      process.stdout.write(JSON.stringify(r.result) + "\n");
+    }
+    return { clean: true, result: {} };
+  },
+};

--- a/clients/cli/src/lobby/commands.ts
+++ b/clients/cli/src/lobby/commands.ts
@@ -18,10 +18,7 @@ async function call(
 ): Promise<{ clean: boolean; result: unknown }> {
   const sock = await ensureDaemon();
   const r = await rpcCall(sock, { id: reqId(), op, args });
-  if (!r.ok) {
-    process.stderr.write(`[${r.code ?? "ERR"}] ${r.error ?? ""}\n`);
-    return { clean: false, result: { error: r.error, code: r.code } };
-  }
+  if (!r.ok) return { clean: false, result: { error: r.error, code: r.code } };
   return { clean: true, result: r.result ?? {} };
 }
 
@@ -97,8 +94,10 @@ export const LOBBY_HANDLERS: Record<string, Handler> = {
       stream: true,
     })) {
       if (r.final) break;
+      const result = r.result as { event?: string };
+      if (result?.event === "registered") continue; // server ack, not user-visible
       process.stdout.write(JSON.stringify(r.result) + "\n");
     }
-    return { clean: true, result: {} };
+    return { clean: true, result: null };
   },
 };

--- a/clients/cli/src/lobby/daemon.ts
+++ b/clients/cli/src/lobby/daemon.ts
@@ -24,9 +24,11 @@ async function main(): Promise<void> {
   const ts = () => new Date().toISOString();
   const logLine = (msg: string) => writeSync(logFd, `${ts()} ${msg}\n`);
 
-  // If a daemon is already up, defer to it. The CLI client's auto-spawn
-  // probes first and only invokes us when no peer answered, but a race
-  // between two parallel spawns is still possible.
+  // Defer to an existing daemon if one's already listening. Bun.listen is the
+  // real serialization primitive; symmetric simultaneous starters will both
+  // reject this probe and race at bind. The narrow gap is a peer mid-shutdown
+  // answering our probe — we'd exit prematurely, but spawn.ts re-probes after
+  // the spawn timeout and can fork a fresh daemon, so the system self-heals.
   try {
     await Bun.connect({
       unix: sock,
@@ -49,10 +51,17 @@ async function main(): Promise<void> {
   const manager = new SessionManager(factory);
   let server: Awaited<ReturnType<typeof startRpcServer>>;
 
+  let shuttingDown = false;
   const shutdown = async (reason: string) => {
+    if (shuttingDown) return;
+    shuttingDown = true;
     logLine(`shutdown: ${reason}`);
-    await manager.killAll().catch(() => {});
-    await server?.stop().catch(() => {});
+    await manager
+      .killAll()
+      .catch((e) => logLine(`killAll error: ${e instanceof Error ? e.message : String(e)}`));
+    await server
+      ?.stop()
+      .catch((e) => logLine(`server.stop error: ${e instanceof Error ? e.message : String(e)}`));
     process.exit(0);
   };
 

--- a/clients/cli/src/lobby/daemon.ts
+++ b/clients/cli/src/lobby/daemon.ts
@@ -1,0 +1,77 @@
+#!/usr/bin/env bun
+// silencer-lobbyd — multiplexes N LobbyClient sessions for the agent CLI.
+//
+// Lifecycle:
+//   1. Resolve dir/socket/log path.
+//   2. mkdir -p dir.
+//   3. Bind unix socket; if bind fails because a live daemon is already
+//      listening, exit 0 (the CLI client will use that one).
+//   4. Serve until idle (zero sessions AND zero connections) or SIGINT.
+
+import { mkdirSync, openSync, writeSync } from "node:fs";
+import { logPath, resolveLobbydDir, socketPath } from "./paths.ts";
+import { startRpcServer } from "./rpc-server.ts";
+import { realLobbyFactory, SessionManager } from "./session-manager.ts";
+
+async function main(): Promise<void> {
+  const dir = resolveLobbydDir();
+  mkdirSync(dir, { recursive: true });
+  const sock = socketPath(dir);
+  const log = logPath(dir);
+
+  // Append-only log file; one line per significant event.
+  const logFd = openSync(log, "a");
+  const ts = () => new Date().toISOString();
+  const logLine = (msg: string) => writeSync(logFd, `${ts()} ${msg}\n`);
+
+  // If a daemon is already up, defer to it. The CLI client's auto-spawn
+  // probes first and only invokes us when no peer answered, but a race
+  // between two parallel spawns is still possible.
+  try {
+    await Bun.connect({
+      unix: sock,
+      socket: {
+        open(s) {
+          s.end();
+        },
+        data() {},
+        close() {},
+        error() {},
+      },
+    });
+    logLine("another lobbyd already listening; exiting");
+    process.exit(0);
+  } catch {
+    /* expected — no peer listening */
+  }
+
+  const factory = await realLobbyFactory();
+  const manager = new SessionManager(factory);
+  let server: Awaited<ReturnType<typeof startRpcServer>>;
+
+  const shutdown = async (reason: string) => {
+    logLine(`shutdown: ${reason}`);
+    await manager.killAll().catch(() => {});
+    await server?.stop().catch(() => {});
+    process.exit(0);
+  };
+
+  server = await startRpcServer({
+    socketPath: sock,
+    manager,
+    onIdle: () => {
+      void shutdown("idle");
+    },
+  });
+
+  process.on("SIGINT", () => void shutdown("SIGINT"));
+  process.on("SIGTERM", () => void shutdown("SIGTERM"));
+  logLine(`listening on ${sock}`);
+}
+
+main().catch((e) => {
+  process.stderr.write(
+    `[lobbyd] fatal: ${e instanceof Error ? (e.stack ?? e.message) : String(e)}\n`,
+  );
+  process.exit(1);
+});

--- a/clients/cli/src/lobby/paths.ts
+++ b/clients/cli/src/lobby/paths.ts
@@ -1,0 +1,45 @@
+// Resolves the co-located directory holding lobbyd's Unix socket and log
+// file. One env override (SILENCER_LOBBYD_DIR) wins on every platform.
+//
+// macOS sun_path is 104 bytes; we cap the resolved socket path at 100
+// to leave a margin for trailing-NUL accounting in different libc impls.
+
+import { join, win32 } from "node:path";
+
+export const MAX_SUN_PATH = 100;
+
+export function resolveLobbydDir(): string {
+    if (process.env.SILENCER_LOBBYD_DIR) return process.env.SILENCER_LOBBYD_DIR;
+    switch (process.platform) {
+        case "linux": {
+            const xdg = process.env.XDG_RUNTIME_DIR;
+            return xdg ? join(xdg, "silencer") : "/tmp/silencer";
+        }
+        case "darwin": {
+            const tmp = process.env.TMPDIR ?? "/tmp/";
+            return join(tmp, "silencer");
+        }
+        case "win32": {
+            const local = process.env.LOCALAPPDATA;
+            if (!local) throw new Error("LOCALAPPDATA not set");
+            return win32.join(local, "Silencer", "lobbyd");
+        }
+        default:
+            return "/tmp/silencer";
+    }
+}
+
+export function socketPath(dir: string): string {
+    const p = join(dir, "lobbyd.sock");
+    if (process.platform === "darwin" && p.length > MAX_SUN_PATH) {
+        throw new Error(
+            `socket path "${p}" (${p.length} bytes) exceeds macOS sun_path limit (${MAX_SUN_PATH}). ` +
+            `Override with SILENCER_LOBBYD_DIR=<shorter dir>.`
+        );
+    }
+    return p;
+}
+
+export function logPath(dir: string): string {
+    return join(dir, "lobbyd.log");
+}

--- a/clients/cli/src/lobby/paths.ts
+++ b/clients/cli/src/lobby/paths.ts
@@ -1,45 +1,45 @@
 // Resolves the co-located directory holding lobbyd's Unix socket and log
 // file. One env override (SILENCER_LOBBYD_DIR) wins on every platform.
 //
-// macOS sun_path is 104 bytes; we cap the resolved socket path at 100
-// to leave a margin for trailing-NUL accounting in different libc impls.
+// macOS sun_path is 104 bytes; 100-byte cap leaves a 3-byte cushion for the
+// trailing NUL.
 
 import { join, win32 } from "node:path";
 
-export const MAX_SUN_PATH = 100;
+export const MAX_SOCKET_PATH = 100;
 
 export function resolveLobbydDir(): string {
-    if (process.env.SILENCER_LOBBYD_DIR) return process.env.SILENCER_LOBBYD_DIR;
-    switch (process.platform) {
-        case "linux": {
-            const xdg = process.env.XDG_RUNTIME_DIR;
-            return xdg ? join(xdg, "silencer") : "/tmp/silencer";
-        }
-        case "darwin": {
-            const tmp = process.env.TMPDIR ?? "/tmp/";
-            return join(tmp, "silencer");
-        }
-        case "win32": {
-            const local = process.env.LOCALAPPDATA;
-            if (!local) throw new Error("LOCALAPPDATA not set");
-            return win32.join(local, "Silencer", "lobbyd");
-        }
-        default:
-            return "/tmp/silencer";
+  if (process.env.SILENCER_LOBBYD_DIR) return process.env.SILENCER_LOBBYD_DIR;
+  switch (process.platform) {
+    case "linux": {
+      const xdg = process.env.XDG_RUNTIME_DIR;
+      return xdg ? join(xdg, "silencer") : "/tmp/silencer";
     }
+    case "darwin": {
+      const tmp = process.env.TMPDIR || "/tmp";
+      return join(tmp, "silencer");
+    }
+    case "win32": {
+      const local = process.env.LOCALAPPDATA;
+      if (!local) throw new Error("LOCALAPPDATA not set");
+      return win32.join(local, "Silencer", "lobbyd");
+    }
+    default:
+      return "/tmp/silencer";
+  }
 }
 
 export function socketPath(dir: string): string {
-    const p = join(dir, "lobbyd.sock");
-    if (process.platform === "darwin" && p.length > MAX_SUN_PATH) {
-        throw new Error(
-            `socket path "${p}" (${p.length} bytes) exceeds macOS sun_path limit (${MAX_SUN_PATH}). ` +
-            `Override with SILENCER_LOBBYD_DIR=<shorter dir>.`
-        );
-    }
-    return p;
+  const p = join(dir, "lobbyd.sock");
+  if (process.platform === "darwin" && p.length > MAX_SOCKET_PATH) {
+    throw new Error(
+      `socket path "${p}" (${p.length} bytes) exceeds macOS sun_path limit (${MAX_SOCKET_PATH}). ` +
+        `Override with SILENCER_LOBBYD_DIR=<shorter dir>.`,
+    );
+  }
+  return p;
 }
 
 export function logPath(dir: string): string {
-    return join(dir, "lobbyd.log");
+  return join(dir, "lobbyd.log");
 }

--- a/clients/cli/src/lobby/protocol.ts
+++ b/clients/cli/src/lobby/protocol.ts
@@ -1,0 +1,38 @@
+// JSON-lines RPC over AF_UNIX. One frame per newline-terminated line.
+
+export type Request = {
+  id: number;
+  op: string;
+  args: Record<string, unknown>;
+  stream?: boolean;
+};
+
+export type Reply = {
+  id: number;
+  ok: boolean;
+  result?: unknown;
+  error?: string;
+  code?: string;
+  final: boolean;
+};
+
+export function encodeFrame(frame: Request | Reply): string {
+  return JSON.stringify(frame) + "\n";
+}
+
+export function parseFrames<T>(buf: string): { frames: T[]; rest: string } {
+  const frames: T[] = [];
+  let rest = buf;
+  for (;;) {
+    const nl = rest.indexOf("\n");
+    if (nl < 0) return { frames, rest };
+    const line = rest.slice(0, nl);
+    rest = rest.slice(nl + 1);
+    if (line.length === 0) continue;
+    try {
+      frames.push(JSON.parse(line) as T);
+    } catch (e) {
+      throw new Error(`malformed RPC frame: ${line} (${(e as Error).message})`);
+    }
+  }
+}

--- a/clients/cli/src/lobby/rpc-client.ts
+++ b/clients/cli/src/lobby/rpc-client.ts
@@ -1,5 +1,7 @@
 import { encodeFrame, parseFrames, type Reply, type Request } from "./protocol.ts";
 
+const decoder = new TextDecoder();
+
 export async function rpcCall(socketPath: string, req: Request): Promise<Reply> {
   for await (const r of rpcStream(socketPath, req)) {
     if (r.final) return r;
@@ -11,20 +13,21 @@ export function rpcStream(socketPath: string, req: Request): AsyncIterable<Reply
   return {
     [Symbol.asyncIterator]() {
       const queue: Reply[] = [];
-      let waiters: Array<(r: IteratorResult<Reply>) => void> = [];
+      type Waiter = { resolve: (r: IteratorResult<Reply>) => void; reject: (e: unknown) => void };
+      let waiters: Waiter[] = [];
       let done = false;
       let errored: unknown = null;
       let buf = "";
       let socket: any;
 
       const push = (r: Reply) => {
-        if (waiters.length) waiters.shift()!({ value: r, done: false });
+        if (waiters.length) waiters.shift()!.resolve({ value: r, done: false });
         else queue.push(r);
         if (r.final) finish();
       };
       const finish = () => {
         done = true;
-        for (const w of waiters) w({ value: undefined as any, done: true });
+        for (const w of waiters) w.resolve({ value: undefined, done: true });
         waiters = [];
         try {
           socket?.end();
@@ -35,8 +38,13 @@ export function rpcStream(socketPath: string, req: Request): AsyncIterable<Reply
       const fail = (e: unknown) => {
         errored = e;
         done = true;
-        for (const w of waiters) w({ value: undefined as any, done: true });
+        for (const w of waiters) w.reject(e);
         waiters = [];
+        try {
+          socket?.end();
+        } catch {
+          /* ignore */
+        }
       };
 
       Bun.connect({
@@ -47,7 +55,7 @@ export function rpcStream(socketPath: string, req: Request): AsyncIterable<Reply
             s.write(encodeFrame(req));
           },
           data(_s: any, chunk: Uint8Array) {
-            buf += new TextDecoder().decode(chunk);
+            buf += decoder.decode(chunk);
             let parsed;
             try {
               parsed = parseFrames<Reply>(buf);
@@ -72,7 +80,13 @@ export function rpcStream(socketPath: string, req: Request): AsyncIterable<Reply
           if (errored) throw errored;
           if (queue.length) return { value: queue.shift()!, done: false };
           if (done) return { value: undefined as any, done: true };
-          return new Promise((resolve) => waiters.push(resolve));
+          return new Promise<IteratorResult<Reply>>((resolve, reject) =>
+            waiters.push({ resolve, reject }),
+          );
+        },
+        async return(value?: unknown): Promise<IteratorResult<Reply>> {
+          finish();
+          return { value: value as Reply, done: true };
         },
       };
     },

--- a/clients/cli/src/lobby/rpc-client.ts
+++ b/clients/cli/src/lobby/rpc-client.ts
@@ -1,0 +1,80 @@
+import { encodeFrame, parseFrames, type Reply, type Request } from "./protocol.ts";
+
+export async function rpcCall(socketPath: string, req: Request): Promise<Reply> {
+  for await (const r of rpcStream(socketPath, req)) {
+    if (r.final) return r;
+  }
+  throw new Error("daemon closed connection without a final reply");
+}
+
+export function rpcStream(socketPath: string, req: Request): AsyncIterable<Reply> {
+  return {
+    [Symbol.asyncIterator]() {
+      const queue: Reply[] = [];
+      let waiters: Array<(r: IteratorResult<Reply>) => void> = [];
+      let done = false;
+      let errored: unknown = null;
+      let buf = "";
+      let socket: any;
+
+      const push = (r: Reply) => {
+        if (waiters.length) waiters.shift()!({ value: r, done: false });
+        else queue.push(r);
+        if (r.final) finish();
+      };
+      const finish = () => {
+        done = true;
+        for (const w of waiters) w({ value: undefined as any, done: true });
+        waiters = [];
+        try {
+          socket?.end();
+        } catch {
+          /* ignore */
+        }
+      };
+      const fail = (e: unknown) => {
+        errored = e;
+        done = true;
+        for (const w of waiters) w({ value: undefined as any, done: true });
+        waiters = [];
+      };
+
+      Bun.connect({
+        unix: socketPath,
+        socket: {
+          open(s: any) {
+            socket = s;
+            s.write(encodeFrame(req));
+          },
+          data(_s: any, chunk: Uint8Array) {
+            buf += new TextDecoder().decode(chunk);
+            let parsed;
+            try {
+              parsed = parseFrames<Reply>(buf);
+            } catch (e) {
+              fail(e);
+              return;
+            }
+            buf = parsed.rest;
+            for (const f of parsed.frames) push(f);
+          },
+          close() {
+            if (!done) fail(new Error("daemon closed connection"));
+          },
+          error(_s: any, e: Error) {
+            fail(e);
+          },
+        },
+      }).catch(fail);
+
+      return {
+        async next(): Promise<IteratorResult<Reply>> {
+          if (errored) throw errored;
+          if (queue.length) return { value: queue.shift()!, done: false };
+          if (done) return { value: undefined as any, done: true };
+          return new Promise((resolve) => waiters.push(resolve));
+        },
+      };
+    },
+  };
+}

--- a/clients/cli/src/lobby/rpc-server.ts
+++ b/clients/cli/src/lobby/rpc-server.ts
@@ -221,6 +221,8 @@ export async function startRpcServer(opts: RpcServerOptions): Promise<RpcServer>
           }
           // Register endTail as the cleanup for this tail; it's idempotent.
           tailUnsubs.set(socket, [...(tailUnsubs.get(socket) ?? []), endTail]);
+          // One-time ack so the client knows the listeners are hot.
+          send(socket, { id: req.id, ok: true, result: { event: "registered" }, final: false });
           return;
         }
         default:

--- a/clients/cli/src/lobby/rpc-server.ts
+++ b/clients/cli/src/lobby/rpc-server.ts
@@ -31,6 +31,10 @@ export async function startRpcServer(opts: RpcServerOptions): Promise<RpcServer>
   await unlink(opts.socketPath).catch(() => {});
 
   let activeConns = 0;
+  // Only trigger idle auto-exit if at least one session was ever created.
+  // Without this guard, a plain `lobby ls` with sessions=0 would cause the
+  // daemon to exit when the connection closes.
+  let hadSessions = false;
   const tailUnsubs = new WeakMap<object, Array<() => void>>();
   const tailing = new WeakSet<object>();
 
@@ -66,7 +70,7 @@ export async function startRpcServer(opts: RpcServerOptions): Promise<RpcServer>
         activeConns--;
         for (const off of tailUnsubs.get(socket) ?? []) off();
         tailUnsubs.delete(socket);
-        if (activeConns === 0 && opts.manager.size() === 0) opts.onIdle?.();
+        if (hadSessions && activeConns === 0 && opts.manager.size() === 0) opts.onIdle?.();
       },
       error(_socket, err: Error) {
         console.warn(`[lobbyd] socket error: ${err.message}`);
@@ -97,6 +101,7 @@ export async function startRpcServer(opts: RpcServerOptions): Promise<RpcServer>
         case "spawn": {
           const a = req.args as any;
           const r = await opts.manager.spawn(a);
+          hadSessions = true;
           send(socket, { id: req.id, ok: true, result: r, final: true });
           return;
         }

--- a/clients/cli/src/lobby/rpc-server.ts
+++ b/clients/cli/src/lobby/rpc-server.ts
@@ -184,19 +184,43 @@ export async function startRpcServer(opts: RpcServerOptions): Promise<RpcServer>
           const a = req.args as any;
           const session = opts.manager.getOrThrow(a.name);
           const offs: Array<() => void> = [];
+          let tailEnded = false;
+          // Cleanup helper: unsubscribe all tail listeners and send final reply.
+          const endTail = () => {
+            if (tailEnded) return;
+            tailEnded = true;
+            for (const off of offs.splice(0)) off();
+            tailing.delete(socket);
+            send(socket, { id: req.id, ok: true, result: { event: "end", data: {} }, final: true });
+          };
           for (const ev of TAIL_EVENTS) {
-            offs.push(
-              session.lobby.on(ev, (data: unknown) => {
-                send(socket, {
-                  id: req.id,
-                  ok: true,
-                  result: { event: ev, data },
-                  final: false,
-                });
-              }),
-            );
+            if (ev === "stateChanged") {
+              offs.push(
+                session.lobby.on(ev, (state: unknown) => {
+                  send(socket, {
+                    id: req.id,
+                    ok: true,
+                    result: { event: ev, data: state },
+                    final: false,
+                  });
+                  if (state === "disconnected" || state === "failed") endTail();
+                }),
+              );
+            } else {
+              offs.push(
+                session.lobby.on(ev, (data: unknown) => {
+                  send(socket, {
+                    id: req.id,
+                    ok: true,
+                    result: { event: ev, data },
+                    final: false,
+                  });
+                }),
+              );
+            }
           }
-          tailUnsubs.set(socket, [...(tailUnsubs.get(socket) ?? []), ...offs]);
+          // Register endTail as the cleanup for this tail; it's idempotent.
+          tailUnsubs.set(socket, [...(tailUnsubs.get(socket) ?? []), endTail]);
           return;
         }
         default:

--- a/clients/cli/src/lobby/rpc-server.ts
+++ b/clients/cli/src/lobby/rpc-server.ts
@@ -1,7 +1,9 @@
 import { unlink } from "node:fs/promises";
 import type { ClientEvents } from "@silencer/lobby-sdk";
-import type { SessionManager } from "./session-manager.ts";
+import { NoSessionError, type SessionManager } from "./session-manager.ts";
 import { encodeFrame, parseFrames, type Reply, type Request } from "./protocol.ts";
+
+const GAME_CREATE_TIMEOUT_MS = 10_000;
 
 export interface RpcServerOptions {
   socketPath: string;
@@ -30,6 +32,7 @@ export async function startRpcServer(opts: RpcServerOptions): Promise<RpcServer>
 
   let activeConns = 0;
   const tailUnsubs = new WeakMap<object, Array<() => void>>();
+  const tailing = new WeakSet<object>();
 
   const server = Bun.listen({
     unix: opts.socketPath,
@@ -65,8 +68,9 @@ export async function startRpcServer(opts: RpcServerOptions): Promise<RpcServer>
         tailUnsubs.delete(socket);
         if (activeConns === 0 && opts.manager.size() === 0) opts.onIdle?.();
       },
-      error(_s, _e) {
-        /* swallow; close will fire */
+      error(_socket, err: Error) {
+        console.warn(`[lobbyd] socket error: ${err.message}`);
+        // close handler will fire next; cleanup happens there.
       },
     },
   });
@@ -123,11 +127,40 @@ export async function startRpcServer(opts: RpcServerOptions): Promise<RpcServer>
         case "game_create": {
           const a = req.args as any;
           const session = opts.manager.getOrThrow(a.name);
-          const off = session.lobby.on("newGame", (e: any) => {
-            off();
+          let off: (() => void) | null = null;
+          let timer: ReturnType<typeof setTimeout> | null = null;
+          const cleanup = () => {
+            if (timer) {
+              clearTimeout(timer);
+              timer = null;
+            }
+            if (off) {
+              off();
+              off = null;
+            }
+          };
+          off = session.lobby.on("newGame", (e: { game: { id: number } }) => {
+            cleanup();
             send(socket, { id: req.id, ok: true, result: { gameId: e.game.id }, final: true });
           });
-          session.lobby.createGame(a.game);
+          // Track for socket-close teardown.
+          tailUnsubs.set(socket, [...(tailUnsubs.get(socket) ?? []), cleanup]);
+          timer = setTimeout(() => {
+            cleanup();
+            send(socket, {
+              id: req.id,
+              ok: false,
+              error: "game_create timed out",
+              code: "TIMEOUT",
+              final: true,
+            });
+          }, GAME_CREATE_TIMEOUT_MS);
+          try {
+            session.lobby.createGame(a.game);
+          } catch (e) {
+            cleanup();
+            throw e; // outer catch routes to ERR
+          }
           return;
         }
         case "game_join": {
@@ -137,6 +170,17 @@ export async function startRpcServer(opts: RpcServerOptions): Promise<RpcServer>
           return;
         }
         case "tail": {
+          if (tailing.has(socket)) {
+            send(socket, {
+              id: req.id,
+              ok: false,
+              error: "already tailing on this connection",
+              code: "ALREADY_TAILING",
+              final: true,
+            });
+            return;
+          }
+          tailing.add(socket);
           const a = req.args as any;
           const session = opts.manager.getOrThrow(a.name);
           const offs: Array<() => void> = [];
@@ -166,7 +210,7 @@ export async function startRpcServer(opts: RpcServerOptions): Promise<RpcServer>
       }
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
-      const code = msg.startsWith("NO_SESSION") ? "NO_SESSION" : "ERR";
+      const code = e instanceof NoSessionError ? "NO_SESSION" : "ERR";
       send(socket, { id: req.id, ok: false, error: msg, code, final: true });
     }
   }

--- a/clients/cli/src/lobby/rpc-server.ts
+++ b/clients/cli/src/lobby/rpc-server.ts
@@ -1,0 +1,183 @@
+import { unlink } from "node:fs/promises";
+import type { ClientEvents } from "@silencer/lobby-sdk";
+import type { SessionManager } from "./session-manager.ts";
+import { encodeFrame, parseFrames, type Reply, type Request } from "./protocol.ts";
+
+export interface RpcServerOptions {
+  socketPath: string;
+  manager: SessionManager;
+  onIdle?: () => void;
+}
+
+export interface RpcServer {
+  stop(): Promise<void>;
+  activeConnections(): number;
+}
+
+const TAIL_EVENTS = [
+  "chat",
+  "presence",
+  "channel",
+  "newGame",
+  "delGame",
+  "stateChanged",
+] as const satisfies (keyof ClientEvents)[];
+
+export async function startRpcServer(opts: RpcServerOptions): Promise<RpcServer> {
+  // Best-effort cleanup of stale socket; bind will fail loudly if a live
+  // peer is still listening, which is exactly what we want.
+  await unlink(opts.socketPath).catch(() => {});
+
+  let activeConns = 0;
+  const tailUnsubs = new WeakMap<object, Array<() => void>>();
+
+  const server = Bun.listen({
+    unix: opts.socketPath,
+    socket: {
+      open(socket) {
+        activeConns++;
+        (socket as any).__buf = "";
+      },
+      data(socket, chunk: Uint8Array) {
+        (socket as any).__buf += new TextDecoder().decode(chunk);
+        let parsed;
+        try {
+          parsed = parseFrames<Request>((socket as any).__buf);
+        } catch (e) {
+          socket.write(
+            encodeFrame({
+              id: 0,
+              ok: false,
+              error: (e as Error).message,
+              code: "BAD_FRAME",
+              final: true,
+            }),
+          );
+          socket.end();
+          return;
+        }
+        (socket as any).__buf = parsed.rest;
+        for (const req of parsed.frames) handle(socket, req);
+      },
+      close(socket) {
+        activeConns--;
+        for (const off of tailUnsubs.get(socket) ?? []) off();
+        tailUnsubs.delete(socket);
+        if (activeConns === 0 && opts.manager.size() === 0) opts.onIdle?.();
+      },
+      error(_s, _e) {
+        /* swallow; close will fire */
+      },
+    },
+  });
+
+  function send(socket: any, reply: Reply): void {
+    try {
+      socket.write(encodeFrame(reply));
+    } catch {
+      /* peer gone */
+    }
+  }
+
+  async function handle(socket: any, req: Request): Promise<void> {
+    try {
+      switch (req.op) {
+        case "ls":
+          send(socket, {
+            id: req.id,
+            ok: true,
+            result: { sessions: opts.manager.list() },
+            final: true,
+          });
+          return;
+        case "spawn": {
+          const a = req.args as any;
+          const r = await opts.manager.spawn(a);
+          send(socket, { id: req.id, ok: true, result: r, final: true });
+          return;
+        }
+        case "kill": {
+          await opts.manager.kill((req.args as any).name);
+          send(socket, { id: req.id, ok: true, result: {}, final: true });
+          if (opts.manager.size() === 0 && activeConns <= 1) opts.onIdle?.();
+          return;
+        }
+        case "kill_all": {
+          await opts.manager.killAll();
+          send(socket, { id: req.id, ok: true, result: {}, final: true });
+          opts.onIdle?.();
+          return;
+        }
+        case "chat": {
+          const a = req.args as any;
+          opts.manager.getOrThrow(a.name).lobby.sendChat(a.channel, a.text);
+          send(socket, { id: req.id, ok: true, result: {}, final: true });
+          return;
+        }
+        case "join_channel": {
+          const a = req.args as any;
+          opts.manager.getOrThrow(a.name).lobby.joinChannel(a.channel);
+          send(socket, { id: req.id, ok: true, result: {}, final: true });
+          return;
+        }
+        case "game_create": {
+          const a = req.args as any;
+          const session = opts.manager.getOrThrow(a.name);
+          const off = session.lobby.on("newGame", (e: any) => {
+            off();
+            send(socket, { id: req.id, ok: true, result: { gameId: e.game.id }, final: true });
+          });
+          session.lobby.createGame(a.game);
+          return;
+        }
+        case "game_join": {
+          const a = req.args as any;
+          opts.manager.getOrThrow(a.name).lobby.setGame(a.gameId, 0 /* Lobby */);
+          send(socket, { id: req.id, ok: true, result: {}, final: true });
+          return;
+        }
+        case "tail": {
+          const a = req.args as any;
+          const session = opts.manager.getOrThrow(a.name);
+          const offs: Array<() => void> = [];
+          for (const ev of TAIL_EVENTS) {
+            offs.push(
+              session.lobby.on(ev, (data: unknown) => {
+                send(socket, {
+                  id: req.id,
+                  ok: true,
+                  result: { event: ev, data },
+                  final: false,
+                });
+              }),
+            );
+          }
+          tailUnsubs.set(socket, [...(tailUnsubs.get(socket) ?? []), ...offs]);
+          return;
+        }
+        default:
+          send(socket, {
+            id: req.id,
+            ok: false,
+            error: `unknown op: ${req.op}`,
+            code: "BAD_OP",
+            final: true,
+          });
+      }
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      const code = msg.startsWith("NO_SESSION") ? "NO_SESSION" : "ERR";
+      send(socket, { id: req.id, ok: false, error: msg, code, final: true });
+    }
+  }
+
+  return {
+    async stop() {
+      server.stop(true);
+      await unlink(opts.socketPath).catch(() => {});
+    },
+    activeConnections() {
+      return activeConns;
+    },
+  };
+}

--- a/clients/cli/src/lobby/session-manager.ts
+++ b/clients/cli/src/lobby/session-manager.ts
@@ -5,6 +5,13 @@
 
 import type { ClientEvents, ConnectionState, LobbyGame } from "@silencer/lobby-sdk";
 
+export class NoSessionError extends Error {
+  readonly code = "NO_SESSION" as const;
+  constructor(public readonly name: string) {
+    super(`NO_SESSION: ${name}`);
+  }
+}
+
 export interface LobbyLike {
   readonly state: ConnectionState;
   readonly accountId: number;
@@ -112,7 +119,7 @@ export class SessionManager {
 
   async kill(name: string): Promise<void> {
     const s = this.sessions.get(name);
-    if (!s) throw new Error(`NO_SESSION: ${name}`);
+    if (!s) throw new NoSessionError(name);
     this.sessions.delete(name);
     await s.lobby.disconnect();
   }
@@ -124,7 +131,7 @@ export class SessionManager {
 
   getOrThrow(name: string): Session {
     const s = this.sessions.get(name);
-    if (!s) throw new Error(`NO_SESSION: ${name}`);
+    if (!s) throw new NoSessionError(name);
     return s;
   }
 

--- a/clients/cli/src/lobby/session-manager.ts
+++ b/clients/cli/src/lobby/session-manager.ts
@@ -3,26 +3,20 @@
 // Decoupled from @silencer/lobby-sdk via the LobbyLike interface so tests
 // can substitute an in-memory fake without standing up a real lobby server.
 
-import type { LobbyClient as RealLobbyClient } from "@silencer/lobby-sdk";
+import type { ClientEvents, ConnectionState, LobbyGame } from "@silencer/lobby-sdk";
 
 export interface LobbyLike {
-  readonly state:
-    | "disconnected"
-    | "connecting"
-    | "awaiting_version"
-    | "awaiting_auth"
-    | "authenticated"
-    | "failed";
+  readonly state: ConnectionState;
   readonly accountId: number;
   readonly lastError: string;
-  on(event: string, fn: (...args: any[]) => void): () => void;
+  on<K extends keyof ClientEvents>(event: K, fn: ClientEvents[K]): () => void;
   connect(): Promise<void>;
   disconnect(): Promise<void>;
   sendVersion(): void;
   sendCredentials(user: string, pass: string): void;
   sendChat(channel: string, text: string): void;
   joinChannel(channel: string): void;
-  createGame(g: any): void;
+  createGame(g: LobbyGame): void;
   setGame(gameId: number, status: number): void;
 }
 
@@ -154,10 +148,10 @@ export class SessionManager {
 export async function realLobbyFactory(): Promise<LobbyFactory> {
   const sdk = await import("@silencer/lobby-sdk");
   return (cfg) =>
-    new (sdk.LobbyClient as typeof RealLobbyClient)({
+    new sdk.LobbyClient({
       host: cfg.host,
       port: cfg.port,
       version: cfg.version,
       platform: cfg.platform as 0 | 1 | 2,
-    }) as unknown as LobbyLike;
+    });
 }

--- a/clients/cli/src/lobby/session-manager.ts
+++ b/clients/cli/src/lobby/session-manager.ts
@@ -1,0 +1,163 @@
+// In-memory session map for lobbyd. Each session wraps one LobbyClient.
+//
+// Decoupled from @silencer/lobby-sdk via the LobbyLike interface so tests
+// can substitute an in-memory fake without standing up a real lobby server.
+
+import type { LobbyClient as RealLobbyClient } from "@silencer/lobby-sdk";
+
+export interface LobbyLike {
+  readonly state:
+    | "disconnected"
+    | "connecting"
+    | "awaiting_version"
+    | "awaiting_auth"
+    | "authenticated"
+    | "failed";
+  readonly accountId: number;
+  readonly lastError: string;
+  on(event: string, fn: (...args: any[]) => void): () => void;
+  connect(): Promise<void>;
+  disconnect(): Promise<void>;
+  sendVersion(): void;
+  sendCredentials(user: string, pass: string): void;
+  sendChat(channel: string, text: string): void;
+  joinChannel(channel: string): void;
+  createGame(g: any): void;
+  setGame(gameId: number, status: number): void;
+}
+
+export type LobbyFactory = (cfg: {
+  host: string;
+  port: number;
+  version: string;
+  platform: number;
+}) => LobbyLike;
+
+export interface SpawnArgs {
+  name: string;
+  host: string;
+  port: number;
+  version: string;
+  platform: number;
+  user: string;
+  pass: string;
+}
+
+export interface Session {
+  name: string;
+  lobby: LobbyLike;
+  host: string;
+  port: number;
+}
+
+export interface SessionSummary {
+  name: string;
+  state: string;
+  accountId: number;
+  host: string;
+  port: number;
+}
+
+const SPAWN_TIMEOUT_MS = 10_000;
+
+export class SessionManager {
+  private sessions = new Map<string, Session>();
+  constructor(private factory: LobbyFactory) {}
+
+  async spawn(args: SpawnArgs): Promise<{ accountId: number }> {
+    if (this.sessions.has(args.name)) {
+      throw new Error(`session "${args.name}" already exists`);
+    }
+    const lobby = this.factory({
+      host: args.host,
+      port: args.port,
+      version: args.version,
+      platform: args.platform,
+    });
+    const session: Session = { name: args.name, lobby, host: args.host, port: args.port };
+    // Reserve the slot eagerly so concurrent spawns can't race the duplicate check.
+    this.sessions.set(args.name, session);
+
+    try {
+      const result = await new Promise<{ accountId: number }>((resolve, reject) => {
+        const timer = setTimeout(() => {
+          cleanup();
+          reject(new Error(`spawn "${args.name}" timed out after ${SPAWN_TIMEOUT_MS}ms`));
+        }, SPAWN_TIMEOUT_MS);
+        const off = lobby.on("stateChanged", (s: string) => {
+          if (s === "awaiting_version") lobby.sendVersion();
+          else if (s === "awaiting_auth") lobby.sendCredentials(args.user, args.pass);
+          else if (s === "authenticated") {
+            cleanup();
+            resolve({ accountId: lobby.accountId });
+          } else if (s === "failed") {
+            cleanup();
+            reject(new Error(lobby.lastError || "auth failed"));
+          }
+        });
+        const cleanup = () => {
+          clearTimeout(timer);
+          off();
+        };
+        lobby.connect().catch((e) => {
+          cleanup();
+          reject(e);
+        });
+      });
+      return result;
+    } catch (e) {
+      this.sessions.delete(args.name);
+      try {
+        await lobby.disconnect();
+      } catch {
+        /* ignore */
+      }
+      throw e;
+    }
+  }
+
+  async kill(name: string): Promise<void> {
+    const s = this.sessions.get(name);
+    if (!s) throw new Error(`NO_SESSION: ${name}`);
+    this.sessions.delete(name);
+    await s.lobby.disconnect();
+  }
+
+  async killAll(): Promise<void> {
+    const names = [...this.sessions.keys()];
+    await Promise.all(names.map((n) => this.kill(n).catch(() => {})));
+  }
+
+  getOrThrow(name: string): Session {
+    const s = this.sessions.get(name);
+    if (!s) throw new Error(`NO_SESSION: ${name}`);
+    return s;
+  }
+
+  list(): SessionSummary[] {
+    return [...this.sessions.values()].map((s) => ({
+      name: s.name,
+      state: s.lobby.state,
+      accountId: s.lobby.accountId,
+      host: s.host,
+      port: s.port,
+    }));
+  }
+
+  size(): number {
+    return this.sessions.size;
+  }
+}
+
+// Convenience factory used by the real daemon. Lazily imports the SDK so
+// unit tests don't pay the cost of resolving it.
+export async function realLobbyFactory(): Promise<LobbyFactory> {
+  const sdk = await import("@silencer/lobby-sdk");
+  return (cfg) =>
+    new (sdk.LobbyClient as typeof RealLobbyClient)({
+      host: cfg.host,
+      port: cfg.port,
+      version: cfg.version,
+      platform: cfg.platform as 0 | 1 | 2,
+    }) as unknown as LobbyLike;
+}

--- a/clients/cli/src/lobby/spawn.ts
+++ b/clients/cli/src/lobby/spawn.ts
@@ -1,7 +1,7 @@
 import { mkdirSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { resolveLobbydDir, socketPath } from "./paths.ts";
+import { logPath, resolveLobbydDir, socketPath } from "./paths.ts";
 
 const POLL_INTERVAL_MS = 50;
 const POLL_TIMEOUT_MS = 5_000;
@@ -30,6 +30,7 @@ export async function ensureDaemon(): Promise<string> {
   const dir = resolveLobbydDir();
   mkdirSync(dir, { recursive: true });
   const sock = socketPath(dir);
+  const log = logPath(dir);
   if (await probe(sock)) return sock;
 
   // Daemon entry lives next to this file at runtime.
@@ -40,7 +41,9 @@ export async function ensureDaemon(): Promise<string> {
     cmd: ["bun", daemonEntry],
     stdio: ["ignore", "ignore", "ignore"],
     // Detach so the parent CLI can exit while the daemon stays up.
-    // unref() lets node-style event-loop drain even if we forget to wait.
+    // unref() removes the child handle from the parent's event-loop
+    // refcount; combined with stdio: ignore, the daemon survives the
+    // CLI's exit.
   }).unref();
 
   const deadline = Date.now() + POLL_TIMEOUT_MS;
@@ -48,5 +51,7 @@ export async function ensureDaemon(): Promise<string> {
     if (await probe(sock)) return sock;
     await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
   }
-  throw new Error(`lobbyd did not start within ${POLL_TIMEOUT_MS}ms (socket: ${sock})`);
+  throw new Error(
+    `lobbyd did not start within ${POLL_TIMEOUT_MS}ms (socket: ${sock}; check ${log} for startup errors)`,
+  );
 }

--- a/clients/cli/src/lobby/spawn.ts
+++ b/clients/cli/src/lobby/spawn.ts
@@ -1,0 +1,52 @@
+import { mkdirSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { resolveLobbydDir, socketPath } from "./paths.ts";
+
+const POLL_INTERVAL_MS = 50;
+const POLL_TIMEOUT_MS = 5_000;
+
+async function probe(sock: string): Promise<boolean> {
+  try {
+    await Bun.connect({
+      unix: sock,
+      socket: {
+        open(s) {
+          s.end();
+        },
+        data() {},
+        close() {},
+        error() {},
+      },
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Returns the resolved socket path, spawning the daemon if not yet listening. */
+export async function ensureDaemon(): Promise<string> {
+  const dir = resolveLobbydDir();
+  mkdirSync(dir, { recursive: true });
+  const sock = socketPath(dir);
+  if (await probe(sock)) return sock;
+
+  // Daemon entry lives next to this file at runtime.
+  const here = fileURLToPath(import.meta.url);
+  const daemonEntry = resolve(dirname(here), "daemon.ts");
+
+  Bun.spawn({
+    cmd: ["bun", daemonEntry],
+    stdio: ["ignore", "ignore", "ignore"],
+    // Detach so the parent CLI can exit while the daemon stays up.
+    // unref() lets node-style event-loop drain even if we forget to wait.
+  }).unref();
+
+  const deadline = Date.now() + POLL_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    if (await probe(sock)) return sock;
+    await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+  }
+  throw new Error(`lobbyd did not start within ${POLL_TIMEOUT_MS}ms (socket: ${sock})`);
+}

--- a/clients/cli/tests/lobby/daemon-integration.test.ts
+++ b/clients/cli/tests/lobby/daemon-integration.test.ts
@@ -1,0 +1,113 @@
+// Drives the real daemon via spawn.ensureDaemon, against an in-memory fake
+// SessionManager? No — easier: hit the daemon's RPC server directly with a
+// SessionManager that uses our fake LobbyClient. That keeps this test
+// hermetic (no real lobby server required).
+//
+// Strategy: instead of forking a child process, build the same wiring
+// (manager + server) in-process and exercise it through the rpc-client.
+// The detached child fork is exercised manually in Task 10's smoke step.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { rpcCall, rpcStream } from "../../src/lobby/rpc-client.ts";
+import { startRpcServer, type RpcServer } from "../../src/lobby/rpc-server.ts";
+import { SessionManager } from "../../src/lobby/session-manager.ts";
+
+class FakeLobby {
+  state: any = "disconnected";
+  accountId = 0;
+  lastError = "";
+  ls: Record<string, Set<any>> = {};
+  on(e: string, fn: any) {
+    (this.ls[e] ??= new Set()).add(fn);
+    return () => this.ls[e]?.delete(fn);
+  }
+  emit(e: string, ...a: any[]) {
+    for (const fn of this.ls[e] ?? []) fn(...a);
+  }
+  async connect() {
+    queueMicrotask(() => {
+      this.state = "authenticated";
+      this.accountId = 99;
+      this.emit("stateChanged", "authenticated");
+    });
+  }
+  async disconnect() {
+    this.state = "disconnected";
+    this.emit("stateChanged", "disconnected");
+  }
+  sendVersion() {}
+  sendCredentials() {}
+  sendChat(channel: string, text: string) {
+    this.emit("chat", { channel, text, color: 0, brightness: 0 });
+  }
+  joinChannel(c: string) {
+    this.emit("channel", c);
+  }
+  createGame(g: any) {
+    this.emit("newGame", { status: 1, game: { ...g, id: 12345 } });
+  }
+  setGame() {}
+}
+
+let tmp: string;
+let sock: string;
+let server: RpcServer;
+beforeEach(async () => {
+  tmp = mkdtempSync(join(tmpdir(), "lobbyd-int-"));
+  sock = join(tmp, "lobbyd.sock");
+  const mgr = new SessionManager(() => new FakeLobby());
+  server = await startRpcServer({ socketPath: sock, manager: mgr });
+});
+afterEach(async () => {
+  await server.stop();
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+describe("daemon integration", () => {
+  test("spawn → chat → tail flow", async () => {
+    const spawn = await rpcCall(sock, {
+      id: 1,
+      op: "spawn",
+      args: { name: "alice", host: "h", port: 1, version: "v", platform: 0, user: "u", pass: "p" },
+    });
+    expect(spawn.ok).toBe(true);
+
+    // Open a tail before sending chat so we observe the emitted event.
+    const tailIter = rpcStream(sock, { id: 2, op: "tail", args: { name: "alice" }, stream: true });
+    const events: any[] = [];
+    const consumer = (async () => {
+      for await (const r of tailIter) {
+        if (r.final) break;
+        events.push(r.result);
+      }
+    })();
+    // Give the tail RPC a tick to register listeners.
+    await new Promise((r) => setTimeout(r, 20));
+
+    const chat = await rpcCall(sock, {
+      id: 3,
+      op: "chat",
+      args: { name: "alice", channel: "main", text: "hi" },
+    });
+    expect(chat.ok).toBe(true);
+
+    // Game create should resolve once the fake echoes a newGame event.
+    const create = await rpcCall(sock, {
+      id: 4,
+      op: "game_create",
+      args: { name: "alice", game: { id: 0 } },
+    });
+    expect(create.ok).toBe(true);
+    expect((create.result as any).gameId).toBe(12345);
+
+    // Trigger end-of-tail by killing the session.
+    await rpcCall(sock, { id: 5, op: "kill", args: { name: "alice" } });
+    await consumer;
+
+    const seenChat = events.some((e) => e.event === "chat" && e.data.text === "hi");
+    expect(seenChat).toBe(true);
+  });
+});

--- a/clients/cli/tests/lobby/daemon-integration.test.ts
+++ b/clients/cli/tests/lobby/daemon-integration.test.ts
@@ -76,16 +76,25 @@ describe("daemon integration", () => {
     expect(spawn.ok).toBe(true);
 
     // Open a tail before sending chat so we observe the emitted event.
-    const tailIter = rpcStream(sock, { id: 2, op: "tail", args: { name: "alice" }, stream: true });
+    const iter = rpcStream(sock, {
+      id: 2,
+      op: "tail",
+      args: { name: "alice" },
+      stream: true,
+    })[Symbol.asyncIterator]();
+    // Wait for the tail to ack registration before sending events through it.
+    const ack = await iter.next();
+    expect((ack.value as any).result).toEqual({ event: "registered" });
+
     const events: any[] = [];
     const consumer = (async () => {
-      for await (const r of tailIter) {
-        if (r.final) break;
-        events.push(r.result);
+      for (;;) {
+        const r = await iter.next();
+        if (r.done) break;
+        if (r.value.final) break;
+        events.push(r.value.result);
       }
     })();
-    // Give the tail RPC a tick to register listeners.
-    await new Promise((r) => setTimeout(r, 20));
 
     const chat = await rpcCall(sock, {
       id: 3,

--- a/clients/cli/tests/lobby/daemon-integration.test.ts
+++ b/clients/cli/tests/lobby/daemon-integration.test.ts
@@ -119,4 +119,73 @@ describe("daemon integration", () => {
     const seenChat = events.some((e) => e.event === "chat" && e.data.text === "hi");
     expect(seenChat).toBe(true);
   });
+
+  // Regression for Devin-flagged JSON round-trip bug: `new Uint8Array(20)` in
+  // commands.ts serialized to {"0":0,...,"19":0} (object keys, not an array)
+  // and `g.mapHash.length` came out undefined on the daemon side, causing the
+  // SDK's encodeLobbyGame to throw before any bytes hit the wire. The fix is
+  // to send mapHash as a regular array; this test asserts the wire shape
+  // round-trips with a usable .length.
+  test("game_create payload survives JSON round-trip with usable mapHash", async () => {
+    let receivedHash: unknown;
+    class CapturingLobby extends FakeLobby {
+      override createGame(g: any) {
+        receivedHash = g.mapHash;
+        super.createGame(g);
+      }
+    }
+    const mgr = new SessionManager(() => new CapturingLobby());
+    const localSock = join(tmp, "lobbyd-cap.sock");
+    const localServer = await startRpcServer({ socketPath: localSock, manager: mgr });
+    try {
+      await rpcCall(localSock, {
+        id: 1,
+        op: "spawn",
+        args: {
+          name: "alice",
+          host: "h",
+          port: 1,
+          version: "v",
+          platform: 0,
+          user: "u",
+          pass: "p",
+        },
+      });
+      const r = await rpcCall(localSock, {
+        id: 2,
+        op: "game_create",
+        args: {
+          name: "alice",
+          // Mirrors what commands.ts builds; the regression here is whether
+          // an array of 20 zeros survives the JSON round-trip with .length === 20.
+          game: {
+            id: 0,
+            name: "TEST",
+            password: "",
+            mapName: "",
+            maxPlayers: 8,
+            maxTeams: 2,
+            minLevel: 0,
+            maxLevel: 0,
+            securityLevel: 0,
+            extra: 0,
+            players: 0,
+            state: 0,
+            accountId: 0,
+            hostname: "",
+            mapHash: new Array(20).fill(0),
+            port: 0,
+          },
+        },
+      });
+      expect(r.ok).toBe(true);
+      // The bug class: if mapHash was sent as a Uint8Array, JSON serialization
+      // would drop .length on the daemon side. We assert .length resolves and
+      // every element is iterable as a number.
+      expect((receivedHash as unknown[])?.length).toBe(20);
+      for (let i = 0; i < 20; i++) expect((receivedHash as number[])[i]).toBe(0);
+    } finally {
+      await localServer.stop();
+    }
+  });
 });

--- a/clients/cli/tests/lobby/paths.test.ts
+++ b/clients/cli/tests/lobby/paths.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { describe, expect, test, afterEach } from "bun:test";
 import { resolveLobbydDir, socketPath, logPath, MAX_SUN_PATH } from "../../src/lobby/paths.ts";
 
 describe("resolveLobbydDir", () => {

--- a/clients/cli/tests/lobby/paths.test.ts
+++ b/clients/cli/tests/lobby/paths.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test, afterEach } from "bun:test";
-import { resolveLobbydDir, socketPath, logPath, MAX_SUN_PATH } from "../../src/lobby/paths.ts";
+import { resolveLobbydDir, socketPath, logPath, MAX_SOCKET_PATH } from "../../src/lobby/paths.ts";
 
 describe("resolveLobbydDir", () => {
   const origPlatform = process.platform;
@@ -46,6 +46,12 @@ describe("resolveLobbydDir", () => {
     Object.defineProperty(process, "platform", { value: "win32" });
     expect(resolveLobbydDir()).toBe("C:\\Users\\u\\AppData\\Local\\Silencer\\lobbyd");
   });
+
+  test("unknown platform falls back to /tmp/silencer", () => {
+    delete process.env.SILENCER_LOBBYD_DIR;
+    Object.defineProperty(process, "platform", { value: "freebsd" });
+    expect(resolveLobbydDir()).toBe("/tmp/silencer");
+  });
 });
 
 describe("socketPath / logPath", () => {
@@ -55,7 +61,7 @@ describe("socketPath / logPath", () => {
   test("logPath is dir + lobbyd.log", () => {
     expect(logPath("/tmp/silencer")).toBe("/tmp/silencer/lobbyd.log");
   });
-  test("socketPath throws when resolved path exceeds MAX_SUN_PATH on darwin", () => {
+  test("socketPath throws when resolved path exceeds MAX_SOCKET_PATH on darwin", () => {
     const longDir = "/" + "a".repeat(120);
     const origPlatform = process.platform;
     Object.defineProperty(process, "platform", { value: "darwin" });
@@ -64,6 +70,6 @@ describe("socketPath / logPath", () => {
   });
 });
 
-test("MAX_SUN_PATH is 100 (10-byte safety margin under macOS's 104)", () => {
-  expect(MAX_SUN_PATH).toBe(100);
+test("MAX_SOCKET_PATH is 100 (104-byte sun_path; 100-byte cap leaves a 3-byte cushion for the trailing NUL)", () => {
+  expect(MAX_SOCKET_PATH).toBe(100);
 });

--- a/clients/cli/tests/lobby/paths.test.ts
+++ b/clients/cli/tests/lobby/paths.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { resolveLobbydDir, socketPath, logPath, MAX_SUN_PATH } from "../../src/lobby/paths.ts";
+
+describe("resolveLobbydDir", () => {
+  const origPlatform = process.platform;
+  const origEnv = { ...process.env };
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { value: origPlatform });
+    process.env = { ...origEnv };
+  });
+
+  test("override env wins on every platform", () => {
+    process.env.SILENCER_LOBBYD_DIR = "/custom/dir";
+    Object.defineProperty(process, "platform", { value: "linux" });
+    expect(resolveLobbydDir()).toBe("/custom/dir");
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    expect(resolveLobbydDir()).toBe("/custom/dir");
+    Object.defineProperty(process, "platform", { value: "win32" });
+    expect(resolveLobbydDir()).toBe("/custom/dir");
+  });
+
+  test("linux uses XDG_RUNTIME_DIR/silencer when set", () => {
+    delete process.env.SILENCER_LOBBYD_DIR;
+    process.env.XDG_RUNTIME_DIR = "/run/user/1000";
+    Object.defineProperty(process, "platform", { value: "linux" });
+    expect(resolveLobbydDir()).toBe("/run/user/1000/silencer");
+  });
+
+  test("linux falls back to /tmp/silencer when XDG_RUNTIME_DIR unset", () => {
+    delete process.env.SILENCER_LOBBYD_DIR;
+    delete process.env.XDG_RUNTIME_DIR;
+    Object.defineProperty(process, "platform", { value: "linux" });
+    expect(resolveLobbydDir()).toBe("/tmp/silencer");
+  });
+
+  test("macOS uses TMPDIR/silencer", () => {
+    delete process.env.SILENCER_LOBBYD_DIR;
+    process.env.TMPDIR = "/var/folders/xx/yy/T/";
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    expect(resolveLobbydDir()).toBe("/var/folders/xx/yy/T/silencer");
+  });
+
+  test("windows uses LOCALAPPDATA\\Silencer\\lobbyd", () => {
+    delete process.env.SILENCER_LOBBYD_DIR;
+    process.env.LOCALAPPDATA = "C:\\Users\\u\\AppData\\Local";
+    Object.defineProperty(process, "platform", { value: "win32" });
+    expect(resolveLobbydDir()).toBe("C:\\Users\\u\\AppData\\Local\\Silencer\\lobbyd");
+  });
+});
+
+describe("socketPath / logPath", () => {
+  test("socketPath is dir + lobbyd.sock", () => {
+    expect(socketPath("/tmp/silencer")).toBe("/tmp/silencer/lobbyd.sock");
+  });
+  test("logPath is dir + lobbyd.log", () => {
+    expect(logPath("/tmp/silencer")).toBe("/tmp/silencer/lobbyd.log");
+  });
+  test("socketPath throws when resolved path exceeds MAX_SUN_PATH on darwin", () => {
+    const longDir = "/" + "a".repeat(120);
+    const origPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    expect(() => socketPath(longDir)).toThrow(/exceeds.*sun_path/);
+    Object.defineProperty(process, "platform", { value: origPlatform });
+  });
+});
+
+test("MAX_SUN_PATH is 100 (10-byte safety margin under macOS's 104)", () => {
+  expect(MAX_SUN_PATH).toBe(100);
+});

--- a/clients/cli/tests/lobby/protocol.test.ts
+++ b/clients/cli/tests/lobby/protocol.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import { encodeFrame, parseFrames, type Reply, type Request } from "../../src/lobby/protocol.ts";
+
+describe("encodeFrame", () => {
+  test("appends a single trailing newline", () => {
+    const out = encodeFrame({ id: 1, ok: true, final: true });
+    expect(out.endsWith("\n")).toBe(true);
+    expect(out.split("\n").filter(Boolean).length).toBe(1);
+  });
+  test("round-trips through JSON.parse", () => {
+    const r: Reply = { id: 7, ok: false, error: "x", code: "Y", final: true };
+    expect(JSON.parse(encodeFrame(r).trim())).toEqual(r);
+  });
+});
+
+describe("parseFrames", () => {
+  test("returns parsed objects and the unconsumed remainder", () => {
+    const a: Request = { id: 1, op: "ls", args: {} };
+    const b: Request = { id: 2, op: "kill", args: { name: "alice" } };
+    const buf = encodeFrame(a) + encodeFrame(b) + '{"id":3,"op":"x"';
+    const { frames, rest } = parseFrames<Request>(buf);
+    expect(frames).toEqual([a, b]);
+    expect(rest).toBe('{"id":3,"op":"x"');
+  });
+  test("empty input → empty frames, empty rest", () => {
+    expect(parseFrames("")).toEqual({ frames: [], rest: "" });
+  });
+  test("malformed JSON throws with the offending line", () => {
+    expect(() => parseFrames("{not json}\n")).toThrow(/{not json}/);
+  });
+});

--- a/clients/cli/tests/lobby/rpc-client.test.ts
+++ b/clients/cli/tests/lobby/rpc-client.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { rpcCall, rpcStream } from "../../src/lobby/rpc-client.ts";
+import { encodeFrame, parseFrames, type Reply, type Request } from "../../src/lobby/protocol.ts";
+
+let tmp: string;
+let sock: string;
+let server: ReturnType<typeof Bun.listen>;
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), "rpcclient-"));
+  sock = join(tmp, "s.sock");
+});
+afterEach(() => {
+  server?.stop(true);
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+function startEcho(reply: (req: Request) => Reply | Reply[]): void {
+  server = Bun.listen({
+    unix: sock,
+    socket: {
+      open(s) {
+        (s as any).__b = "";
+      },
+      data(s, chunk) {
+        (s as any).__b += new TextDecoder().decode(chunk);
+        const { frames, rest } = parseFrames<Request>((s as any).__b);
+        (s as any).__b = rest;
+        for (const f of frames) {
+          const out = reply(f);
+          for (const r of Array.isArray(out) ? out : [out]) s.write(encodeFrame(r));
+        }
+      },
+      close() {},
+      error() {},
+    },
+  });
+}
+
+describe("rpcCall", () => {
+  test("returns the single final reply", async () => {
+    startEcho((req) => ({ id: req.id, ok: true, result: { echoed: req.op }, final: true }));
+    const r = await rpcCall(sock, { id: 1, op: "ping", args: {} });
+    expect(r).toEqual({ id: 1, ok: true, result: { echoed: "ping" }, final: true });
+  });
+
+  test("rejects when daemon socket is missing", async () => {
+    const missing = join(tmp, "nope.sock");
+    await expect(rpcCall(missing, { id: 1, op: "x", args: {} })).rejects.toThrow();
+  });
+});
+
+describe("rpcStream", () => {
+  test("yields frames until final", async () => {
+    startEcho((req) => [
+      { id: req.id, ok: true, result: { event: "a" }, final: false },
+      { id: req.id, ok: true, result: { event: "b" }, final: false },
+      { id: req.id, ok: true, result: {}, final: true },
+    ]);
+    const out: Reply[] = [];
+    for await (const r of rpcStream(sock, { id: 1, op: "tail", args: {}, stream: true }))
+      out.push(r);
+    expect(out.map((r) => (r.result as any).event ?? "<final>")).toEqual(["a", "b", "<final>"]);
+  });
+});

--- a/clients/cli/tests/lobby/rpc-client.test.ts
+++ b/clients/cli/tests/lobby/rpc-client.test.ts
@@ -66,3 +66,79 @@ describe("rpcStream", () => {
     expect(out.map((r) => (r.result as any).event ?? "<final>")).toEqual(["a", "b", "<final>"]);
   });
 });
+
+describe("rpcStream error semantics", () => {
+  test("pending waiter rejects when daemon closes mid-stream", async () => {
+    // Echo replies one frame and then stops the server, simulating mid-stream close.
+    let serverSocket: any;
+    server = Bun.listen({
+      unix: sock,
+      socket: {
+        open(s) {
+          serverSocket = s;
+          (s as any).__b = "";
+        },
+        data(s, chunk) {
+          (s as any).__b += new TextDecoder().decode(chunk);
+          const { frames, rest } = parseFrames<Request>((s as any).__b);
+          (s as any).__b = rest;
+          for (const f of frames) {
+            // Send one non-final frame, then close.
+            s.write(encodeFrame({ id: f.id, ok: true, result: { event: "a" }, final: false }));
+            s.end();
+          }
+        },
+        close() {},
+        error() {},
+      },
+    });
+
+    const out: Reply[] = [];
+    let errMsg = "";
+    try {
+      for await (const r of rpcStream(sock, { id: 1, op: "tail", args: {}, stream: true })) {
+        out.push(r);
+      }
+    } catch (e) {
+      errMsg = (e as Error).message;
+    }
+    expect(out).toHaveLength(1);
+    expect(errMsg).toMatch(/closed connection/);
+  });
+
+  test("malformed reply propagates as iterator error", async () => {
+    server = Bun.listen({
+      unix: sock,
+      socket: {
+        open(s) {
+          s.write("{not json}\n");
+          s.end();
+        },
+        data() {},
+        close() {},
+        error() {},
+      },
+    });
+    let errMsg = "";
+    try {
+      for await (const _r of rpcStream(sock, { id: 1, op: "x", args: {} })) {
+        // shouldn't yield anything
+      }
+    } catch (e) {
+      errMsg = (e as Error).message;
+    }
+    expect(errMsg).toMatch(/malformed RPC frame/);
+  });
+
+  test("two frames in one chunk yield in order", async () => {
+    startEcho((req) => [
+      { id: req.id, ok: true, result: { n: 1 }, final: false },
+      { id: req.id, ok: true, result: { n: 2 }, final: true },
+    ]);
+    const out: Reply[] = [];
+    for await (const r of rpcStream(sock, { id: 1, op: "x", args: {}, stream: true })) {
+      out.push(r);
+    }
+    expect(out.map((r) => (r.result as any).n)).toEqual([1, 2]);
+  });
+});

--- a/clients/cli/tests/lobby/rpc-server.test.ts
+++ b/clients/cli/tests/lobby/rpc-server.test.ts
@@ -33,7 +33,9 @@ class FakeLobby {
   sendCredentials() {}
   sendChat() {}
   joinChannel() {}
-  createGame() {}
+  createGame(g: any) {
+    queueMicrotask(() => this.emit("newGame", { game: { id: 999 } }));
+  }
   setGame() {}
 }
 
@@ -130,5 +132,110 @@ describe("rpc-server", () => {
     const r = await rpc({ id: 5, op: "nope", args: {} });
     expect(r.ok).toBe(false);
     expect(r.code).toBe("BAD_OP");
+  });
+
+  test("malformed JSON frame returns BAD_FRAME and closes socket", async () => {
+    // Direct send (bypassing rpc helper) to inject malformed bytes.
+    const replies: Reply[] = [];
+    let buf = "";
+    await new Promise<void>((resolve, reject) => {
+      Bun.connect({
+        unix: sock,
+        socket: {
+          open(s) {
+            s.write("{not json}\n");
+          },
+          data(_s, chunk) {
+            buf += new TextDecoder().decode(chunk);
+            const { frames, rest } = parseFrames<Reply>(buf);
+            buf = rest;
+            replies.push(...frames);
+          },
+          close() {
+            resolve();
+          },
+          error(_s, e) {
+            reject(e);
+          },
+        },
+      });
+    });
+    expect(replies).toHaveLength(1);
+    expect(replies[0]!.ok).toBe(false);
+    expect(replies[0]!.code).toBe("BAD_FRAME");
+  });
+
+  test("game_create happy path resolves on echoed newGame", async () => {
+    // Spawn alice first.
+    const s = await rpc({
+      id: 100,
+      op: "spawn",
+      args: {
+        name: "alice",
+        host: "h",
+        port: 1,
+        version: "v",
+        platform: 0,
+        user: "u",
+        pass: "p",
+      },
+    });
+    expect(s.ok).toBe(true);
+
+    // FakeLobby.createGame emits newGame via queueMicrotask; the listener resolves.
+    const r = await rpc({ id: 101, op: "game_create", args: { name: "alice", game: { id: 0 } } });
+    expect(r.ok).toBe(true);
+    expect((r.result as any).gameId).toBe(999);
+  });
+
+  test("second tail on the same connection returns ALREADY_TAILING", async () => {
+    await rpc({
+      id: 200,
+      op: "spawn",
+      args: {
+        name: "alice",
+        host: "h",
+        port: 1,
+        version: "v",
+        platform: 0,
+        user: "u",
+        pass: "p",
+      },
+    });
+    // Open a connection, send tail, then a second tail on the SAME connection,
+    // and observe both replies.
+    const replies: Reply[] = [];
+    let buf = "";
+    await new Promise<void>((resolve, reject) => {
+      Bun.connect({
+        unix: sock,
+        socket: {
+          open(s) {
+            s.write(encodeFrame({ id: 201, op: "tail", args: { name: "alice" }, stream: true }));
+            s.write(encodeFrame({ id: 202, op: "tail", args: { name: "alice" }, stream: true }));
+          },
+          data(s, chunk) {
+            buf += new TextDecoder().decode(chunk);
+            const { frames, rest } = parseFrames<Reply>(buf);
+            buf = rest;
+            replies.push(...frames);
+            // Wait for the rejection of id 202 then close.
+            if (replies.some((r) => r.id === 202 && r.final)) {
+              s.end();
+            }
+          },
+          close() {
+            resolve();
+          },
+          error(_s, e) {
+            reject(e);
+          },
+        },
+      });
+    });
+    const second = replies.find((r) => r.id === 202);
+    expect(second).toBeTruthy();
+    expect(second!.ok).toBe(false);
+    expect(second!.code).toBe("ALREADY_TAILING");
   });
 });

--- a/clients/cli/tests/lobby/rpc-server.test.ts
+++ b/clients/cli/tests/lobby/rpc-server.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SessionManager } from "../../src/lobby/session-manager.ts";
+import { startRpcServer, type RpcServer } from "../../src/lobby/rpc-server.ts";
+import { encodeFrame, parseFrames, type Reply, type Request } from "../../src/lobby/protocol.ts";
+
+class FakeLobby {
+  state: any = "disconnected";
+  accountId = 0;
+  lastError = "";
+  private ls: Record<string, Set<any>> = {};
+  on(e: string, fn: any) {
+    (this.ls[e] ??= new Set()).add(fn);
+    return () => this.ls[e]?.delete(fn);
+  }
+  emit(e: string, ...a: any[]) {
+    for (const fn of this.ls[e] ?? []) fn(...a);
+  }
+  async connect() {
+    queueMicrotask(() => {
+      this.state = "authenticated";
+      this.accountId = 7;
+      this.emit("stateChanged", "authenticated");
+    });
+  }
+  async disconnect() {
+    this.state = "disconnected";
+    this.emit("stateChanged", "disconnected");
+  }
+  sendVersion() {}
+  sendCredentials() {}
+  sendChat() {}
+  joinChannel() {}
+  createGame() {}
+  setGame() {}
+}
+
+let tmp: string;
+let sock: string;
+let server: RpcServer;
+let mgr: SessionManager;
+
+beforeEach(async () => {
+  tmp = mkdtempSync(join(tmpdir(), "lobbyd-test-"));
+  sock = join(tmp, "lobbyd.sock");
+  mgr = new SessionManager(() => new FakeLobby());
+  server = await startRpcServer({ socketPath: sock, manager: mgr });
+});
+afterEach(async () => {
+  await server.stop();
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+async function rpc(req: Request): Promise<Reply> {
+  const replies = await rpcStream(req, 1);
+  return replies[0]!;
+}
+
+async function rpcStream(req: Request, expected: number): Promise<Reply[]> {
+  return new Promise((resolve, reject) => {
+    const out: Reply[] = [];
+    let buf = "";
+    Bun.connect({
+      unix: sock,
+      socket: {
+        open(s) {
+          s.write(encodeFrame(req));
+        },
+        data(s, chunk) {
+          buf += new TextDecoder().decode(chunk);
+          const { frames, rest } = parseFrames<Reply>(buf);
+          buf = rest;
+          for (const f of frames) {
+            out.push(f);
+            if (out.length >= expected) {
+              s.end();
+              resolve(out);
+              return;
+            }
+          }
+        },
+        close() {
+          if (out.length < expected)
+            reject(new Error(`closed early; got ${out.length}/${expected}`));
+        },
+        error(_s, e) {
+          reject(e);
+        },
+      },
+    });
+  });
+}
+
+describe("rpc-server", () => {
+  test("ls on empty manager returns empty list", async () => {
+    const r = await rpc({ id: 1, op: "ls", args: {} });
+    expect(r).toEqual({ id: 1, ok: true, result: { sessions: [] }, final: true });
+  });
+
+  test("spawn → ls round trip", async () => {
+    const s = await rpc({
+      id: 2,
+      op: "spawn",
+      args: {
+        name: "alice",
+        host: "h",
+        port: 1,
+        version: "v",
+        platform: 0,
+        user: "u",
+        pass: "p",
+      },
+    });
+    expect(s.ok).toBe(true);
+    expect((s.result as any).accountId).toBe(7);
+    const ls = await rpc({ id: 3, op: "ls", args: {} });
+    expect((ls.result as any).sessions).toHaveLength(1);
+    expect((ls.result as any).sessions[0].name).toBe("alice");
+  });
+
+  test("kill on missing session returns NO_SESSION", async () => {
+    const r = await rpc({ id: 4, op: "kill", args: { name: "ghost" } });
+    expect(r.ok).toBe(false);
+    expect(r.code).toBe("NO_SESSION");
+  });
+
+  test("unknown op returns BAD_OP", async () => {
+    const r = await rpc({ id: 5, op: "nope", args: {} });
+    expect(r.ok).toBe(false);
+    expect(r.code).toBe("BAD_OP");
+  });
+});

--- a/clients/cli/tests/lobby/session-manager.test.ts
+++ b/clients/cli/tests/lobby/session-manager.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from "bun:test";
+import type { ClientEvents } from "@silencer/lobby-sdk";
 import { SessionManager, type LobbyLike } from "../../src/lobby/session-manager.ts";
-
-type Listener = (...args: any[]) => void;
 
 class FakeLobby implements LobbyLike {
   state:
@@ -13,10 +12,12 @@ class FakeLobby implements LobbyLike {
     | "failed" = "disconnected";
   accountId = 0;
   lastError = "";
-  private ls: Record<string, Set<Listener>> = {};
-  on(event: string, fn: Listener): () => void {
-    (this.ls[event] ??= new Set()).add(fn);
-    return () => this.ls[event]?.delete(fn);
+  private ls: Record<string, Set<(...args: unknown[]) => void>> = {};
+  on<K extends keyof ClientEvents>(event: K, fn: ClientEvents[K]): () => void {
+    (this.ls[event] ??= new Set()).add(fn as (...args: unknown[]) => void);
+    return () => {
+      this.ls[event]?.delete(fn as (...args: unknown[]) => void);
+    };
   }
   emit(event: string, ...args: unknown[]): void {
     for (const fn of this.ls[event] ?? []) fn(...args);
@@ -26,6 +27,7 @@ class FakeLobby implements LobbyLike {
   }
   async disconnect(): Promise<void> {
     this.state = "disconnected";
+    this.accountId = 0;
     this.emit("stateChanged", "disconnected");
   }
   sendVersion(): void {}

--- a/clients/cli/tests/lobby/session-manager.test.ts
+++ b/clients/cli/tests/lobby/session-manager.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from "bun:test";
+import { SessionManager, type LobbyLike } from "../../src/lobby/session-manager.ts";
+
+type Listener = (...args: any[]) => void;
+
+class FakeLobby implements LobbyLike {
+  state:
+    | "disconnected"
+    | "connecting"
+    | "awaiting_version"
+    | "awaiting_auth"
+    | "authenticated"
+    | "failed" = "disconnected";
+  accountId = 0;
+  lastError = "";
+  private ls: Record<string, Set<Listener>> = {};
+  on(event: string, fn: Listener): () => void {
+    (this.ls[event] ??= new Set()).add(fn);
+    return () => this.ls[event]?.delete(fn);
+  }
+  emit(event: string, ...args: unknown[]): void {
+    for (const fn of this.ls[event] ?? []) fn(...args);
+  }
+  async connect(): Promise<void> {
+    /* tests drive state manually */
+  }
+  async disconnect(): Promise<void> {
+    this.state = "disconnected";
+    this.emit("stateChanged", "disconnected");
+  }
+  sendVersion(): void {}
+  sendCredentials(): void {}
+  sendChat(): void {}
+  joinChannel(): void {}
+  createGame(): void {}
+  setGame(): void {}
+}
+
+const factory = (_cfg: unknown) => new FakeLobby();
+
+describe("SessionManager", () => {
+  test("spawn resolves with accountId on auth success", async () => {
+    let lobby!: FakeLobby;
+    const mgr = new SessionManager((cfg) => (lobby = new FakeLobby()));
+    const p = mgr.spawn({
+      name: "alice",
+      host: "h",
+      port: 1,
+      version: "v",
+      platform: 0,
+      user: "u",
+      pass: "p",
+    });
+    // Drive the fake through the auth dance.
+    await Promise.resolve();
+    lobby.state = "awaiting_version";
+    lobby.emit("stateChanged", "awaiting_version");
+    lobby.state = "awaiting_auth";
+    lobby.emit("stateChanged", "awaiting_auth");
+    lobby.accountId = 42;
+    lobby.state = "authenticated";
+    lobby.emit("stateChanged", "authenticated");
+    await expect(p).resolves.toEqual({ accountId: 42 });
+    expect(mgr.list().map((s) => s.name)).toEqual(["alice"]);
+  });
+
+  test("spawn rejects with lastError on failure", async () => {
+    let lobby!: FakeLobby;
+    const mgr = new SessionManager((cfg) => (lobby = new FakeLobby()));
+    const p = mgr.spawn({
+      name: "alice",
+      host: "h",
+      port: 1,
+      version: "v",
+      platform: 0,
+      user: "u",
+      pass: "p",
+    });
+    await Promise.resolve();
+    lobby.lastError = "bad password";
+    lobby.state = "failed";
+    lobby.emit("stateChanged", "failed");
+    await expect(p).rejects.toThrow("bad password");
+    expect(mgr.list()).toEqual([]);
+  });
+
+  test("kill removes the session and disconnects", async () => {
+    let lobby!: FakeLobby;
+    const mgr = new SessionManager((cfg) => (lobby = new FakeLobby()));
+    const p = mgr.spawn({
+      name: "alice",
+      host: "h",
+      port: 1,
+      version: "v",
+      platform: 0,
+      user: "u",
+      pass: "p",
+    });
+    await Promise.resolve();
+    lobby.accountId = 1;
+    lobby.state = "authenticated";
+    lobby.emit("stateChanged", "authenticated");
+    await p;
+    await mgr.kill("alice");
+    const stateAfterKill: string = lobby.state;
+    expect(stateAfterKill).toBe("disconnected");
+    expect(mgr.list()).toEqual([]);
+  });
+
+  test("spawn rejects on duplicate name", async () => {
+    const mgr = new SessionManager(() => new FakeLobby());
+    const cfg = {
+      name: "alice",
+      host: "h",
+      port: 1,
+      version: "v",
+      platform: 0 as 0,
+      user: "u",
+      pass: "p",
+    };
+    // Trigger the duplicate check synchronously by adding the session first.
+    (mgr as any).sessions.set("alice", { name: "alice", lobby: new FakeLobby() });
+    await expect(mgr.spawn(cfg)).rejects.toThrow(/already exists/);
+  });
+
+  test("kill on missing session throws NO_SESSION", async () => {
+    const mgr = new SessionManager(() => new FakeLobby());
+    await expect(mgr.kill("nobody")).rejects.toThrow(/NO_SESSION/);
+  });
+
+  test("getOrThrow returns the session or throws NO_SESSION", () => {
+    const mgr = new SessionManager(() => new FakeLobby());
+    expect(() => mgr.getOrThrow("nobody")).toThrow(/NO_SESSION/);
+  });
+});

--- a/clients/cli/tests/lobby/session-manager.test.ts
+++ b/clients/cli/tests/lobby/session-manager.test.ts
@@ -36,8 +36,6 @@ class FakeLobby implements LobbyLike {
   setGame(): void {}
 }
 
-const factory = (_cfg: unknown) => new FakeLobby();
-
 describe("SessionManager", () => {
   test("spawn resolves with accountId on auth success", async () => {
     let lobby!: FakeLobby;

--- a/clients/cli/tsconfig.json
+++ b/clients/cli/tsconfig.json
@@ -6,6 +6,7 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
+    "allowImportingTsExtensions": true,
     "types": ["bun"]
   },
   "include": ["index.ts", "src/**/*.ts", "tests/**/*.ts"]

--- a/clients/cli/tsconfig.json
+++ b/clients/cli/tsconfig.json
@@ -8,5 +8,5 @@
     "skipLibCheck": true,
     "types": ["bun"]
   },
-  "include": ["index.ts"]
+  "include": ["index.ts", "src/**/*.ts", "tests/**/*.ts"]
 }

--- a/clients/lobby-sdk/ts/src/client.ts
+++ b/clients/lobby-sdk/ts/src/client.ts
@@ -2,304 +2,376 @@
 
 import { createHash } from "node:crypto";
 import {
-    decodeAuthReply,
-    decodeChannel,
-    decodeChatPush,
-    decodeDelGame,
-    decodeMotd,
-    decodeNewGame,
-    decodePresence,
-    decodeUserInfo,
-    decodeVersionReply,
-    encodeAuthRequest,
-    encodeChat,
-    encodeJoinChannel,
-    encodeNewGame,
-    encodePingAck,
-    encodeRegisterStats,
-    encodeSetGame,
-    encodeUpgradeStat,
-    encodeUserInfoRequest,
-    encodeVersionRequest,
-    frameEncode,
-    frameTryDecode,
-    Reader,
+  decodeAuthReply,
+  decodeChannel,
+  decodeChatPush,
+  decodeDelGame,
+  decodeMotd,
+  decodeNewGame,
+  decodePresence,
+  decodeUserInfo,
+  decodeVersionReply,
+  encodeAuthRequest,
+  encodeChat,
+  encodeJoinChannel,
+  encodeNewGame,
+  encodePingAck,
+  encodeRegisterStats,
+  encodeSetGame,
+  encodeUpgradeStat,
+  encodeUserInfoRequest,
+  encodeVersionRequest,
+  frameEncode,
+  frameTryDecode,
+  Reader,
 } from "./codec.ts";
 import {
-    type AuthResult,
-    type ChatMessage,
-    type GameStatus,
-    type LobbyGame,
-    type MatchStats,
-    type NewGameEvent,
-    Op,
-    type Platform,
-    type PresenceUpdate,
-    type UserInfo,
-    type VersionResult,
+  type AuthResult,
+  type ChatMessage,
+  type GameStatus,
+  type LobbyGame,
+  type MatchStats,
+  type NewGameEvent,
+  Op,
+  type Platform,
+  type PresenceUpdate,
+  type UserInfo,
+  type VersionResult,
 } from "./types.ts";
 
 export type ConnectionState =
-    | "disconnected"
-    | "connecting"
-    | "awaiting_version"
-    | "awaiting_auth"
-    | "authenticated"
-    | "failed";
+  | "disconnected"
+  | "connecting"
+  | "awaiting_version"
+  | "awaiting_auth"
+  | "authenticated"
+  | "failed";
 
 export interface ClientConfig {
-    host: string;
-    port: number;
-    /** Empty string = skip version handshake. */
-    version?: string;
-    platform?: Platform;
-    /** Inactivity threshold; client closes the socket if no bytes arrive
-     *  within this window. Default 20s, matching the reference C++ client. */
-    readTimeoutMs?: number;
+  host: string;
+  port: number;
+  /** Empty string = skip version handshake. */
+  version?: string;
+  platform?: Platform;
+  /** Inactivity threshold; client closes the socket if no bytes arrive
+   *  within this window. Default 20s, matching the reference C++ client. */
+  readTimeoutMs?: number;
 }
 
 export interface ClientEvents {
-    stateChanged: (state: ConnectionState) => void;
-    version: (v: VersionResult) => void;
-    auth: (a: AuthResult) => void;
-    motd: (full: string) => void;
-    chat: (m: ChatMessage) => void;
-    channel: (name: string) => void;
-    newGame: (e: NewGameEvent) => void;
-    delGame: (id: number) => void;
-    userInfo: (u: UserInfo) => void;
-    presence: (p: PresenceUpdate) => void;
-    statUpgraded: () => void;
-    error: (message: string) => void;
+  stateChanged: (state: ConnectionState) => void;
+  version: (v: VersionResult) => void;
+  auth: (a: AuthResult) => void;
+  motd: (full: string) => void;
+  chat: (m: ChatMessage) => void;
+  channel: (name: string) => void;
+  newGame: (e: NewGameEvent) => void;
+  delGame: (id: number) => void;
+  userInfo: (u: UserInfo) => void;
+  presence: (p: PresenceUpdate) => void;
+  statUpgraded: () => void;
+  error: (message: string) => void;
 }
 
 export function sha1(data: Uint8Array | string): Uint8Array {
-    const h = createHash("sha1");
-    h.update(typeof data === "string" ? data : data);
-    return new Uint8Array(h.digest());
+  const h = createHash("sha1");
+  h.update(typeof data === "string" ? data : data);
+  return new Uint8Array(h.digest());
 }
 
 export class LobbyClient {
-    private cfg: Required<ClientConfig>;
-    private socket: any | null = null;
-    private rx = new Uint8Array(0);
-    private motdBuf = "";
-    private _state: ConnectionState = "disconnected";
-    private _accountId = 0;
-    private _lastError = "";
-    private rxTimer: ReturnType<typeof setTimeout> | null = null;
-    private lastRxAt = 0;
+  private cfg: Required<ClientConfig>;
+  private socket: any | null = null;
+  private rx = new Uint8Array(0);
+  private motdBuf = "";
+  private _state: ConnectionState = "disconnected";
+  private _accountId = 0;
+  private _lastError = "";
+  private rxTimer: ReturnType<typeof setTimeout> | null = null;
+  private lastRxAt = 0;
 
-    private listeners: { [K in keyof ClientEvents]: Set<ClientEvents[K]> } = {
-        stateChanged: new Set(),
-        version: new Set(),
-        auth: new Set(),
-        motd: new Set(),
-        chat: new Set(),
-        channel: new Set(),
-        newGame: new Set(),
-        delGame: new Set(),
-        userInfo: new Set(),
-        presence: new Set(),
-        statUpgraded: new Set(),
-        error: new Set(),
+  private listeners: { [K in keyof ClientEvents]: Set<ClientEvents[K]> } = {
+    stateChanged: new Set(),
+    version: new Set(),
+    auth: new Set(),
+    motd: new Set(),
+    chat: new Set(),
+    channel: new Set(),
+    newGame: new Set(),
+    delGame: new Set(),
+    userInfo: new Set(),
+    presence: new Set(),
+    statUpgraded: new Set(),
+    error: new Set(),
+  };
+
+  constructor(cfg: ClientConfig) {
+    this.cfg = {
+      host: cfg.host,
+      port: cfg.port,
+      version: cfg.version ?? "",
+      platform: cfg.platform ?? 0,
+      readTimeoutMs: cfg.readTimeoutMs ?? 20_000,
     };
+  }
 
-    constructor(cfg: ClientConfig) {
-        this.cfg = {
-            host: cfg.host,
-            port: cfg.port,
-            version: cfg.version ?? "",
-            platform: cfg.platform ?? 0,
-            readTimeoutMs: cfg.readTimeoutMs ?? 20_000,
-        };
+  get state(): ConnectionState {
+    return this._state;
+  }
+  get accountId(): number {
+    return this._accountId;
+  }
+  get lastError(): string {
+    return this._lastError;
+  }
+
+  on<K extends keyof ClientEvents>(event: K, fn: ClientEvents[K]): () => void {
+    this.listeners[event].add(fn as never);
+    return () => {
+      this.listeners[event].delete(fn as never);
+    };
+  }
+
+  private emit<K extends keyof ClientEvents>(event: K, ...args: Parameters<ClientEvents[K]>): void {
+    for (const fn of this.listeners[event]) (fn as (...a: unknown[]) => void)(...args);
+  }
+
+  private setState(s: ConnectionState): void {
+    if (this._state === s) return;
+    this._state = s;
+    this.emit("stateChanged", s);
+  }
+
+  async connect(): Promise<void> {
+    await this.disconnect();
+    this.setState("connecting");
+    this.lastRxAt = Date.now();
+    const self = this;
+    this.socket = await Bun.connect({
+      hostname: this.cfg.host,
+      port: this.cfg.port,
+      socket: {
+        open(s: any) {
+          // Assign socket before emitting stateChanged so sendRaw()
+          // calls inside the stateChanged listener (sendVersion /
+          // sendCredentials) can write immediately.
+          self.socket = s;
+          self.setState(self.cfg.version === "" ? "awaiting_auth" : "awaiting_version");
+        },
+        data(_sock, chunk: Uint8Array) {
+          self.lastRxAt = Date.now();
+          self.appendRx(chunk);
+          self.drain();
+        },
+        close() {
+          self.handleClose("connection closed by peer");
+        },
+        error(_sock, err: Error) {
+          self.handleClose("socket: " + err.message);
+        },
+      },
+    });
+    this.startTimeoutWatch();
+  }
+
+  async disconnect(): Promise<void> {
+    this.stopTimeoutWatch();
+    if (this.socket) {
+      try {
+        this.socket.end();
+      } catch {
+        /* ignore */
+      }
+      this.socket = null;
     }
+    this.rx = new Uint8Array(0);
+    this.motdBuf = "";
+    this._accountId = 0;
+    this.setState("disconnected");
+  }
 
-    get state(): ConnectionState { return this._state; }
-    get accountId(): number { return this._accountId; }
-    get lastError(): string { return this._lastError; }
-
-    on<K extends keyof ClientEvents>(event: K, fn: ClientEvents[K]): () => void {
-        this.listeners[event].add(fn as never);
-        return () => { this.listeners[event].delete(fn as never); };
+  private handleClose(msg: string): void {
+    // Both 'failed' and 'disconnected' are terminal — when the dispatch
+    // path already set 'failed' (version/auth rejection), a follow-up
+    // socket close from the server should preserve that signal rather
+    // than emit a spurious 'failed → disconnected' transition.
+    if (this._state === "disconnected" || this._state === "failed") {
+      this.stopTimeoutWatch();
+      this.socket = null;
+      return;
     }
+    this._lastError = msg;
+    this.emit("error", msg);
+    this.stopTimeoutWatch();
+    this.socket = null;
+    this.setState("disconnected");
+  }
 
-    private emit<K extends keyof ClientEvents>(event: K, ...args: Parameters<ClientEvents[K]>): void {
-        for (const fn of this.listeners[event]) (fn as (...a: unknown[]) => void)(...args);
-    }
-
-    private setState(s: ConnectionState): void {
-        if (this._state === s) return;
-        this._state = s;
-        this.emit("stateChanged", s);
-    }
-
-    async connect(): Promise<void> {
-        await this.disconnect();
-        this.setState("connecting");
-        this.lastRxAt = Date.now();
-        const self = this;
-        this.socket = await Bun.connect({
-            hostname: this.cfg.host,
-            port: this.cfg.port,
-            socket: {
-                open() {
-                    self.setState(self.cfg.version === "" ? "awaiting_auth" : "awaiting_version");
-                },
-                data(_sock, chunk: Uint8Array) {
-                    self.lastRxAt = Date.now();
-                    self.appendRx(chunk);
-                    self.drain();
-                },
-                close() { self.handleClose("connection closed by peer"); },
-                error(_sock, err: Error) { self.handleClose("socket: " + err.message); },
-            },
-        });
-        this.startTimeoutWatch();
-    }
-
-    async disconnect(): Promise<void> {
-        this.stopTimeoutWatch();
-        if (this.socket) {
-            try { this.socket.end(); } catch { /* ignore */ }
-            this.socket = null;
+  private startTimeoutWatch(): void {
+    this.stopTimeoutWatch();
+    this.rxTimer = setInterval(
+      () => {
+        if (Date.now() - this.lastRxAt > this.cfg.readTimeoutMs) {
+          this.handleClose("read timeout");
         }
-        this.rx = new Uint8Array(0);
-        this.motdBuf = "";
-        this._accountId = 0;
-        this.setState("disconnected");
-    }
+      },
+      Math.min(2_000, this.cfg.readTimeoutMs),
+    );
+  }
 
-    private handleClose(msg: string): void {
-        // Both 'failed' and 'disconnected' are terminal — when the dispatch
-        // path already set 'failed' (version/auth rejection), a follow-up
-        // socket close from the server should preserve that signal rather
-        // than emit a spurious 'failed → disconnected' transition.
-        if (this._state === "disconnected" || this._state === "failed") {
-            this.stopTimeoutWatch();
-            this.socket = null;
-            return;
+  private stopTimeoutWatch(): void {
+    if (this.rxTimer) {
+      clearInterval(this.rxTimer);
+      this.rxTimer = null;
+    }
+  }
+
+  private appendRx(chunk: Uint8Array): void {
+    const next = new Uint8Array(this.rx.length + chunk.length);
+    next.set(this.rx, 0);
+    next.set(chunk, this.rx.length);
+    this.rx = next;
+  }
+
+  private drain(): void {
+    for (;;) {
+      let frame: { payload: Uint8Array; consumed: number } | null;
+      try {
+        frame = frameTryDecode(this.rx);
+      } catch (e) {
+        this.handleClose("frame: " + (e as Error).message);
+        return;
+      }
+      if (!frame) return;
+      this.rx = this.rx.slice(frame.consumed);
+      try {
+        this.dispatch(frame.payload);
+      } catch (e) {
+        this.handleClose("decode: " + (e as Error).message);
+        return;
+      }
+    }
+  }
+
+  private dispatch(payload: Uint8Array): void {
+    if (payload.length === 0) return;
+    const r = new Reader(payload);
+    const op = r.u8();
+    switch (op) {
+      case Op.Version: {
+        const v = decodeVersionReply(r);
+        if (v.ok) this.setState("awaiting_auth");
+        else {
+          this._lastError = "version rejected";
+          this.setState("failed");
         }
-        this._lastError = msg;
-        this.emit("error", msg);
-        this.stopTimeoutWatch();
-        this.socket = null;
-        this.setState("disconnected");
-    }
-
-    private startTimeoutWatch(): void {
-        this.stopTimeoutWatch();
-        this.rxTimer = setInterval(() => {
-            if (Date.now() - this.lastRxAt > this.cfg.readTimeoutMs) {
-                this.handleClose("read timeout");
-            }
-        }, Math.min(2_000, this.cfg.readTimeoutMs));
-    }
-
-    private stopTimeoutWatch(): void {
-        if (this.rxTimer) { clearInterval(this.rxTimer); this.rxTimer = null; }
-    }
-
-    private appendRx(chunk: Uint8Array): void {
-        const next = new Uint8Array(this.rx.length + chunk.length);
-        next.set(this.rx, 0);
-        next.set(chunk, this.rx.length);
-        this.rx = next;
-    }
-
-    private drain(): void {
-        for (;;) {
-            let frame: { payload: Uint8Array; consumed: number } | null;
-            try {
-                frame = frameTryDecode(this.rx);
-            } catch (e) {
-                this.handleClose("frame: " + (e as Error).message);
-                return;
-            }
-            if (!frame) return;
-            this.rx = this.rx.slice(frame.consumed);
-            try {
-                this.dispatch(frame.payload);
-            } catch (e) {
-                this.handleClose("decode: " + (e as Error).message);
-                return;
-            }
+        this.emit("version", v);
+        break;
+      }
+      case Op.Auth: {
+        const a = decodeAuthReply(r);
+        if (a.ok) {
+          this._accountId = a.accountId;
+          this.setState("authenticated");
+        } else {
+          this._lastError = a.error;
+          this.setState("failed");
         }
-    }
-
-    private dispatch(payload: Uint8Array): void {
-        if (payload.length === 0) return;
-        const r = new Reader(payload);
-        const op = r.u8();
-        switch (op) {
-            case Op.Version: {
-                const v = decodeVersionReply(r);
-                if (v.ok) this.setState("awaiting_auth");
-                else { this._lastError = "version rejected"; this.setState("failed"); }
-                this.emit("version", v);
-                break;
-            }
-            case Op.Auth: {
-                const a = decodeAuthReply(r);
-                if (a.ok) { this._accountId = a.accountId; this.setState("authenticated"); }
-                else { this._lastError = a.error; this.setState("failed"); }
-                this.emit("auth", a);
-                break;
-            }
-            case Op.MOTD: {
-                const c = decodeMotd(r, payload.length);
-                if (c.terminator) {
-                    this.emit("motd", this.motdBuf);
-                    this.motdBuf = "";
-                } else {
-                    this.motdBuf += c.text;
-                }
-                break;
-            }
-            case Op.Chat:        this.emit("chat", decodeChatPush(r)); break;
-            case Op.NewGame:     this.emit("newGame", decodeNewGame(r)); break;
-            case Op.DelGame:     this.emit("delGame", decodeDelGame(r)); break;
-            case Op.Channel:     this.emit("channel", decodeChannel(r)); break;
-            case Op.UserInfo:    this.emit("userInfo", decodeUserInfo(r)); break;
-            case Op.Ping:        this.sendRaw(encodePingAck()); break;
-            case Op.Presence:    this.emit("presence", decodePresence(r)); break;
-            case Op.UpgradeStat: this.emit("statUpgraded"); break;
-            case Op.Connect:     /* reserved, ignore */ break;
-            default:             this.emit("error", `unknown opcode ${op}`); break;
+        this.emit("auth", a);
+        break;
+      }
+      case Op.MOTD: {
+        const c = decodeMotd(r, payload.length);
+        if (c.terminator) {
+          this.emit("motd", this.motdBuf);
+          this.motdBuf = "";
+        } else {
+          this.motdBuf += c.text;
         }
+        break;
+      }
+      case Op.Chat:
+        this.emit("chat", decodeChatPush(r));
+        break;
+      case Op.NewGame:
+        this.emit("newGame", decodeNewGame(r));
+        break;
+      case Op.DelGame:
+        this.emit("delGame", decodeDelGame(r));
+        break;
+      case Op.Channel:
+        this.emit("channel", decodeChannel(r));
+        break;
+      case Op.UserInfo:
+        this.emit("userInfo", decodeUserInfo(r));
+        break;
+      case Op.Ping:
+        this.sendRaw(encodePingAck());
+        break;
+      case Op.Presence:
+        this.emit("presence", decodePresence(r));
+        break;
+      case Op.UpgradeStat:
+        this.emit("statUpgraded");
+        break;
+      case Op.Connect:
+        /* reserved, ignore */ break;
+      default:
+        this.emit("error", `unknown opcode ${op}`);
+        break;
     }
+  }
 
-    private sendRaw(payload: Uint8Array): void {
-        if (!this.socket) return;
-        this.socket.write(frameEncode(payload));
-    }
+  private sendRaw(payload: Uint8Array): void {
+    if (!this.socket) return;
+    this.socket.write(frameEncode(payload));
+  }
 
-    // ---- outbound API ---------------------------------------------------
+  // ---- outbound API ---------------------------------------------------
 
-    sendVersion(): void { this.sendRaw(encodeVersionRequest(this.cfg.version, this.cfg.platform)); }
-    sendCredentials(username: string, password: string): void {
-        this.sendRaw(encodeAuthRequest(username, sha1(password)));
-    }
-    sendChat(channel: string, message: string): void { this.sendRaw(encodeChat(channel, message)); }
-    joinChannel(channel: string): void { this.sendRaw(encodeJoinChannel("", channel)); }
-    createGame(g: LobbyGame): void { this.sendRaw(encodeNewGame(g)); }
-    requestUserInfo(accountId: number): void { this.sendRaw(encodeUserInfoRequest(accountId)); }
-    upgradeStat(agencyIdx: number, statId: number): void {
-        this.sendRaw(encodeUpgradeStat(agencyIdx, statId));
-    }
-    setGame(gameId: number, status: GameStatus): void {
-        this.sendRaw(encodeSetGame(gameId, status));
-    }
-    registerStats(args: {
-        gameId: number;
-        teamNumber: number;
-        accountId: number;
-        statsAgency: number;
-        won: boolean;
-        xp: number;
-        stats: MatchStats;
-    }): void {
-        this.sendRaw(encodeRegisterStats(args.gameId, args.teamNumber, args.accountId,
-            args.statsAgency, args.won, args.xp, args.stats));
-    }
+  sendVersion(): void {
+    this.sendRaw(encodeVersionRequest(this.cfg.version, this.cfg.platform));
+  }
+  sendCredentials(username: string, password: string): void {
+    this.sendRaw(encodeAuthRequest(username, sha1(password)));
+  }
+  sendChat(channel: string, message: string): void {
+    this.sendRaw(encodeChat(channel, message));
+  }
+  joinChannel(channel: string): void {
+    this.sendRaw(encodeJoinChannel("", channel));
+  }
+  createGame(g: LobbyGame): void {
+    this.sendRaw(encodeNewGame(g));
+  }
+  requestUserInfo(accountId: number): void {
+    this.sendRaw(encodeUserInfoRequest(accountId));
+  }
+  upgradeStat(agencyIdx: number, statId: number): void {
+    this.sendRaw(encodeUpgradeStat(agencyIdx, statId));
+  }
+  setGame(gameId: number, status: GameStatus): void {
+    this.sendRaw(encodeSetGame(gameId, status));
+  }
+  registerStats(args: {
+    gameId: number;
+    teamNumber: number;
+    accountId: number;
+    statsAgency: number;
+    won: boolean;
+    xp: number;
+    stats: MatchStats;
+  }): void {
+    this.sendRaw(
+      encodeRegisterStats(
+        args.gameId,
+        args.teamNumber,
+        args.accountId,
+        args.statsAgency,
+        args.won,
+        args.xp,
+        args.stats,
+      ),
+    );
+  }
 }

--- a/docs/superpowers/plans/2026-04-29-lobby-session-daemon.md
+++ b/docs/superpowers/plans/2026-04-29-lobby-session-daemon.md
@@ -1,0 +1,1770 @@
+# Lobby Session Daemon Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `lobby` namespace to `silencer-cli` that lets agents spin up persistent authenticated lobby presences ("fake players") during dev, multiplexed inside a single supervisor daemon (`silencer-lobbyd`).
+
+**Architecture:** One long-running Bun process holds N `LobbyClient` instances keyed by session name; thin CLI subcommands talk to it over a single Unix domain socket using JSON-lines RPC. Daemon auto-spawns on first use and auto-exits when its last session and last connection are gone. Per-session memory is just the `LobbyClient` (single-digit MB) — Bun runtime is amortized once across all sessions.
+
+**Tech Stack:** Bun + TypeScript, `@silencer/lobby-sdk` (already on main), AF_UNIX sockets via `Bun.listen`/`Bun.connect`, `bun:test` for tests, `oxfmt` for formatting.
+
+---
+
+## File Structure
+
+All new code lives under `clients/cli/src/lobby/`. The existing `clients/cli/index.ts` stays as the entry point and dispatch shell; the lobby namespace bolts in alongside the existing `keybind` / `gas` namespaces.
+
+```
+clients/cli/
+├── package.json                   (modify: add @silencer/lobby-sdk + test script)
+├── tsconfig.json                  (modify: include src/**)
+├── index.ts                       (modify: register lobby namespace)
+├── src/
+│   └── lobby/
+│       ├── paths.ts               platform dir resolution + sun_path guard
+│       ├── protocol.ts            JSON-lines RPC frame types
+│       ├── session-manager.ts     in-memory session map; takes a LobbyClient factory
+│       ├── rpc-server.ts          unix-socket listener; dispatches to session-manager
+│       ├── rpc-client.ts          unix-socket dialer; one-shot + streaming requests
+│       ├── spawn.ts               auto-spawn detached daemon, wait for socket
+│       ├── daemon.ts              entry point: wires manager + server, handles SIGINT
+│       ├── commands.ts            CLI subcommand handlers (spawn/chat/game/ls/tail/kill)
+│       └── CLAUDE.md              one-pager for this dir
+└── tests/
+    └── lobby/
+        ├── paths.test.ts
+        ├── protocol.test.ts
+        ├── session-manager.test.ts
+        ├── rpc-server.test.ts
+        ├── rpc-client.test.ts
+        └── daemon-integration.test.ts
+```
+
+Root files:
+
+```
+package.json                       (modify: add clients/lobby-sdk/ts to workspaces)
+```
+
+## RPC protocol (locked here for reference by every task)
+
+JSON-lines over AF_UNIX. One JSON object per `\n`-terminated line.
+
+**Request frame** (CLI → daemon):
+```ts
+type Request = {
+  id: number;            // client-generated, opaque
+  op: string;            // "spawn" | "kill" | "kill_all" | "ls" | "chat" | "join_channel"
+                         //   | "game_create" | "game_join" | "tail"
+  args: Record<string, unknown>;
+  stream?: boolean;      // true for "tail"; default false
+};
+```
+
+**Reply frame** (daemon → CLI):
+```ts
+type Reply = {
+  id: number;            // matches request
+  ok: boolean;
+  result?: unknown;      // present when ok
+  error?: string;        // present when !ok
+  code?: string;         // short error code (e.g. "NO_SESSION", "AUTH_FAILED")
+  final: boolean;        // false = more replies coming (streaming); true = RPC done
+};
+```
+
+**Op contracts:**
+- `spawn { name, host, port, version, platform, user, pass }` → `{ accountId }`. Final reply only when `state === "authenticated"` or `"failed"` (10s timeout).
+- `kill { name }` → `{}`. Disconnects and removes the session.
+- `kill_all {}` → `{}`. Disconnects all and triggers daemon exit.
+- `ls {}` → `{ sessions: SessionSummary[] }`.
+- `chat { name, channel, text }` → `{}`.
+- `join_channel { name, channel }` → `{}`.
+- `game_create { name, game: LobbyGame }` → `{ gameId }`. Resolves on the echoed `newGame` event for the host.
+- `game_join { name, gameId }` → `{}`. Sends `setGame(gameId, GameStatus.Lobby)`.
+- `tail { name }` (streaming) → series of `{ event: "chat" | "presence" | "channel" | "newGame" | "delGame" | "stateChanged", data: ... }` frames with `final: false`, then a final `{ ok: true, final: true }` when the session goes away or the client disconnects.
+
+---
+
+## Task 1: Register `@silencer/lobby-sdk` as a workspace and a CLI dep
+
+**Files:**
+- Modify: `package.json` (root)
+- Modify: `clients/cli/package.json`
+- Modify: `clients/cli/tsconfig.json`
+
+- [ ] **Step 1: Add the SDK to root workspaces**
+
+Edit `package.json` (root). Insert `"clients/lobby-sdk/ts"` into `workspaces`, alphabetically:
+
+```json
+{
+  "name": "silencer",
+  "private": true,
+  "type": "module",
+  "workspaces": [
+    "clients/cli",
+    "clients/lobby-sdk/ts",
+    "services/admin-api",
+    "shared/fonts",
+    "shared/gas-validation",
+    "web/admin",
+    "web/website"
+  ],
+  "scripts": {
+    "typecheck": "bun run --filter '*' typecheck"
+  }
+}
+```
+
+- [ ] **Step 2: Add the SDK as a CLI dep + add a test script + bin for the daemon**
+
+Edit `clients/cli/package.json`:
+
+```json
+{
+  "name": "silencer-cli",
+  "private": true,
+  "type": "module",
+  "bin": {
+    "silencer-cli": "./index.ts",
+    "silencer-lobbyd": "./src/lobby/daemon.ts"
+  },
+  "scripts": {
+    "fmt": "oxfmt --write .",
+    "typecheck": "tsc --noEmit",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@silencer/gas-validation": "workspace:*",
+    "@silencer/lobby-sdk": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.3.13",
+    "typescript": "^5.4.0"
+  }
+}
+```
+
+- [ ] **Step 3: Widen the CLI tsconfig include**
+
+Edit `clients/cli/tsconfig.json`:
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["bun"]
+  },
+  "include": ["index.ts", "src/**/*.ts", "tests/**/*.ts"]
+}
+```
+
+- [ ] **Step 4: Resolve workspace deps**
+
+Run from repo root:
+
+```bash
+bun install
+```
+
+Expected: lockfile updates, no install errors. `clients/cli/node_modules/@silencer/lobby-sdk` resolves to `../../../lobby-sdk/ts` (or similar workspace symlink).
+
+- [ ] **Step 5: Smoke-import the SDK from CLI tree**
+
+Verify the resolution works:
+
+```bash
+cd clients/cli && bun -e 'import("@silencer/lobby-sdk").then(m => console.log(Object.keys(m).slice(0,3)))'
+```
+
+Expected output starts with `LobbyClient` (or another export name) — at minimum, no `Cannot find module` error.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add package.json bun.lock clients/cli/package.json clients/cli/tsconfig.json
+git commit -m "build(cli): wire @silencer/lobby-sdk as workspace dep"
+```
+
+---
+
+## Task 2: Platform path resolution (`paths.ts`)
+
+**Files:**
+- Create: `clients/cli/src/lobby/paths.ts`
+- Test: `clients/cli/tests/lobby/paths.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `clients/cli/tests/lobby/paths.test.ts`:
+
+```ts
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { resolveLobbydDir, socketPath, logPath, MAX_SUN_PATH } from "../../src/lobby/paths.ts";
+
+describe("resolveLobbydDir", () => {
+  const origPlatform = process.platform;
+  const origEnv = { ...process.env };
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { value: origPlatform });
+    process.env = { ...origEnv };
+  });
+
+  test("override env wins on every platform", () => {
+    process.env.SILENCER_LOBBYD_DIR = "/custom/dir";
+    Object.defineProperty(process, "platform", { value: "linux" });
+    expect(resolveLobbydDir()).toBe("/custom/dir");
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    expect(resolveLobbydDir()).toBe("/custom/dir");
+    Object.defineProperty(process, "platform", { value: "win32" });
+    expect(resolveLobbydDir()).toBe("/custom/dir");
+  });
+
+  test("linux uses XDG_RUNTIME_DIR/silencer when set", () => {
+    delete process.env.SILENCER_LOBBYD_DIR;
+    process.env.XDG_RUNTIME_DIR = "/run/user/1000";
+    Object.defineProperty(process, "platform", { value: "linux" });
+    expect(resolveLobbydDir()).toBe("/run/user/1000/silencer");
+  });
+
+  test("linux falls back to /tmp/silencer when XDG_RUNTIME_DIR unset", () => {
+    delete process.env.SILENCER_LOBBYD_DIR;
+    delete process.env.XDG_RUNTIME_DIR;
+    Object.defineProperty(process, "platform", { value: "linux" });
+    expect(resolveLobbydDir()).toBe("/tmp/silencer");
+  });
+
+  test("macOS uses TMPDIR/silencer", () => {
+    delete process.env.SILENCER_LOBBYD_DIR;
+    process.env.TMPDIR = "/var/folders/xx/yy/T/";
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    expect(resolveLobbydDir()).toBe("/var/folders/xx/yy/T/silencer");
+  });
+
+  test("windows uses LOCALAPPDATA\\Silencer\\lobbyd", () => {
+    delete process.env.SILENCER_LOBBYD_DIR;
+    process.env.LOCALAPPDATA = "C:\\Users\\u\\AppData\\Local";
+    Object.defineProperty(process, "platform", { value: "win32" });
+    expect(resolveLobbydDir()).toBe("C:\\Users\\u\\AppData\\Local\\Silencer\\lobbyd");
+  });
+});
+
+describe("socketPath / logPath", () => {
+  test("socketPath is dir + lobbyd.sock", () => {
+    expect(socketPath("/tmp/silencer")).toBe("/tmp/silencer/lobbyd.sock");
+  });
+  test("logPath is dir + lobbyd.log", () => {
+    expect(logPath("/tmp/silencer")).toBe("/tmp/silencer/lobbyd.log");
+  });
+  test("socketPath throws when resolved path exceeds MAX_SUN_PATH on darwin", () => {
+    const longDir = "/" + "a".repeat(120);
+    const origPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    expect(() => socketPath(longDir)).toThrow(/exceeds.*sun_path/);
+    Object.defineProperty(process, "platform", { value: origPlatform });
+  });
+});
+
+test("MAX_SUN_PATH is 100 (10-byte safety margin under macOS's 104)", () => {
+  expect(MAX_SUN_PATH).toBe(100);
+});
+```
+
+- [ ] **Step 2: Run the tests (expect failure)**
+
+```bash
+cd clients/cli && bun test tests/lobby/paths.test.ts
+```
+
+Expected: all tests fail with "Cannot find module".
+
+- [ ] **Step 3: Implement `paths.ts`**
+
+Create `clients/cli/src/lobby/paths.ts`:
+
+```ts
+// Resolves the co-located directory holding lobbyd's Unix socket and log
+// file. One env override (SILENCER_LOBBYD_DIR) wins on every platform.
+//
+// macOS sun_path is 104 bytes; we cap the resolved socket path at 100
+// to leave a margin for trailing-NUL accounting in different libc impls.
+
+import { join } from "node:path";
+
+export const MAX_SUN_PATH = 100;
+
+export function resolveLobbydDir(): string {
+    if (process.env.SILENCER_LOBBYD_DIR) return process.env.SILENCER_LOBBYD_DIR;
+    switch (process.platform) {
+        case "linux": {
+            const xdg = process.env.XDG_RUNTIME_DIR;
+            return xdg ? join(xdg, "silencer") : "/tmp/silencer";
+        }
+        case "darwin": {
+            const tmp = process.env.TMPDIR ?? "/tmp/";
+            return join(tmp, "silencer");
+        }
+        case "win32": {
+            const local = process.env.LOCALAPPDATA;
+            if (!local) throw new Error("LOCALAPPDATA not set");
+            return join(local, "Silencer", "lobbyd");
+        }
+        default:
+            return "/tmp/silencer";
+    }
+}
+
+export function socketPath(dir: string): string {
+    const p = join(dir, "lobbyd.sock");
+    if (process.platform === "darwin" && p.length > MAX_SUN_PATH) {
+        throw new Error(
+            `socket path "${p}" (${p.length} bytes) exceeds macOS sun_path limit (${MAX_SUN_PATH}). ` +
+            `Override with SILENCER_LOBBYD_DIR=<shorter dir>.`
+        );
+    }
+    return p;
+}
+
+export function logPath(dir: string): string {
+    return join(dir, "lobbyd.log");
+}
+```
+
+- [ ] **Step 4: Run tests (expect green)**
+
+```bash
+cd clients/cli && bun test tests/lobby/paths.test.ts
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add clients/cli/src/lobby/paths.ts clients/cli/tests/lobby/paths.test.ts
+git commit -m "feat(cli): platform path resolution for lobbyd"
+```
+
+---
+
+## Task 3: RPC frame types (`protocol.ts`)
+
+**Files:**
+- Create: `clients/cli/src/lobby/protocol.ts`
+- Test: `clients/cli/tests/lobby/protocol.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `clients/cli/tests/lobby/protocol.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { encodeFrame, parseFrames, type Reply, type Request } from "../../src/lobby/protocol.ts";
+
+describe("encodeFrame", () => {
+  test("appends a single trailing newline", () => {
+    const out = encodeFrame({ id: 1, ok: true, final: true });
+    expect(out.endsWith("\n")).toBe(true);
+    expect(out.split("\n").filter(Boolean).length).toBe(1);
+  });
+  test("round-trips through JSON.parse", () => {
+    const r: Reply = { id: 7, ok: false, error: "x", code: "Y", final: true };
+    expect(JSON.parse(encodeFrame(r).trim())).toEqual(r);
+  });
+});
+
+describe("parseFrames", () => {
+  test("returns parsed objects and the unconsumed remainder", () => {
+    const a: Request = { id: 1, op: "ls", args: {} };
+    const b: Request = { id: 2, op: "kill", args: { name: "alice" } };
+    const buf = encodeFrame(a) + encodeFrame(b) + '{"id":3,"op":"x"';
+    const { frames, rest } = parseFrames<Request>(buf);
+    expect(frames).toEqual([a, b]);
+    expect(rest).toBe('{"id":3,"op":"x"');
+  });
+  test("empty input → empty frames, empty rest", () => {
+    expect(parseFrames("")).toEqual({ frames: [], rest: "" });
+  });
+  test("malformed JSON throws with the offending line", () => {
+    expect(() => parseFrames("{not json}\n")).toThrow(/{not json}/);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests (expect failure)**
+
+```bash
+cd clients/cli && bun test tests/lobby/protocol.test.ts
+```
+
+Expected: failure with "Cannot find module".
+
+- [ ] **Step 3: Implement `protocol.ts`**
+
+Create `clients/cli/src/lobby/protocol.ts`:
+
+```ts
+// JSON-lines RPC over AF_UNIX. One frame per newline-terminated line.
+
+export type Request = {
+    id: number;
+    op: string;
+    args: Record<string, unknown>;
+    stream?: boolean;
+};
+
+export type Reply = {
+    id: number;
+    ok: boolean;
+    result?: unknown;
+    error?: string;
+    code?: string;
+    final: boolean;
+};
+
+export function encodeFrame(frame: Request | Reply): string {
+    return JSON.stringify(frame) + "\n";
+}
+
+export function parseFrames<T>(buf: string): { frames: T[]; rest: string } {
+    const frames: T[] = [];
+    let rest = buf;
+    for (;;) {
+        const nl = rest.indexOf("\n");
+        if (nl < 0) return { frames, rest };
+        const line = rest.slice(0, nl);
+        rest = rest.slice(nl + 1);
+        if (line.length === 0) continue;
+        try {
+            frames.push(JSON.parse(line) as T);
+        } catch (e) {
+            throw new Error(`malformed RPC frame: ${line} (${(e as Error).message})`);
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests (expect green)**
+
+```bash
+cd clients/cli && bun test tests/lobby/protocol.test.ts
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add clients/cli/src/lobby/protocol.ts clients/cli/tests/lobby/protocol.test.ts
+git commit -m "feat(cli): JSON-lines RPC frame types for lobbyd"
+```
+
+---
+
+## Task 4: Session manager (`session-manager.ts`)
+
+The session manager owns the in-memory session map. It takes a `LobbyClient`-shaped factory so tests can inject a fake. This is the only file that talks to `@silencer/lobby-sdk` directly.
+
+**Files:**
+- Create: `clients/cli/src/lobby/session-manager.ts`
+- Test: `clients/cli/tests/lobby/session-manager.test.ts`
+
+- [ ] **Step 1: Write the failing tests (uses an in-memory fake LobbyClient)**
+
+Create `clients/cli/tests/lobby/session-manager.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { SessionManager, type LobbyLike } from "../../src/lobby/session-manager.ts";
+
+type Listener = (...args: any[]) => void;
+
+class FakeLobby implements LobbyLike {
+  state: "disconnected" | "connecting" | "awaiting_version" | "awaiting_auth" | "authenticated" | "failed" = "disconnected";
+  accountId = 0;
+  lastError = "";
+  private ls: Record<string, Set<Listener>> = {};
+  on(event: string, fn: Listener): () => void {
+    (this.ls[event] ??= new Set()).add(fn);
+    return () => this.ls[event]?.delete(fn);
+  }
+  emit(event: string, ...args: unknown[]): void {
+    for (const fn of this.ls[event] ?? []) fn(...args);
+  }
+  async connect(): Promise<void> { /* tests drive state manually */ }
+  async disconnect(): Promise<void> { this.state = "disconnected"; this.emit("stateChanged", "disconnected"); }
+  sendVersion(): void {}
+  sendCredentials(): void {}
+  sendChat(): void {}
+  joinChannel(): void {}
+  createGame(): void {}
+  setGame(): void {}
+}
+
+const factory = (_cfg: unknown) => new FakeLobby();
+
+describe("SessionManager", () => {
+  test("spawn resolves with accountId on auth success", async () => {
+    let lobby!: FakeLobby;
+    const mgr = new SessionManager((cfg) => (lobby = new FakeLobby()));
+    const p = mgr.spawn({ name: "alice", host: "h", port: 1, version: "v", platform: 0, user: "u", pass: "p" });
+    // Drive the fake through the auth dance.
+    await Promise.resolve();
+    lobby.state = "awaiting_version"; lobby.emit("stateChanged", "awaiting_version");
+    lobby.state = "awaiting_auth";    lobby.emit("stateChanged", "awaiting_auth");
+    lobby.accountId = 42; lobby.state = "authenticated"; lobby.emit("stateChanged", "authenticated");
+    await expect(p).resolves.toEqual({ accountId: 42 });
+    expect(mgr.list().map((s) => s.name)).toEqual(["alice"]);
+  });
+
+  test("spawn rejects with lastError on failure", async () => {
+    let lobby!: FakeLobby;
+    const mgr = new SessionManager((cfg) => (lobby = new FakeLobby()));
+    const p = mgr.spawn({ name: "alice", host: "h", port: 1, version: "v", platform: 0, user: "u", pass: "p" });
+    await Promise.resolve();
+    lobby.lastError = "bad password"; lobby.state = "failed"; lobby.emit("stateChanged", "failed");
+    await expect(p).rejects.toThrow("bad password");
+    expect(mgr.list()).toEqual([]);
+  });
+
+  test("kill removes the session and disconnects", async () => {
+    let lobby!: FakeLobby;
+    const mgr = new SessionManager((cfg) => (lobby = new FakeLobby()));
+    const p = mgr.spawn({ name: "alice", host: "h", port: 1, version: "v", platform: 0, user: "u", pass: "p" });
+    await Promise.resolve();
+    lobby.accountId = 1; lobby.state = "authenticated"; lobby.emit("stateChanged", "authenticated");
+    await p;
+    await mgr.kill("alice");
+    expect(lobby.state).toBe("disconnected");
+    expect(mgr.list()).toEqual([]);
+  });
+
+  test("spawn rejects on duplicate name", async () => {
+    const mgr = new SessionManager(() => new FakeLobby());
+    const cfg = { name: "alice", host: "h", port: 1, version: "v", platform: 0 as 0, user: "u", pass: "p" };
+    // Trigger the duplicate check synchronously by adding the session first.
+    (mgr as any).sessions.set("alice", { name: "alice", lobby: new FakeLobby() });
+    await expect(mgr.spawn(cfg)).rejects.toThrow(/already exists/);
+  });
+
+  test("kill on missing session throws NO_SESSION", async () => {
+    const mgr = new SessionManager(() => new FakeLobby());
+    await expect(mgr.kill("nobody")).rejects.toThrow(/NO_SESSION/);
+  });
+
+  test("getOrThrow returns the session or throws NO_SESSION", () => {
+    const mgr = new SessionManager(() => new FakeLobby());
+    expect(() => mgr.getOrThrow("nobody")).toThrow(/NO_SESSION/);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests (expect failure)**
+
+```bash
+cd clients/cli && bun test tests/lobby/session-manager.test.ts
+```
+
+Expected: failure (module missing).
+
+- [ ] **Step 3: Implement `session-manager.ts`**
+
+Create `clients/cli/src/lobby/session-manager.ts`:
+
+```ts
+// In-memory session map for lobbyd. Each session wraps one LobbyClient.
+//
+// Decoupled from @silencer/lobby-sdk via the LobbyLike interface so tests
+// can substitute an in-memory fake without standing up a real lobby server.
+
+import type { LobbyClient as RealLobbyClient } from "@silencer/lobby-sdk";
+
+export interface LobbyLike {
+    readonly state: "disconnected" | "connecting" | "awaiting_version" | "awaiting_auth" | "authenticated" | "failed";
+    readonly accountId: number;
+    readonly lastError: string;
+    on(event: string, fn: (...args: any[]) => void): () => void;
+    connect(): Promise<void>;
+    disconnect(): Promise<void>;
+    sendVersion(): void;
+    sendCredentials(user: string, pass: string): void;
+    sendChat(channel: string, text: string): void;
+    joinChannel(channel: string): void;
+    createGame(g: any): void;
+    setGame(gameId: number, status: number): void;
+}
+
+export type LobbyFactory = (cfg: {
+    host: string; port: number; version: string; platform: number;
+}) => LobbyLike;
+
+export interface SpawnArgs {
+    name: string;
+    host: string;
+    port: number;
+    version: string;
+    platform: number;
+    user: string;
+    pass: string;
+}
+
+export interface Session {
+    name: string;
+    lobby: LobbyLike;
+    host: string;
+    port: number;
+}
+
+export interface SessionSummary {
+    name: string;
+    state: string;
+    accountId: number;
+    host: string;
+    port: number;
+}
+
+const SPAWN_TIMEOUT_MS = 10_000;
+
+export class SessionManager {
+    private sessions = new Map<string, Session>();
+    constructor(private factory: LobbyFactory) {}
+
+    async spawn(args: SpawnArgs): Promise<{ accountId: number }> {
+        if (this.sessions.has(args.name)) {
+            throw new Error(`session "${args.name}" already exists`);
+        }
+        const lobby = this.factory({
+            host: args.host, port: args.port, version: args.version, platform: args.platform,
+        });
+        const session: Session = { name: args.name, lobby, host: args.host, port: args.port };
+        // Reserve the slot eagerly so concurrent spawns can't race the duplicate check.
+        this.sessions.set(args.name, session);
+
+        try {
+            const result = await new Promise<{ accountId: number }>((resolve, reject) => {
+                const timer = setTimeout(() => {
+                    cleanup();
+                    reject(new Error(`spawn "${args.name}" timed out after ${SPAWN_TIMEOUT_MS}ms`));
+                }, SPAWN_TIMEOUT_MS);
+                const off = lobby.on("stateChanged", (s: string) => {
+                    if (s === "awaiting_version") lobby.sendVersion();
+                    else if (s === "awaiting_auth") lobby.sendCredentials(args.user, args.pass);
+                    else if (s === "authenticated") { cleanup(); resolve({ accountId: lobby.accountId }); }
+                    else if (s === "failed") { cleanup(); reject(new Error(lobby.lastError || "auth failed")); }
+                });
+                const cleanup = () => { clearTimeout(timer); off(); };
+                lobby.connect().catch((e) => { cleanup(); reject(e); });
+            });
+            return result;
+        } catch (e) {
+            this.sessions.delete(args.name);
+            try { await lobby.disconnect(); } catch { /* ignore */ }
+            throw e;
+        }
+    }
+
+    async kill(name: string): Promise<void> {
+        const s = this.sessions.get(name);
+        if (!s) throw new Error(`NO_SESSION: ${name}`);
+        this.sessions.delete(name);
+        await s.lobby.disconnect();
+    }
+
+    async killAll(): Promise<void> {
+        const names = [...this.sessions.keys()];
+        await Promise.all(names.map((n) => this.kill(n).catch(() => {})));
+    }
+
+    getOrThrow(name: string): Session {
+        const s = this.sessions.get(name);
+        if (!s) throw new Error(`NO_SESSION: ${name}`);
+        return s;
+    }
+
+    list(): SessionSummary[] {
+        return [...this.sessions.values()].map((s) => ({
+            name: s.name,
+            state: s.lobby.state,
+            accountId: s.lobby.accountId,
+            host: s.host,
+            port: s.port,
+        }));
+    }
+
+    size(): number { return this.sessions.size; }
+}
+
+// Convenience factory used by the real daemon. Lazily imports the SDK so
+// unit tests don't pay the cost of resolving it.
+export async function realLobbyFactory(): Promise<LobbyFactory> {
+    const sdk = await import("@silencer/lobby-sdk");
+    return (cfg) => new (sdk.LobbyClient as typeof RealLobbyClient)({
+        host: cfg.host, port: cfg.port, version: cfg.version,
+        platform: cfg.platform as 0 | 1 | 2,
+    }) as unknown as LobbyLike;
+}
+```
+
+- [ ] **Step 4: Run tests (expect green)**
+
+```bash
+cd clients/cli && bun test tests/lobby/session-manager.test.ts
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add clients/cli/src/lobby/session-manager.ts clients/cli/tests/lobby/session-manager.test.ts
+git commit -m "feat(cli): in-memory session manager for lobbyd"
+```
+
+---
+
+## Task 5: RPC server (`rpc-server.ts`)
+
+The RPC server binds the unix socket, parses JSON-lines frames, and dispatches each `Request` to the `SessionManager`. Streaming `tail` requests subscribe to session events and emit `final: false` reply frames until the client disconnects.
+
+**Files:**
+- Create: `clients/cli/src/lobby/rpc-server.ts`
+- Test: `clients/cli/tests/lobby/rpc-server.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `clients/cli/tests/lobby/rpc-server.test.ts`:
+
+```ts
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SessionManager } from "../../src/lobby/session-manager.ts";
+import { startRpcServer, type RpcServer } from "../../src/lobby/rpc-server.ts";
+import { encodeFrame, parseFrames, type Reply, type Request } from "../../src/lobby/protocol.ts";
+
+class FakeLobby {
+  state: any = "disconnected"; accountId = 0; lastError = "";
+  private ls: Record<string, Set<any>> = {};
+  on(e: string, fn: any) { (this.ls[e] ??= new Set()).add(fn); return () => this.ls[e]?.delete(fn); }
+  emit(e: string, ...a: any[]) { for (const fn of this.ls[e] ?? []) fn(...a); }
+  async connect() { queueMicrotask(() => { this.state = "authenticated"; this.accountId = 7; this.emit("stateChanged", "authenticated"); }); }
+  async disconnect() { this.state = "disconnected"; this.emit("stateChanged", "disconnected"); }
+  sendVersion() {} sendCredentials() {} sendChat() {} joinChannel() {} createGame() {} setGame() {}
+}
+
+let tmp: string;
+let sock: string;
+let server: RpcServer;
+let mgr: SessionManager;
+
+beforeEach(async () => {
+  tmp = mkdtempSync(join(tmpdir(), "lobbyd-test-"));
+  sock = join(tmp, "lobbyd.sock");
+  mgr = new SessionManager(() => new FakeLobby());
+  server = await startRpcServer({ socketPath: sock, manager: mgr });
+});
+afterEach(async () => {
+  await server.stop();
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+async function rpc(req: Request): Promise<Reply> {
+  const replies = await rpcStream(req, 1);
+  return replies[0]!;
+}
+
+async function rpcStream(req: Request, expected: number): Promise<Reply[]> {
+  return new Promise((resolve, reject) => {
+    const out: Reply[] = [];
+    let buf = "";
+    Bun.connect({
+      unix: sock,
+      socket: {
+        open(s) { s.write(encodeFrame(req)); },
+        data(s, chunk) {
+          buf += new TextDecoder().decode(chunk);
+          const { frames, rest } = parseFrames<Reply>(buf);
+          buf = rest;
+          for (const f of frames) {
+            out.push(f);
+            if (out.length >= expected) { s.end(); resolve(out); return; }
+          }
+        },
+        close() { if (out.length < expected) reject(new Error(`closed early; got ${out.length}/${expected}`)); },
+        error(_s, e) { reject(e); },
+      },
+    });
+  });
+}
+
+describe("rpc-server", () => {
+  test("ls on empty manager returns empty list", async () => {
+    const r = await rpc({ id: 1, op: "ls", args: {} });
+    expect(r).toEqual({ id: 1, ok: true, result: { sessions: [] }, final: true });
+  });
+
+  test("spawn → ls round trip", async () => {
+    const s = await rpc({ id: 2, op: "spawn", args: {
+      name: "alice", host: "h", port: 1, version: "v", platform: 0, user: "u", pass: "p",
+    }});
+    expect(s.ok).toBe(true);
+    expect((s.result as any).accountId).toBe(7);
+    const ls = await rpc({ id: 3, op: "ls", args: {} });
+    expect((ls.result as any).sessions).toHaveLength(1);
+    expect((ls.result as any).sessions[0].name).toBe("alice");
+  });
+
+  test("kill on missing session returns NO_SESSION", async () => {
+    const r = await rpc({ id: 4, op: "kill", args: { name: "ghost" } });
+    expect(r.ok).toBe(false);
+    expect(r.code).toBe("NO_SESSION");
+  });
+
+  test("unknown op returns BAD_OP", async () => {
+    const r = await rpc({ id: 5, op: "nope", args: {} });
+    expect(r.ok).toBe(false);
+    expect(r.code).toBe("BAD_OP");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests (expect failure — module missing)**
+
+```bash
+cd clients/cli && bun test tests/lobby/rpc-server.test.ts
+```
+
+- [ ] **Step 3: Implement `rpc-server.ts`**
+
+Create `clients/cli/src/lobby/rpc-server.ts`:
+
+```ts
+import { unlink } from "node:fs/promises";
+import type { SessionManager } from "./session-manager.ts";
+import { encodeFrame, parseFrames, type Reply, type Request } from "./protocol.ts";
+
+export interface RpcServerOptions {
+    socketPath: string;
+    manager: SessionManager;
+    onIdle?: () => void;
+}
+
+export interface RpcServer {
+    stop(): Promise<void>;
+    activeConnections(): number;
+}
+
+export async function startRpcServer(opts: RpcServerOptions): Promise<RpcServer> {
+    // Best-effort cleanup of stale socket; bind will fail loudly if a live
+    // peer is still listening, which is exactly what we want.
+    await unlink(opts.socketPath).catch(() => {});
+
+    let activeConns = 0;
+    const tailUnsubs = new WeakMap<any, Array<() => void>>();
+
+    const server = Bun.listen({
+        unix: opts.socketPath,
+        socket: {
+            open(socket) {
+                activeConns++;
+                (socket as any).__buf = "";
+            },
+            data(socket, chunk: Uint8Array) {
+                (socket as any).__buf += new TextDecoder().decode(chunk);
+                let parsed;
+                try {
+                    parsed = parseFrames<Request>((socket as any).__buf);
+                } catch (e) {
+                    socket.write(encodeFrame({ id: 0, ok: false, error: (e as Error).message, code: "BAD_FRAME", final: true }));
+                    socket.end();
+                    return;
+                }
+                (socket as any).__buf = parsed.rest;
+                for (const req of parsed.frames) handle(socket, req);
+            },
+            close(socket) {
+                activeConns--;
+                for (const off of tailUnsubs.get(socket) ?? []) off();
+                tailUnsubs.delete(socket);
+                if (activeConns === 0 && opts.manager.size() === 0) opts.onIdle?.();
+            },
+            error(_s, _e) { /* swallow; close will fire */ },
+        },
+    });
+
+    function send(socket: any, reply: Reply): void {
+        try { socket.write(encodeFrame(reply)); } catch { /* peer gone */ }
+    }
+
+    async function handle(socket: any, req: Request): Promise<void> {
+        try {
+            switch (req.op) {
+                case "ls":
+                    send(socket, { id: req.id, ok: true, result: { sessions: opts.manager.list() }, final: true });
+                    return;
+                case "spawn": {
+                    const a = req.args as any;
+                    const r = await opts.manager.spawn(a);
+                    send(socket, { id: req.id, ok: true, result: r, final: true });
+                    return;
+                }
+                case "kill": {
+                    await opts.manager.kill((req.args as any).name);
+                    send(socket, { id: req.id, ok: true, result: {}, final: true });
+                    if (opts.manager.size() === 0 && activeConns <= 1) opts.onIdle?.();
+                    return;
+                }
+                case "kill_all": {
+                    await opts.manager.killAll();
+                    send(socket, { id: req.id, ok: true, result: {}, final: true });
+                    opts.onIdle?.();
+                    return;
+                }
+                case "chat": {
+                    const a = req.args as any;
+                    opts.manager.getOrThrow(a.name).lobby.sendChat(a.channel, a.text);
+                    send(socket, { id: req.id, ok: true, result: {}, final: true });
+                    return;
+                }
+                case "join_channel": {
+                    const a = req.args as any;
+                    opts.manager.getOrThrow(a.name).lobby.joinChannel(a.channel);
+                    send(socket, { id: req.id, ok: true, result: {}, final: true });
+                    return;
+                }
+                case "game_create": {
+                    const a = req.args as any;
+                    const session = opts.manager.getOrThrow(a.name);
+                    const off = session.lobby.on("newGame", (e: any) => {
+                        off();
+                        send(socket, { id: req.id, ok: true, result: { gameId: e.game.id }, final: true });
+                    });
+                    session.lobby.createGame(a.game);
+                    return;
+                }
+                case "game_join": {
+                    const a = req.args as any;
+                    opts.manager.getOrThrow(a.name).lobby.setGame(a.gameId, 0 /* Lobby */);
+                    send(socket, { id: req.id, ok: true, result: {}, final: true });
+                    return;
+                }
+                case "tail": {
+                    const a = req.args as any;
+                    const session = opts.manager.getOrThrow(a.name);
+                    const offs: Array<() => void> = [];
+                    for (const ev of ["chat", "presence", "channel", "newGame", "delGame", "stateChanged"]) {
+                        offs.push(session.lobby.on(ev, (data: unknown) => {
+                            send(socket, { id: req.id, ok: true, result: { event: ev, data }, final: false });
+                        }));
+                    }
+                    tailUnsubs.set(socket, [...(tailUnsubs.get(socket) ?? []), ...offs]);
+                    return;
+                }
+                default:
+                    send(socket, { id: req.id, ok: false, error: `unknown op: ${req.op}`, code: "BAD_OP", final: true });
+            }
+        } catch (e) {
+            const msg = e instanceof Error ? e.message : String(e);
+            const code = msg.startsWith("NO_SESSION") ? "NO_SESSION" : "ERR";
+            send(socket, { id: req.id, ok: false, error: msg, code, final: true });
+        }
+    }
+
+    return {
+        async stop() {
+            server.stop(true);
+            await unlink(opts.socketPath).catch(() => {});
+        },
+        activeConnections() { return activeConns; },
+    };
+}
+```
+
+- [ ] **Step 4: Run tests (expect green)**
+
+```bash
+cd clients/cli && bun test tests/lobby/rpc-server.test.ts
+```
+
+Expected: all four tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add clients/cli/src/lobby/rpc-server.ts clients/cli/tests/lobby/rpc-server.test.ts
+git commit -m "feat(cli): unix-socket RPC server for lobbyd"
+```
+
+---
+
+## Task 6: RPC client (`rpc-client.ts`)
+
+The CLI's view of the daemon: open a socket, write one request, return either one reply (one-shot) or an `AsyncIterable<Reply>` (streaming).
+
+**Files:**
+- Create: `clients/cli/src/lobby/rpc-client.ts`
+- Test: `clients/cli/tests/lobby/rpc-client.test.ts`
+
+- [ ] **Step 1: Write the failing tests (uses a tiny fake server)**
+
+Create `clients/cli/tests/lobby/rpc-client.test.ts`:
+
+```ts
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { rpcCall, rpcStream } from "../../src/lobby/rpc-client.ts";
+import { encodeFrame, parseFrames, type Reply, type Request } from "../../src/lobby/protocol.ts";
+
+let tmp: string;
+let sock: string;
+let server: ReturnType<typeof Bun.listen>;
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), "rpcclient-"));
+  sock = join(tmp, "s.sock");
+});
+afterEach(() => {
+  server?.stop(true);
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+function startEcho(reply: (req: Request) => Reply | Reply[]): void {
+  server = Bun.listen({
+    unix: sock,
+    socket: {
+      open(s) { (s as any).__b = ""; },
+      data(s, chunk) {
+        (s as any).__b += new TextDecoder().decode(chunk);
+        const { frames, rest } = parseFrames<Request>((s as any).__b);
+        (s as any).__b = rest;
+        for (const f of frames) {
+          const out = reply(f);
+          for (const r of Array.isArray(out) ? out : [out]) s.write(encodeFrame(r));
+        }
+      },
+      close() {}, error() {},
+    },
+  });
+}
+
+describe("rpcCall", () => {
+  test("returns the single final reply", async () => {
+    startEcho((req) => ({ id: req.id, ok: true, result: { echoed: req.op }, final: true }));
+    const r = await rpcCall(sock, { id: 1, op: "ping", args: {} });
+    expect(r).toEqual({ id: 1, ok: true, result: { echoed: "ping" }, final: true });
+  });
+
+  test("rejects when daemon socket is missing", async () => {
+    const missing = join(tmp, "nope.sock");
+    await expect(rpcCall(missing, { id: 1, op: "x", args: {} })).rejects.toThrow();
+  });
+});
+
+describe("rpcStream", () => {
+  test("yields frames until final", async () => {
+    startEcho((req) => [
+      { id: req.id, ok: true, result: { event: "a" }, final: false },
+      { id: req.id, ok: true, result: { event: "b" }, final: false },
+      { id: req.id, ok: true, result: {}, final: true },
+    ]);
+    const out: Reply[] = [];
+    for await (const r of rpcStream(sock, { id: 1, op: "tail", args: {}, stream: true })) out.push(r);
+    expect(out.map((r) => (r.result as any).event ?? "<final>")).toEqual(["a", "b", "<final>"]);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests (expect failure)**
+
+```bash
+cd clients/cli && bun test tests/lobby/rpc-client.test.ts
+```
+
+- [ ] **Step 3: Implement `rpc-client.ts`**
+
+Create `clients/cli/src/lobby/rpc-client.ts`:
+
+```ts
+import { encodeFrame, parseFrames, type Reply, type Request } from "./protocol.ts";
+
+export async function rpcCall(socketPath: string, req: Request): Promise<Reply> {
+    for await (const r of rpcStream(socketPath, req)) {
+        if (r.final) return r;
+    }
+    throw new Error("daemon closed connection without a final reply");
+}
+
+export function rpcStream(socketPath: string, req: Request): AsyncIterable<Reply> {
+    return {
+        [Symbol.asyncIterator]() {
+            const queue: Reply[] = [];
+            let waiters: Array<(r: IteratorResult<Reply>) => void> = [];
+            let done = false;
+            let errored: unknown = null;
+            let buf = "";
+            let socket: any;
+
+            const push = (r: Reply) => {
+                if (waiters.length) waiters.shift()!({ value: r, done: false });
+                else queue.push(r);
+                if (r.final) finish();
+            };
+            const finish = () => {
+                done = true;
+                for (const w of waiters) w({ value: undefined, done: true });
+                waiters = [];
+                try { socket?.end(); } catch { /* ignore */ }
+            };
+            const fail = (e: unknown) => {
+                errored = e;
+                done = true;
+                for (const w of waiters) w({ value: undefined as any, done: true });
+                waiters = [];
+            };
+
+            Bun.connect({
+                unix: socketPath,
+                socket: {
+                    open(s: any) { socket = s; s.write(encodeFrame(req)); },
+                    data(_s: any, chunk: Uint8Array) {
+                        buf += new TextDecoder().decode(chunk);
+                        let parsed;
+                        try { parsed = parseFrames<Reply>(buf); }
+                        catch (e) { fail(e); return; }
+                        buf = parsed.rest;
+                        for (const f of parsed.frames) push(f);
+                    },
+                    close() { if (!done) fail(new Error("daemon closed connection")); },
+                    error(_s: any, e: Error) { fail(e); },
+                },
+            }).catch(fail);
+
+            return {
+                async next(): Promise<IteratorResult<Reply>> {
+                    if (errored) throw errored;
+                    if (queue.length) return { value: queue.shift()!, done: false };
+                    if (done) return { value: undefined as any, done: true };
+                    return new Promise((resolve) => waiters.push(resolve));
+                },
+            };
+        },
+    };
+}
+```
+
+- [ ] **Step 4: Run tests (expect green)**
+
+```bash
+cd clients/cli && bun test tests/lobby/rpc-client.test.ts
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add clients/cli/src/lobby/rpc-client.ts clients/cli/tests/lobby/rpc-client.test.ts
+git commit -m "feat(cli): unix-socket RPC client for lobbyd"
+```
+
+---
+
+## Task 7: Auto-spawn (`spawn.ts`)
+
+Detect whether the daemon is up; if not, fork a detached Bun process running `daemon.ts` and poll the socket until it accepts a connection.
+
+**Files:**
+- Create: `clients/cli/src/lobby/spawn.ts`
+
+(No unit tests for this module — it's a thin glue around `Bun.spawn` and the filesystem; covered by the daemon integration test in Task 9.)
+
+- [ ] **Step 1: Implement `spawn.ts`**
+
+Create `clients/cli/src/lobby/spawn.ts`:
+
+```ts
+import { existsSync, mkdirSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { resolveLobbydDir, socketPath } from "./paths.ts";
+
+const POLL_INTERVAL_MS = 50;
+const POLL_TIMEOUT_MS = 5_000;
+
+async function probe(sock: string): Promise<boolean> {
+    try {
+        const s = await Bun.connect({
+            unix: sock,
+            socket: { open(s) { s.end(); }, data() {}, close() {}, error() {} },
+        });
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+/** Returns the resolved socket path, spawning the daemon if not yet listening. */
+export async function ensureDaemon(): Promise<string> {
+    const dir = resolveLobbydDir();
+    mkdirSync(dir, { recursive: true });
+    const sock = socketPath(dir);
+    if (await probe(sock)) return sock;
+
+    // Daemon entry lives next to this file at runtime.
+    const here = fileURLToPath(import.meta.url);
+    const daemonEntry = resolve(dirname(here), "daemon.ts");
+
+    Bun.spawn({
+        cmd: ["bun", daemonEntry],
+        stdio: ["ignore", "ignore", "ignore"],
+        // Detach so the parent CLI can exit while the daemon stays up.
+        // unref() lets node-style event-loop drain even if we forget to wait.
+    }).unref();
+
+    const deadline = Date.now() + POLL_TIMEOUT_MS;
+    while (Date.now() < deadline) {
+        if (await probe(sock)) return sock;
+        await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+    }
+    throw new Error(`lobbyd did not start within ${POLL_TIMEOUT_MS}ms (socket: ${sock})`);
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+```bash
+cd clients/cli && bun run typecheck
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add clients/cli/src/lobby/spawn.ts
+git commit -m "feat(cli): auto-spawn detached lobbyd"
+```
+
+---
+
+## Task 8: Daemon entry point (`daemon.ts`)
+
+Wires `SessionManager` + `RpcServer`, installs signal handlers, and exits when idle (no sessions AND no active connections).
+
+**Files:**
+- Create: `clients/cli/src/lobby/daemon.ts`
+
+- [ ] **Step 1: Implement `daemon.ts`**
+
+Create `clients/cli/src/lobby/daemon.ts`:
+
+```ts
+#!/usr/bin/env bun
+// silencer-lobbyd — multiplexes N LobbyClient sessions for the agent CLI.
+//
+// Lifecycle:
+//   1. Resolve dir/socket/log path.
+//   2. mkdir -p dir.
+//   3. Bind unix socket; if bind fails because a live daemon is already
+//      listening, exit 0 (the CLI client will use that one).
+//   4. Serve until idle (zero sessions AND zero connections) or SIGINT.
+
+import { mkdirSync, openSync, writeSync } from "node:fs";
+import { logPath, resolveLobbydDir, socketPath } from "./paths.ts";
+import { startRpcServer } from "./rpc-server.ts";
+import { realLobbyFactory, SessionManager } from "./session-manager.ts";
+
+async function main(): Promise<void> {
+    const dir = resolveLobbydDir();
+    mkdirSync(dir, { recursive: true });
+    const sock = socketPath(dir);
+    const log = logPath(dir);
+
+    // Append-only log file; one line per significant event.
+    const logFd = openSync(log, "a");
+    const ts = () => new Date().toISOString();
+    const logLine = (msg: string) => writeSync(logFd, `${ts()} ${msg}\n`);
+
+    // If a daemon is already up, defer to it. The CLI client's auto-spawn
+    // probes first and only invokes us when no peer answered, but a race
+    // between two parallel spawns is still possible.
+    try {
+        const probe = await Bun.connect({
+            unix: sock, socket: { open(s) { s.end(); }, data() {}, close() {}, error() {} },
+        });
+        logLine("another lobbyd already listening; exiting");
+        process.exit(0);
+    } catch { /* expected */ }
+
+    const factory = await realLobbyFactory();
+    const manager = new SessionManager(factory);
+    let server: Awaited<ReturnType<typeof startRpcServer>>;
+
+    const shutdown = async (reason: string) => {
+        logLine(`shutdown: ${reason}`);
+        await manager.killAll().catch(() => {});
+        await server?.stop().catch(() => {});
+        process.exit(0);
+    };
+
+    server = await startRpcServer({
+        socketPath: sock,
+        manager,
+        onIdle: () => { void shutdown("idle"); },
+    });
+
+    process.on("SIGINT", () => void shutdown("SIGINT"));
+    process.on("SIGTERM", () => void shutdown("SIGTERM"));
+    logLine(`listening on ${sock}`);
+}
+
+main().catch((e) => {
+    process.stderr.write(`[lobbyd] fatal: ${e instanceof Error ? e.stack ?? e.message : String(e)}\n`);
+    process.exit(1);
+});
+```
+
+- [ ] **Step 2: Typecheck**
+
+```bash
+cd clients/cli && bun run typecheck
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add clients/cli/src/lobby/daemon.ts
+git commit -m "feat(cli): lobbyd entry point with idle exit"
+```
+
+---
+
+## Task 9: CLI commands and dispatch wire-up (`commands.ts` + `index.ts`)
+
+**Files:**
+- Create: `clients/cli/src/lobby/commands.ts`
+- Modify: `clients/cli/index.ts`
+- Test: `clients/cli/tests/lobby/daemon-integration.test.ts`
+
+- [ ] **Step 1: Write the integration test (drives the real daemon)**
+
+Create `clients/cli/tests/lobby/daemon-integration.test.ts`:
+
+```ts
+// Drives the real daemon via spawn.ensureDaemon, against an in-memory fake
+// SessionManager? No — easier: hit the daemon's RPC server directly with a
+// SessionManager that uses our fake LobbyClient. That keeps this test
+// hermetic (no real lobby server required).
+//
+// Strategy: instead of forking a child process, build the same wiring
+// (manager + server) in-process and exercise it through the rpc-client.
+// The detached child fork is exercised manually in Task 10's smoke step.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { rpcCall, rpcStream } from "../../src/lobby/rpc-client.ts";
+import { startRpcServer, type RpcServer } from "../../src/lobby/rpc-server.ts";
+import { SessionManager } from "../../src/lobby/session-manager.ts";
+
+class FakeLobby {
+  state: any = "disconnected"; accountId = 0; lastError = "";
+  ls: Record<string, Set<any>> = {};
+  on(e: string, fn: any) { (this.ls[e] ??= new Set()).add(fn); return () => this.ls[e]?.delete(fn); }
+  emit(e: string, ...a: any[]) { for (const fn of this.ls[e] ?? []) fn(...a); }
+  async connect() { queueMicrotask(() => { this.state = "authenticated"; this.accountId = 99; this.emit("stateChanged", "authenticated"); }); }
+  async disconnect() { this.state = "disconnected"; this.emit("stateChanged", "disconnected"); }
+  sendVersion() {} sendCredentials() {}
+  sendChat(channel: string, text: string) { this.emit("chat", { channel, text, color: 0, brightness: 0 }); }
+  joinChannel(c: string) { this.emit("channel", c); }
+  createGame(g: any) { this.emit("newGame", { status: 1, game: { ...g, id: 12345 } }); }
+  setGame() {}
+}
+
+let tmp: string; let sock: string; let server: RpcServer;
+beforeEach(async () => {
+  tmp = mkdtempSync(join(tmpdir(), "lobbyd-int-"));
+  sock = join(tmp, "lobbyd.sock");
+  const mgr = new SessionManager(() => new FakeLobby());
+  server = await startRpcServer({ socketPath: sock, manager: mgr });
+});
+afterEach(async () => { await server.stop(); rmSync(tmp, { recursive: true, force: true }); });
+
+describe("daemon integration", () => {
+  test("spawn → chat → tail flow", async () => {
+    const spawn = await rpcCall(sock, {
+      id: 1, op: "spawn",
+      args: { name: "alice", host: "h", port: 1, version: "v", platform: 0, user: "u", pass: "p" },
+    });
+    expect(spawn.ok).toBe(true);
+
+    // Open a tail before sending chat so we observe the emitted event.
+    const tailIter = rpcStream(sock, { id: 2, op: "tail", args: { name: "alice" }, stream: true });
+    const events: any[] = [];
+    const consumer = (async () => {
+      for await (const r of tailIter) {
+        if (r.final) break;
+        events.push(r.result);
+      }
+    })();
+    // Give the tail RPC a tick to register listeners.
+    await new Promise((r) => setTimeout(r, 20));
+
+    const chat = await rpcCall(sock, { id: 3, op: "chat", args: { name: "alice", channel: "main", text: "hi" } });
+    expect(chat.ok).toBe(true);
+
+    // Game create should resolve once the fake echoes a newGame event.
+    const create = await rpcCall(sock, { id: 4, op: "game_create", args: { name: "alice", game: { id: 0 } } });
+    expect(create.ok).toBe(true);
+    expect((create.result as any).gameId).toBe(12345);
+
+    // Trigger end-of-tail by killing the session.
+    await rpcCall(sock, { id: 5, op: "kill", args: { name: "alice" } });
+    await consumer;
+
+    const seenChat = events.some((e) => e.event === "chat" && e.data.text === "hi");
+    expect(seenChat).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test (expect failure: handlers don't exist yet — but actually the server already implements them, so this should pass)**
+
+```bash
+cd clients/cli && bun test tests/lobby/daemon-integration.test.ts
+```
+
+If passing: good — the server already covers this. Move on. If failing: fix `rpc-server.ts` until green before continuing.
+
+- [ ] **Step 3: Implement `commands.ts`**
+
+Create `clients/cli/src/lobby/commands.ts`:
+
+```ts
+// CLI subcommand handlers for the `lobby` namespace. Each handler returns
+// { clean, result } in the same shape as LOCAL_OPS in index.ts. Anything
+// stateful goes through the daemon; we ensure it's running first.
+
+import { rpcCall, rpcStream } from "./rpc-client.ts";
+import { ensureDaemon } from "./spawn.ts";
+
+type Handler = (args: Record<string, unknown>) => Promise<{ clean: boolean; result: unknown }>;
+
+let nextId = 1;
+function reqId(): number { return nextId++; }
+
+async function call(op: string, args: Record<string, unknown>): Promise<{ clean: boolean; result: unknown }> {
+    const sock = await ensureDaemon();
+    const r = await rpcCall(sock, { id: reqId(), op, args });
+    if (!r.ok) {
+        process.stderr.write(`[${r.code ?? "ERR"}] ${r.error ?? ""}\n`);
+        return { clean: false, result: { error: r.error, code: r.code } };
+    }
+    return { clean: true, result: r.result ?? {} };
+}
+
+export const LOBBY_HANDLERS: Record<string, Handler> = {
+    spawn: async (args) => {
+        const required = ["as", "user", "pass", "version", "host", "port"] as const;
+        for (const k of required) if (args[k] === undefined) throw new Error(`missing --${k}`);
+        return call("spawn", {
+            name: args["as"],
+            user: args["user"],
+            pass: args["pass"],
+            version: args["version"],
+            host: args["host"],
+            port: Number(args["port"]),
+            platform: Number(args["platform"] ?? 0),
+        });
+    },
+    ls: async (_args) => call("ls", {}),
+    kill: async (args) => {
+        if (args["all"]) return call("kill_all", {});
+        if (!args["as"]) throw new Error("kill requires --as <name> or --all");
+        return call("kill", { name: args["as"] });
+    },
+    chat: async (args) => {
+        if (!args["as"] || !args["channel"] || args["text"] === undefined) {
+            throw new Error("chat requires --as --channel --text");
+        }
+        return call("chat", { name: args["as"], channel: args["channel"], text: args["text"] });
+    },
+    join_channel: async (args) => {
+        if (!args["as"] || !args["channel"]) throw new Error("join_channel requires --as --channel");
+        return call("join_channel", { name: args["as"], channel: args["channel"] });
+    },
+    game: async (args) => {
+        const sub = args["_subgame"] as string | undefined;
+        if (sub === "create") {
+            if (!args["as"] || !args["name"]) throw new Error("game create requires --as and --name");
+            return call("game_create", {
+                name: args["as"],
+                game: {
+                    id: 0,
+                    name: args["name"],
+                    password: args["password"] ?? "",
+                    mapName: args["map"] ?? "",
+                    maxPlayers: Number(args["max_players"] ?? 8),
+                    maxTeams: Number(args["max_teams"] ?? 2),
+                    minLevel: 0, maxLevel: 0, securityLevel: 0,
+                    extra: 0, players: 0, state: 0,
+                    accountId: 0, hostname: "", mapHash: new Uint8Array(20), port: 0,
+                },
+            });
+        }
+        if (sub === "join") {
+            if (!args["as"] || args["id"] === undefined) throw new Error("game join requires --as --id");
+            return call("game_join", { name: args["as"], gameId: Number(args["id"]) });
+        }
+        throw new Error(`unknown game subcommand: ${sub}`);
+    },
+    tail: async (args) => {
+        if (!args["as"]) throw new Error("tail requires --as <name>");
+        const sock = await ensureDaemon();
+        for await (const r of rpcStream(sock, { id: reqId(), op: "tail", args: { name: args["as"] }, stream: true })) {
+            if (r.final) break;
+            process.stdout.write(JSON.stringify(r.result) + "\n");
+        }
+        return { clean: true, result: {} };
+    },
+};
+```
+
+- [ ] **Step 4: Wire `lobby` into `index.ts`**
+
+Edit `clients/cli/index.ts` — three small changes:
+
+1. At the top of the file, add the import:
+```ts
+import { LOBBY_HANDLERS } from "./src/lobby/commands.ts";
+```
+
+2. Add `"lobby"` to `NOUN_FIRST_OPS`:
+```ts
+const NOUN_FIRST_OPS = new Set(["keybind", "gas", "lobby"]);
+```
+
+3. Add the lobby branch into `LOCAL_OPS` (so it goes through the local-op fast-path and never opens the silencer game's control port):
+```ts
+const LOCAL_OPS: Record<string, Record<string, LocalHandler>> = {
+  gas: {
+    validate: async (args) => {
+      const dir = (args["dir"] as string | undefined) ?? (args["_positional"] as string | undefined);
+      if (!dir) throw new Error("gas validate requires a directory: silencer-cli gas validate <dir>");
+      const { validateDirectory } = await import("@silencer/gas-validation/node");
+      const res = await validateDirectory(dir);
+      return { clean: res.ok, result: res };
+    },
+  },
+  lobby: LOBBY_HANDLERS,
+};
+```
+
+4. In `STRING_FLAGS`, register the lobby flags that must stay strings (passwords with digits, account names, etc.):
+```ts
+const STRING_FLAGS: Record<string, Record<string, Set<string>>> = {
+  keybind: {
+    get:    new Set(["profile", "action"]),
+    put:    new Set(["profile", "action"]),
+    unset:  new Set(["profile", "action"]),
+    use:    new Set(["profile"]),
+    new:    new Set(["profile", "from"]),
+    delete: new Set(["profile"]),
+  },
+  gas: {
+    validate: new Set(["dir"]),
+  },
+  lobby: {
+    spawn:        new Set(["as", "user", "pass", "version", "host"]),
+    chat:         new Set(["as", "channel", "text"]),
+    join_channel: new Set(["as", "channel"]),
+    kill:         new Set(["as"]),
+    game:         new Set(["as", "name", "map", "password"]),
+    tail:         new Set(["as"]),
+  },
+};
+```
+
+5. Update the `usage()` string. Append before the env-vars footer:
+```
+       silencer-cli lobby spawn --as alice --host H --port P --version V --user U --pass P
+       silencer-cli lobby ls
+       silencer-cli lobby chat --as alice --channel main --text "hi"
+       silencer-cli lobby game create --as alice --name TEST [--map M --max-players 8]
+       silencer-cli lobby game join   --as alice --id 12345
+       silencer-cli lobby tail --as alice
+       silencer-cli lobby kill --as alice | --all
+       silencer-cli lobby join_channel --as alice --channel main
+```
+
+6. Handle the `game` sub-subcommand. After the existing positional-handling block in `parseArgs`, add a branch that captures the third positional when `op === "lobby" && subop === "game"` into `args["_subgame"]`:
+```ts
+      // lobby game <create|join>: third positional is the sub-subcommand.
+      else if (op === "lobby" && subop === "game" && args["_subgame"] === undefined) {
+        args["_subgame"] = a;
+      }
+```
+
+- [ ] **Step 5: Typecheck and run all tests**
+
+```bash
+cd clients/cli && bun run typecheck && bun test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add clients/cli/src/lobby/commands.ts clients/cli/index.ts clients/cli/tests/lobby/daemon-integration.test.ts
+git commit -m "feat(cli): lobby namespace — spawn/chat/game/tail/kill/ls"
+```
+
+---
+
+## Task 10: Docs + end-to-end smoke + finalize
+
+**Files:**
+- Create: `clients/cli/src/lobby/CLAUDE.md` (+ `AGENTS.md` symlink)
+- Modify: `clients/cli/CLAUDE.md`
+
+- [ ] **Step 1: Write the lobby CLAUDE.md**
+
+Create `clients/cli/src/lobby/CLAUDE.md`:
+
+```markdown
+# clients/cli/src/lobby — agent-driven fake lobby presences
+
+Single supervisor daemon (`silencer-lobbyd`) holds N `@silencer/lobby-sdk`
+`LobbyClient` instances keyed by session name. CLI subcommands are thin
+clients: open the unix socket, send one JSON-lines request, exit.
+
+## Files
+
+- `paths.ts` — co-located dir resolution
+  (`SILENCER_LOBBYD_DIR` overrides; defaults: `$XDG_RUNTIME_DIR/silencer/`
+  on Linux, `$TMPDIR/silencer/` on macOS, `%LOCALAPPDATA%\Silencer\lobbyd\`
+  on Windows). Both `lobbyd.sock` and `lobbyd.log` live here.
+- `protocol.ts` — `Request` / `Reply` JSON-lines frames.
+- `session-manager.ts` — in-memory session map; takes a `LobbyLike`
+  factory so tests can inject fakes.
+- `rpc-server.ts` — `Bun.listen({ unix })`; dispatches to the manager.
+- `rpc-client.ts` — `Bun.connect({ unix })`; one-shot + streaming.
+- `spawn.ts` — auto-spawn detached `silencer-lobbyd`, poll the socket.
+- `daemon.ts` — entry point. Auto-exits when sessions=0 AND conns=0.
+- `commands.ts` — handlers wired into `index.ts`'s `LOCAL_OPS.lobby`.
+
+## Lifecycle
+
+1. First `lobby spawn` → `ensureDaemon` probes the socket. Refused → forks
+   detached `bun src/lobby/daemon.ts` and polls until it accepts.
+2. Daemon serves until `kill_all` or until `kill` removes the last
+   session AND the last connection drops.
+3. Stale socket file (crashed daemon) is unlinked on the next bind.
+
+## Invariants
+
+- Creds (`--user`, `--pass`) are passed once to `spawn`; subsequent calls
+  use only `--as <name>`. Passwords never touch disk.
+- macOS sun_path is 104 bytes; `paths.ts` caps the resolved socket path
+  at 100 and throws a clear error otherwise.
+- One process, N sessions: per-player overhead is just a `LobbyClient`
+  instance + its TCP socket. The Bun runtime cost is amortized once.
+
+## When NOT to touch this dir
+
+- If you're changing the wire protocol (adding lobby opcodes), edit
+  `services/lobby/protocol.go` first, then `clients/lobby-sdk/ts`, then
+  `shared/lobby-protocol/vectors.json`. This module consumes the SDK
+  and shouldn't grow protocol knowledge of its own.
+- If you're adding non-lobby CLI features, they don't belong here. The
+  `lobby` namespace is the only thing in this dir.
+```
+
+- [ ] **Step 2: Add the AGENTS.md symlink (one-line stub on Windows)**
+
+```bash
+cd clients/cli/src/lobby && ln -s CLAUDE.md AGENTS.md
+```
+
+- [ ] **Step 3: Update the parent CLAUDE.md to mention the new namespace**
+
+Edit `clients/cli/CLAUDE.md`. After the existing `Run` section, append:
+
+```markdown
+## Lobby fake players
+
+`lobby` namespace spawns persistent authenticated lobby presences in a
+shared supervisor daemon. See [`src/lobby/CLAUDE.md`](src/lobby/CLAUDE.md).
+
+```bash
+silencer-cli lobby spawn --as alice --host LOBBY_HOST --port 15170 \
+                         --version 1.2.3 --user alice --pass hunter2
+silencer-cli lobby chat  --as alice --channel main --text "hi"
+silencer-cli lobby tail  --as alice    # streams events until SIGINT
+silencer-cli lobby kill  --as alice
+```
+
+Defaults co-locate socket+log at `$SILENCER_LOBBYD_DIR` (override) or the
+platform default (`$XDG_RUNTIME_DIR/silencer/` on Linux,
+`$TMPDIR/silencer/` on macOS, `%LOCALAPPDATA%\Silencer\lobbyd\` on
+Windows).
+```
+
+- [ ] **Step 4: End-to-end smoke against a real lobby**
+
+Bring up a local lobby (`cd services/lobby && go run . -version=""`). In another shell:
+
+```bash
+cd clients/cli
+bun ./index.ts lobby spawn --as alice --host 127.0.0.1 --port 15170 \
+                           --version "" --user alice --pass alice
+bun ./index.ts lobby ls
+bun ./index.ts lobby chat --as alice --channel main --text "hello"
+bun ./index.ts lobby kill --as alice
+```
+
+Expected:
+- `spawn` prints `{"accountId":<n>}` and exits 0.
+- `ls` shows alice with `state: "authenticated"`.
+- `chat` prints `{}` and exits 0.
+- `kill` prints `{}` and exits 0.
+- After ~100ms, `silencer-lobbyd` process is gone (`pgrep -f silencer-lobbyd` empty).
+
+Then verify auto-spawn works on a fresh shell: `bun ./index.ts lobby ls` from a clean state should silently start the daemon and return `{"sessions":[]}`.
+
+- [ ] **Step 5: Final typecheck + tests + format**
+
+```bash
+cd clients/cli && bun run fmt && bun run typecheck && bun test
+```
+
+Expected: format clean, typecheck clean, tests green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add clients/cli/src/lobby/CLAUDE.md clients/cli/src/lobby/AGENTS.md clients/cli/CLAUDE.md
+git commit -m "docs(cli): document lobby namespace and lobbyd"
+```
+
+---
+
+## Self-review notes (verified against spec)
+
+- **Spec coverage** — every requirement maps to a task: workspace registration (T1), platform paths + sun_path guard (T2), RPC protocol (T3), session lifecycle incl. duplicate/timeout/auth-fail (T4), unix server with all ops including streaming tail (T5), client with one-shot + streaming (T6), auto-spawn (T7), idle exit + signal handlers (T8), CLI namespace incl. `game create`/`game join` (T9), docs + smoke (T10).
+- **Type consistency** — `LobbyLike` is the single interface across manager/server/tests. RPC ops names are consistent (`spawn`, `kill`, `kill_all`, `ls`, `chat`, `join_channel`, `game_create`, `game_join`, `tail`) — used identically in server, client handlers, and CLI dispatch.
+- **No placeholders** — every step has the actual code or command. Test code is full and runnable.
+- **Known caveats baked into the plan**:
+  - macOS sun_path: hard-asserted at 100 bytes with a clear error suggesting `SILENCER_LOBBYD_DIR`.
+  - Stale socket: unlinked on bind (server) and detected on probe (auto-spawn).
+  - Auto-exit race: daemon checks idle on every `close` AND on every successful `kill`/`kill_all`; first idle wins.
+  - The integration test (T9) avoids forking a real child process so it stays hermetic; the actual fork path is exercised in the smoke step (T10 step 4).

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "workspaces": [
     "clients/cli",
+    "clients/lobby-sdk/ts",
     "services/admin-api",
     "shared/fonts",
     "shared/gas-validation",

--- a/services/admin-api/Dockerfile
+++ b/services/admin-api/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /app
 # the workspace graph; --filter ./services/admin-api scopes the dep set.
 COPY package.json bun.lock ./
 COPY clients/cli/package.json            ./clients/cli/
+COPY clients/lobby-sdk/ts/package.json   ./clients/lobby-sdk/ts/
 COPY services/admin-api/package.json     ./services/admin-api/
 COPY shared/fonts/package.json           ./shared/fonts/
 COPY shared/gas-validation/package.json  ./shared/gas-validation/

--- a/web/admin/Dockerfile
+++ b/web/admin/Dockerfile
@@ -8,6 +8,7 @@ WORKDIR /app
 FROM base AS deps
 COPY package.json bun.lock ./
 COPY clients/cli/package.json            ./clients/cli/
+COPY clients/lobby-sdk/ts/package.json   ./clients/lobby-sdk/ts/
 COPY services/admin-api/package.json     ./services/admin-api/
 COPY shared/fonts/package.json           ./shared/fonts/
 COPY shared/gas-validation/package.json  ./shared/gas-validation/


### PR DESCRIPTION
## Summary

- Adds a `lobby` namespace to `silencer-cli` for spinning up persistent authenticated lobby presences during dev. One supervisor daemon (`silencer-lobbyd`) holds N `@silencer/lobby-sdk` `LobbyClient` instances; CLI subcommands are thin clients over a JSON-lines RPC unix socket. Per-session overhead is just a `LobbyClient` — Bun runtime is amortized once across all sessions.
- Surfaces `spawn` / `ls` / `kill` / `chat` / `join_channel` / `game create|join` / `tail` ops, plus `--all` for `kill`. Daemon auto-spawns on first use, auto-exits when sessions=0 AND conns=0. Co-located socket+log under `$XDG_RUNTIME_DIR/silencer/` (Linux) / `$TMPDIR/silencer/` (macOS) / `%LOCALAPPDATA%\Silencer\lobbyd\` (Windows); `SILENCER_LOBBYD_DIR` overrides.
- Registers `clients/lobby-sdk/ts` as a Bun workspace (it's now a real consumer). Live smoke-test against the Go lobby surfaced and fixed three runtime bugs: a Bun-socket race in the SDK's `LobbyClient.connect()`, a daemon premature-idle-exit on `lobby ls` against an empty manager, and a CLI flag-parser conflict on `--host`/`--port`.

## Test plan

- [ ] `cd clients/cli && bun test` — 35 unit tests pass (paths, protocol, session-manager, rpc-server, rpc-client, daemon-integration).
- [ ] `cd clients/lobby-sdk/ts && bun test` — 31 SDK codec tests pass (no regressions from the connect-race fix).
- [ ] `bun run --filter '*' typecheck` — clean across all packages.
- [ ] Live smoke against a local lobby:
  ```
  (cd services/lobby && go run . -version="" -addr=:15170 &)
  bun ./clients/cli/index.ts lobby spawn --as alice --host 127.0.0.1 --port 15170 --version "" --user alice --pass alice
  bun ./clients/cli/index.ts lobby ls
  bun ./clients/cli/index.ts lobby chat --as alice --channel main --text "hi"
  bun ./clients/cli/index.ts lobby kill --as alice
  pgrep -f silencer-lobbyd  # empty (daemon auto-exited)
  ```
- [ ] Spec / docs: `clients/cli/src/lobby/CLAUDE.md` describes the dir; `clients/cli/CLAUDE.md` has a lobby section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/arsia-mons/silencer/pull/105" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
