### PR TITLE
fix: jetpack/hack loops continuing + civilian disguise bypass

### DIFF
--- a/clients/silencer/CMakeLists.txt
+++ b/clients/silencer/CMakeLists.txt
@@ -148,6 +148,8 @@ if(MSVC)
 	# Force-include the shim before every TU to re-expose it.
 	target_compile_options(${SILENCER_TARGET} PRIVATE
 		"/FI${CMAKE_CURRENT_SOURCE_DIR}/cmake/msvc_snprintf_compat.h")
+	# windows.h's min/max macros mangle std::min / std::max calls.
+	target_compile_definitions(${SILENCER_TARGET} PRIVATE NOMINMAX)
 endif()
 
 set(SILENCER_LOBBY_HOST "lobby.arsiamons.com" CACHE STRING "Lobby host the client connects to at startup")

--- a/clients/silencer/src/actors/guard.cpp
+++ b/clients/silencer/src/actors/guard.cpp
@@ -1029,7 +1029,7 @@ Object * Guard::Look(World & world, Uint8 direction){
 			int xv2 = x2 - x1;
 			int yv2 = y2 - y1;
 			Object * object = world.TestIncr(x + x1, y + y1 - 1, x + x1, y + y1, &xv2, &yv2, types);
-			if(object){
+			if(object && ShouldTarget(*object, world)){
 				if(!world.map.TestIncr(x + x1, y + y1 - 1, x + x1, y + y1, &xv2, &yv2, Platform::STAIRSDOWN | Platform::STAIRSDOWN | Platform::RECTANGLE, 0, true)){
 					if(world.debugoverlay) world.debuglines.push_back({x+x1, y+y1, x+x2, y+y2, 68}); // green = hit
 					return object;

--- a/clients/silencer/src/audio/audio.cpp
+++ b/clients/silencer/src/audio/audio.cpp
@@ -79,7 +79,11 @@ int Audio::Play(MIX_Audio * chunk, int volume, bool loop){
 
 void Audio::Stop(int channel, int fadeoutms){
 	if(!enabled || channel < 0 || channel >= maxchannels) return;
-	Sint64 fade_frames = fadeoutms ? MIX_MSToFrames(mixerspec.freq, fadeoutms) : 0;
+	Sint64 fade_frames = 0;
+	if(fadeoutms > 0){
+		fade_frames = MIX_TrackMSToFrames(tracks[channel], fadeoutms);
+		if(fade_frames < 0) fade_frames = 0;
+	}
 	MIX_StopTrack(tracks[channel], fade_frames);
 }
 
@@ -127,8 +131,6 @@ void Audio::UpdateVolume(World & world, int channel, Sint16 x, Sint16 y, int rad
 			MIX_SetTrackGain(tracks[channel], ((oldvolume * volume) / 128.0f) * effectvolume);
 			lastx = x;
 			lasty = y;
-		}else{
-			MIX_StopTrack(tracks[channel], 0);
 		}
 	}
 }

--- a/clients/silencer/src/audio/audio.cpp
+++ b/clients/silencer/src/audio/audio.cpp
@@ -127,6 +127,8 @@ void Audio::UpdateVolume(World & world, int channel, Sint16 x, Sint16 y, int rad
 			MIX_SetTrackGain(tracks[channel], ((oldvolume * volume) / 128.0f) * effectvolume);
 			lastx = x;
 			lasty = y;
+		}else{
+			MIX_StopTrack(tracks[channel], 0);
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Three bugs reported in playtesting; one MSVC build break encountered in passing.

- **Jetpack and hack ambient loops kept playing long after release/cancel.** Root cause was a sample-rate mismatch in `Audio::Stop`: `MIX_StopTrack`'s `fade_out_frames` is in the track input's sample rate per the SDL3_mixer docs, but we were computing it from the mixer output rate (96 kHz). With game ADPCM at ~22 kHz, the intended 200 ms jetpack fade was running ~870 ms; the 700 ms hack fade was running ~3 s. The bug was hidden until `021f671` fixed SDL3_mixer looping — before that, looped sounds played once and self-terminated regardless. Fix: `MIX_TrackMSToFrames(track, ms)` instead of `MIX_MSToFrames(mixer_freq, ms)`. (`Audio::Stop`)

- **Civilian disguise was bypassed when another player was visible to the same guard.** In the line-shaped lookbox path of `Guard::Look` (the standing-forward, crouched-forward, up, and down rays — most detection cases), the code scanned the AABB for any `ShouldTarget` candidate to set a flag, then called `TestIncr` and returned the closest object on the ray *without* re-validating. With one undisguised and one disguised player in the same lookbox, the AABB scan saw the undisguised one and set `target = true`, `TestIncr` returned the closer disguised player, and the guard opened fire on the disguised player. The rectangular-lookbox path already gates the return on `ShouldTarget`; this PR makes the line path do the same. (`Guard::Look`)

- **MSVC build was broken on `main` independent of these fixes.** `playerai.cpp` uses `std::min` / `std::max`, which collide with windows.h's unscoped `min`/`max` macros (C2589/C2059). Adds `NOMINMAX` to the MSVC compile definitions so the build passes locally. (`CMakeLists.txt`)

## Commits

`73cd46b` is a misdiagnosis (orphan-channel cleanup in `Audio::UpdateVolume`); `629325b` reverts that hunk and applies the actual fix. The user asked not to rewrite history, so the misdiagnosis is left as a visible step. Net diff is clean.

## Test plan

- [x] Local build with `-DSILENCER_LOBBY_HOST=lobby.arsiamons.com -DSILENCER_VERSION=00044`, prod admin API
- [x] Tutorial: jetpack press-and-release → loop fades out cleanly within ~200 ms
- [x] Tutorial: hack a terminal, walk away → loop fades out cleanly within ~700 ms
- [x] Tutorial: blaster fire → full pew, no clipping (verified after reverting the orphan-cleanup hunk that was clipping projectile-emitted one-shots)
- [ ] Multiplayer: same three above hold against a real lobby
- [ ] Disguise bypass: stand in front of a teammate facing a guard, activate disguise, confirm guard does not target

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/arsia-mons/silencer/pull/125" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->