### PR TITLE
Fix admin-api Docker build context to repo root

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -74,7 +74,8 @@ services:
 
   admin-api:
     build:
-      context: ../services/admin-api
+      context: ..
+      dockerfile: services/admin-api/Dockerfile
     ports:
       - "24080:24080"
     depends_on:


### PR DESCRIPTION
Follows up on #111. admin-api Dockerfile also uses the repo root as build context (workspace manifests, bun.lock), but docker-compose had `context: ../services/admin-api`. Fixed to `context: ..` + `dockerfile: services/admin-api/Dockerfile`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/arsia-mons/silencer/pull/112" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
