### PR TITLE
fix(silencer): ListFiles INVALID_HANDLE_VALUE — stack overflow on missing dir

### DIFF
--- a/clients/silencer/src/game/game.cpp
+++ b/clients/silencer/src/game/game.cpp
@@ -5964,7 +5964,7 @@ std::vector<std::string> Game::ListFiles(const char * directory){
 	strcpy(directory2, directory);
 	strcat(directory2, "\\*");
 	HANDLE dir = FindFirstFile(directory2, &info);
-	if(dir){
+	if(dir != INVALID_HANDLE_VALUE){
 		do{
 			char fullname[MAX_PATH];
 			sprintf(fullname, "%s\\%s", directory, info.cFileName);

--- a/clients/silencer/src/ui/selectbox.cpp
+++ b/clients/silencer/src/ui/selectbox.cpp
@@ -113,7 +113,7 @@ void SelectBox::ListFiles(const char * directory){
 	strcpy(directory2, directory);
 	strcat(directory2, "\\*");
 	HANDLE dir = FindFirstFile(directory2, &info);
-	if(dir){
+	if(dir != INVALID_HANDLE_VALUE){
 		do{
 			char fullname[MAX_PATH];
 			sprintf(fullname, "%s\\%s", directory, info.cFileName);


### PR DESCRIPTION
## Summary

- Fix `Game::ListFiles` (and `SelectBox::ListFiles`) to check `INVALID_HANDLE_VALUE` after `FindFirstFile`. The truthy `if(dir)` let the loop run with unpopulated `WIN32_FIND_DATA` when the target directory was missing.
- That triggered an `sprintf("%s\%s", directory, info.cFileName)` against an `info.cFileName` with no null terminator (debug fill = `0xCC`), which read 308 bytes past the struct until hitting the null inside `directory2` and copied the whole run into `fullname[MAX_PATH]` — a ~228-byte stack overflow that clobbered the saved NRVO return-slot pointer at the function's home space and crashed inside `std::vector`'s move ctor on `return files;` with `this = 0x3a43cccccccccccc` (bytes `cc cc cc cc cc cc 'C' ':'`).

The bug has been latent in `Game::ListFiles` since the original 2014 import; it surfaced now because unrelated UI work shifted the caller's stack just enough that the corrupted slot lands on a kernel-space address (instant AV) instead of a possibly-survivable stack address. Repro: open **Create New Game** without an existing `<datadir>/level/download` directory (only created lazily by `SaveMap` after a first map download).

`SelectBox::ListFiles` had the identical bug pattern; same fix.

## Test plan

- [ ] Build Debug `Silencer.exe` (already verified locally).
- [ ] With no `<datadir>/level/download` directory present, log into the lobby and click **New Game** → **Create Game**. Dialog should open without crashing; map list populates from `level/` only.
- [ ] Create the directory, drop a downloaded map into it, reopen the dialog — that map appears in the list.
- [ ] `SelectBox::ListFiles` exercise (whatever screen calls it) opens against a missing directory without crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/arsia-mons/silencer/pull/139" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->