### PR TITLE
fix(guard): stop wedging at walls + PR-125 review follow-ups

### DIFF
--- a/clients/silencer/CMakeLists.txt
+++ b/clients/silencer/CMakeLists.txt
@@ -229,6 +229,21 @@ endif()
 
 target_link_libraries(${SILENCER_TARGET} minizip_dep)
 
+# Dev-build asset staging (Windows/Linux): copy shared/assets/ next to the
+# binary so the runtime fallback (`GetResDir() + "<subdir>/..."` in
+# `src/platform/os.cpp`) resolves without needing `cmake --install`. Affects
+# gas/, keybinds/, behaviortrees/, and any future runtime asset subdir;
+# without this every fresh build silently runs with empty GAS/keybind data.
+# macOS bakes assets into the .app bundle directly via the bundle_extras
+# list above, so this branch is no-op there.
+if(NOT APPLE)
+	add_custom_command(TARGET ${SILENCER_TARGET} POST_BUILD
+		COMMAND ${CMAKE_COMMAND} -E copy_directory
+				"${SILENCER_SHARED_DIR}/assets"
+				"$<TARGET_FILE_DIR:${SILENCER_TARGET}>/assets"
+		COMMENT "Staging shared/assets/ next to ${SILENCER_TARGET}")
+endif()
+
 install(TARGETS "${SILENCER_TARGET}" RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}" BUNDLE DESTINATION "${CMAKE_INSTALL_BINDIR}")
 install(DIRECTORY "${SILENCER_SHARED_DIR}/assets/" DESTINATION "${CMAKE_INSTALL_DATADIR}/silencer")
 install(FILES "${SILENCER_SHARED_DIR}/icons/icon_16.png"  DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/16x16/apps"   RENAME "silencer.png")

--- a/clients/silencer/src/actors/civilian.cpp
+++ b/clients/silencer/src/actors/civilian.cpp
@@ -62,7 +62,7 @@ void Civilian::Tick(World & world){
 			}
 			Uint32 xe = x + xv;
 			Uint32 ye = y + yv;
-			Platform * platform = world->map.TestLine(x, y, xe, ye, &xe, &ye, Platform::RECTANGLE | Platform::STAIRSDOWN | Platform::STAIRSDOWN);
+			Platform * platform = world->map.TestLine(x, y, xe, ye, &xe, &ye, Platform::RECTANGLE | Platform::STAIRSUP | Platform::STAIRSDOWN);
 			if(platform){
 				currentplatformid = platform->id;
 				state = WALKING;

--- a/clients/silencer/src/actors/guard.cpp
+++ b/clients/silencer/src/actors/guard.cpp
@@ -227,8 +227,25 @@ void Guard::InitBT(){
 		return BTResult::Running;
 	};
 
-	btctx_.actions["Patrol"] = [this](BTContext&) -> BTResult {
-		if(state == STANDING || state == LOOKING){ state = WALKING; state_i = 0; }
+	btctx_.actions["Patrol"] = [this](BTContext& ctx) -> BTResult {
+		World& world = *static_cast<World*>(ctx.userData);
+		if(state == STANDING || state == LOOKING){
+			state = WALKING;
+			state_i = 0;
+		} else if(state == WALKING){
+			// Patrol owns turnaround at chain ends and the walk-duration timeout.
+			// Both used to live in the WALKING state block; the former fought with
+			// SearchAndReturn writing `mirrored` every tick, wedging guards at walls.
+			if(DistanceToEnd(*this, world) <= world.minwalldistance){
+				mirrored = !mirrored;
+			}
+			const EnemyDef* gd = GASLoader::Get().GetEnemyDef("guard-blaster");
+			const int dur = gd ? gd->walkingDurationTicks : 240;
+			if(state_i >= dur){
+				state = LOOKING;
+				state_i = 0;
+			}
+		}
 		return BTResult::Success;
 	};
 
@@ -260,6 +277,15 @@ void Guard::InitBT(){
 						mirrored = (obj->x < x); // orient toward target
 					}
 					// <=80px: keep current direction to avoid oscillation
+					// Blocked at the platform-chain end facing the target — give up the chase
+					// instead of pressing into the wall for the full search timeout.
+					if (state == WALKING && DistanceToEnd(*this, world) <= world.minwalldistance) {
+						bool target_on_wall_side = mirrored ? (signed(obj->x) <= signed(x)) : (signed(obj->x) >= signed(x));
+						if (target_on_wall_side) {
+							chasing = 0;
+							return BTResult::Running;
+						}
+					}
 					// Climb ladder toward target if on a meaningfully different level
 					int ydiff = signed(obj->y) - signed(y);
 					{ const EnemyDef* _gg = GASLoader::Get().GetEnemyDef("guard-blaster");
@@ -301,6 +327,16 @@ void Guard::InitBT(){
 		}
 		if (state != LADDER) {
 			mirrored = (signed(originalx) < signed(x));
+			// Blocked at the platform-chain end on the way home — accept current
+			// position as "home enough" rather than wedging at the wall.
+			if (state == WALKING && DistanceToEnd(*this, world) <= world.minwalldistance) {
+				chasing = 0;
+				bt_walk_ticks_ = 0;
+				state = STANDING;
+				state_i = -1;
+				mirrored = originalmirrored;
+				return BTResult::Success;
+			}
 			// Climb ladders back to original level
 			int ydiff = signed(originaly) - signed(y);
 			if(abs(ydiff) > (_ggr?_ggr->ladderYThreshold:48) && bt_ladder_cooldown_ == 0){
@@ -582,13 +618,12 @@ void Guard::Tick(World & world){
 			res_index = state_i / 4;
 		}break;
 		case WALKING:{
+			// Pure motion + animation. Turnaround and duration timeout are BT decisions
+			// (see the "Patrol" / "SearchAndReturn" actions in InitBT).
 			res_bank = 60;
 			res_index = state_i % 19;
 			xv = mirrored ? -speed : speed;
 			FollowGround(*this, world, xv);
-			if(DistanceToEnd(*this, world) <= world.minwalldistance){
-				mirrored = !mirrored;
-			}
 			// play per-frame sounds defined in actordefs/guard.json
 			{
 				auto it = world.resources.actordefs.find(ActorDefName(weapon));
@@ -599,13 +634,6 @@ void Guard::Tick(World & world){
 						EmitSound(world, world.resources.soundbank[snd], vol);
 					}
 				}
-			}
-			{ const EnemyDef* _gwd = GASLoader::Get().GetEnemyDef("guard-blaster");
-			  if(state_i >= (_gwd ? _gwd->walkingDurationTicks : 240)){
-				state = LOOKING;
-				state_i = -1;
-				break;
-			  }
 			}
 		}break;
 		case SHOOTSTANDING:{
@@ -1030,7 +1058,7 @@ Object * Guard::Look(World & world, Uint8 direction){
 			int yv2 = y2 - y1;
 			Object * object = world.TestIncr(x + x1, y + y1 - 1, x + x1, y + y1, &xv2, &yv2, types);
 			if(object && ShouldTarget(*object, world)){
-				if(!world.map.TestIncr(x + x1, y + y1 - 1, x + x1, y + y1, &xv2, &yv2, Platform::STAIRSDOWN | Platform::STAIRSDOWN | Platform::RECTANGLE, 0, true)){
+				if(!world.map.TestIncr(x + x1, y + y1 - 1, x + x1, y + y1, &xv2, &yv2, Platform::STAIRSUP | Platform::STAIRSDOWN | Platform::RECTANGLE, 0, true)){
 					if(world.debugoverlay) world.debuglines.push_back({x+x1, y+y1, x+x2, y+y2, 68}); // green = hit
 					return object;
 				}
@@ -1042,7 +1070,7 @@ Object * Guard::Look(World & world, Uint8 direction){
 		int yv2 = y2 - y1;
 		Object * object = world.TestIncr(x + x1, y + y1 - 1, x + x1, y + y1, &xv2, &yv2, types);
 		if(object && ShouldTarget(*object, world)){
-			if(!world.map.TestIncr(x + x1, y + y1 - 1, x + x1, y + y1, &xv2, &yv2, Platform::STAIRSDOWN | Platform::STAIRSDOWN | Platform::RECTANGLE, 0, true)){
+			if(!world.map.TestIncr(x + x1, y + y1 - 1, x + x1, y + y1, &xv2, &yv2, Platform::STAIRSUP | Platform::STAIRSDOWN | Platform::RECTANGLE, 0, true)){
 				if(world.debugoverlay) world.debuglines.push_back({x+x1, y+y1, x+x2, y+y2, 68}); // green = hit
 				return object;
 			}

--- a/clients/silencer/src/actors/robot.cpp
+++ b/clients/silencer/src/actors/robot.cpp
@@ -536,7 +536,7 @@ bool Robot::Look(World & world, Uint8 direction){
 			int yv2 = y2 - y1;
 			Object * object = world.TestIncr(x + minx, y + y1 - 1, x + minx, y + y1, &xv2, &yv2, types);
 			if(object){
-				if(!world.map.TestIncr(x + minx, y + y1 - 1, x + minx, y + y1, &xv2, &yv2, Platform::STAIRSDOWN | Platform::STAIRSDOWN | Platform::RECTANGLE, 0, true)){
+				if(!world.map.TestIncr(x + minx, y + y1 - 1, x + minx, y + y1, &xv2, &yv2, Platform::STAIRSUP | Platform::STAIRSDOWN | Platform::RECTANGLE, 0, true)){
 					if(state == ASLEEP){
 						if(object->x < x){
 							mirrored = true;

--- a/clients/silencer/src/audio/audio.cpp
+++ b/clients/silencer/src/audio/audio.cpp
@@ -184,7 +184,7 @@ bool Audio::PlayMusic(MIX_Audio * music){
 
 void Audio::StopMusic(void){
 	if(!enabled) return;
-	MIX_StopTrack(musictrack, MIX_MSToFrames(mixerspec.freq, 700));
+	MIX_StopTrack(musictrack, MIX_TrackMSToFrames(musictrack, 700));
 }
 
 void Audio::PauseMusic(void){

--- a/clients/silencer/src/objects/walldefense.cpp
+++ b/clients/silencer/src/objects/walldefense.cpp
@@ -168,7 +168,7 @@ Object * WallDefense::Look(World & world){
 		int objecty = y1 + ((y2 - y1) / 2);
 		int xv2 = objectx - x;
 		int yv2 = objecty - y;
-		if(!world.map.TestIncr(x, y, x, y, &xv2, &yv2, Platform::STAIRSDOWN | Platform::STAIRSDOWN | Platform::RECTANGLE, 0, true)){
+		if(!world.map.TestIncr(x, y, x, y, &xv2, &yv2, Platform::STAIRSUP | Platform::STAIRSDOWN | Platform::RECTANGLE, 0, true)){
 			return object;
 		}
 	}


### PR DESCRIPTION
## Summary

Fourth bug from the playtest batch: guards getting stuck in corners. Root cause was the BT and the WALKING state-machine block both writing `mirrored` each tick — BT re-orients toward target, state machine flips on wall, repeat. Author noted this is residual state-machine logic that needs to come out.

WALKING now does only motion + animation. Patrol turnaround and walk-duration timeout move into the `Patrol` BT action. `SearchAndReturn` gains "blocked at wall" detection in both the search phase (clear `chasing`, fall through to return-to-post) and the return-to-post phase (snap to STANDING facing `originalmirrored`).

Bundled the two valid PR #125 review comments while touching adjacent code:

- **STAIRSUP typo** at `guard.cpp:1033/1045`, `civilian.cpp:65`, `robot.cpp:539`, `walldefense.cpp:171`. `STAIRSDOWN | STAIRSDOWN | RECTANGLE` was OR-ing a flag with itself; missing `STAIRSUP` meant line-of-sight ignored upward staircases. Every other call site has the full triple.
- **`StopMusic` sample-rate fix.** Same bug class as the `Stop` fix in #125 — `MIX_MSToFrames(mixerspec.freq, ...)` instead of the track-rate variant, so the 700 ms music fade wasn't actually 700 ms when the music's sample rate ≠ mixer's.

## Follow-up

Add an NPC-state CLI control op (extend `world_state` or new `npc_state`) + `tests/cli-agent/e2e/30_guard_no_corner_stuck.sh` regression test. Filed separately so this fix isn't gated on the harness work.

## Test plan

- [x] Local MSVC build clean (Release).
- [ ] Tutorial / a guarded level: lure a guard toward an unreachable target across a wall. Confirm no oscillation, guard either gives up + stands or returns to post within ~10s.
- [ ] Patrol guards: walk back and forth on a normal platform, turn around at chain ends as before.
- [ ] Spawn near a STAIRSUP staircase and confirm guards no longer "see through" it.
- [ ] Multiplayer: same as above against a real lobby.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/arsia-mons/silencer/pull/126" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->