### PR TITLE
Remove dev-only Host/Join/Test/Test Replay menu buttons

### DIFF
--- a/clients/silencer/src/game/game.cpp
+++ b/clients/silencer/src/game/game.cpp
@@ -2588,37 +2588,6 @@ Interface * Game::CreateMainMenuInterface(void){
 	Interface * iface = (Interface *)world.CreateObject(ObjectTypes::INTERFACE);
 	iface->AddObject(startbutton->id);
 	iface->AddObject(lobbybutton->id);
-	if(1){
-		Button * hostbutton = (Button *)world.CreateObject(ObjectTypes::BUTTON);
-		hostbutton->y = -270;
-		hostbutton->x = -240;
-		hostbutton->uid = 4;
-		strcpy(hostbutton->text, "Host Game");
-		
-		Button * joinbutton = (Button *)world.CreateObject(ObjectTypes::BUTTON);
-		joinbutton->y = -230;
-		joinbutton->x = -240;
-		joinbutton->uid = 5;
-		strcpy(joinbutton->text, "Join Game");
-		
-		Button * replaybutton = (Button *)world.CreateObject(ObjectTypes::BUTTON);
-		replaybutton->y = -270;
-		replaybutton->x = -40;
-		replaybutton->uid = 7;
-		strcpy(replaybutton->text, "Test Replay");
-		
-		Button * testbutton = (Button *)world.CreateObject(ObjectTypes::BUTTON);
-		testbutton->y = -201;
-		testbutton->x = 0;
-		testbutton->uid = 6;
-		strcpy(testbutton->text, "Test");
-		
-		iface->AddObject(hostbutton->id);
-		iface->AddObject(joinbutton->id);
-		iface->AddObject(replaybutton->id);
-		iface->AddObject(testbutton->id);
-		iface->AddTabObject(testbutton->id);
-	}
 	iface->AddObject(optionsbutton->id);
 	iface->AddObject(exitbutton->id);
 	iface->AddTabObject(startbutton->id);
@@ -4358,18 +4327,6 @@ bool Game::ProcessMainMenuInterface(Interface * iface){
 					break;
 					case 3:
 						return false;
-					break;
-					case 4:
-						GoToState(HOSTGAME);
-					break;
-					case 5:
-						GoToState(JOINGAME);
-					break;
-					case 6:
-						GoToState(TESTGAME);
-					break;
-					case 7:
-						GoToState(REPLAYGAME);
 					break;
 				}
 			}


### PR DESCRIPTION
## Summary
- Removes the four dev/test buttons exposed by the `if(1)` gate in `MAINMENU` (uids 4/5/6/7 → HOSTGAME/JOINGAME/TESTGAME/REPLAYGAME) along with their click-handler cases in `Game::ProcessMainMenuInterface`.
- Leaves the state enums and state handlers in place: `HOSTGAME` is referenced by the dedicated-server gate at game.cpp:636, and `REPLAYGAME` is reachable via the `-r` CLI flag (game.cpp:182).

## Caveat
This rolls back the "Test button on the main menu" bullet that was just announced in v00045's changelog. v00046 will not advertise the Test entry point.

## Test plan
- [x] Builds clean (Debug, Ninja, MSVC).
- [x] Launched `Silencer.exe` — main menu now shows only Tutorial / Connect To Lobby / Options / Exit.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/arsia-mons/silencer/pull/130" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->