### PR TITLE
Fix admin-web Docker build context to repo root

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -100,7 +100,8 @@ services:
 
   admin-web:
     build:
-      context: ../web/admin
+      context: ..
+      dockerfile: web/admin/Dockerfile
       args:
         NEXT_PUBLIC_API_URL: "http://${PUBLIC_ADDR:-localhost}:24080"
         NEXT_PUBLIC_WS_URL: "ws://${PUBLIC_ADDR:-localhost}:24080"


### PR DESCRIPTION
Fixes #110

`infra/docker-compose.yml` had `context: ../web/admin` for the admin-web service, but the Dockerfile expects the repo root as context since it COPYs `package.json`, `bun.lock`, `shared/gas-validation`, and `web/admin` from root paths.

Changed to `context: ..` with explicit `dockerfile: web/admin/Dockerfile`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/arsia-mons/silencer/pull/111" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
