### PR TITLE
fix(macOS): auto-updater Info.plist seal + ship DMG installer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -412,8 +412,6 @@ jobs:
             - **Windows (x64) — portable zip:** `silencer-windows-x64.zip`
             - **Linux (x64):** `silencer-linux-x64.tar.gz`
 
-            The macOS `.zip` artifact is consumed by the in-app updater; first-time installs should use the `.dmg`.
-
             ## First-run warnings
 
             ### Windows

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -407,7 +407,8 @@ jobs:
           body: |
             ## Downloads
 
-            - **macOS (Apple Silicon):** `silencer-macos-arm64.dmg` (drag to Applications)
+            - **macOS (Apple Silicon) — DMG (recommended):** `silencer-macos-arm64.dmg` (drag to Applications)
+            - **macOS (Apple Silicon) — portable zip:** `silencer-macos-arm64.zip`
             - **Windows (x64) — installer (recommended):** `silencer-windows-x64-setup-*.exe`
             - **Windows (x64) — portable zip:** `silencer-windows-x64.zip`
             - **Linux (x64):** `silencer-linux-x64.tar.gz`

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         # SDL3 and especially SDL3_mixer aren't reliably in homebrew-core
         # on the macos-latest runner image — install via setup-sdl below
         # (same approach as deploy.yml's Linux build).
-        run: brew install minizip dylibbundler
+        run: brew install minizip dylibbundler create-dmg
 
       - name: Install SDL3 + SDL3_mixer
         uses: libsdl-org/setup-sdl@main
@@ -129,7 +129,47 @@ jobs:
           xcrun stapler validate Silencer.app
           spctl -a -vv -t execute Silencer.app
 
-      - name: Package .app
+      - name: Build, sign, notarize, staple DMG
+        working-directory: build
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        # The DMG is the user-facing download: Finder presents the
+        # drag-to-/Applications affordance, and an explicit copy to
+        # /Applications avoids App Translocation (which broke our
+        # auto-updater's in-place rename for users running from
+        # ~/Downloads). The Silencer.app inside is already stapled, so
+        # both the DMG itself and its contents are notarized/stapled —
+        # offline launch works either way.
+        run: |
+          create-dmg \
+            --volname "Silencer" \
+            --window-pos 200 120 \
+            --window-size 600 400 \
+            --icon-size 100 \
+            --icon "Silencer.app" 175 200 \
+            --hide-extension "Silencer.app" \
+            --app-drop-link 425 200 \
+            silencer-macos-arm64.dmg \
+            Silencer.app
+          codesign --force --timestamp \
+            --sign "Developer ID Application" \
+            silencer-macos-arm64.dmg
+          xcrun notarytool submit silencer-macos-arm64.dmg \
+            --apple-id "$APPLE_ID" \
+            --password "$APPLE_APP_PASSWORD" \
+            --team-id "$APPLE_TEAM_ID" \
+            --wait
+          xcrun stapler staple silencer-macos-arm64.dmg
+          xcrun stapler validate silencer-macos-arm64.dmg
+          spctl -a -vv -t open --context context:primary-signature \
+            silencer-macos-arm64.dmg
+
+      - name: Package .app for auto-updater
+        # The DMG is the install channel; the in-app updater still
+        # consumes a zip (see clients/silencer/src/updater/updaterstage2.cpp
+        # and services/lobby/update.go's MacOSURL field). Ship both.
         working-directory: build
         run: |
           ditto -ck --sequesterRsrc --keepParent Silencer.app silencer-macos-arm64.zip
@@ -143,6 +183,12 @@ jobs:
         with:
           name: macos-arm64
           path: build/silencer-macos-arm64.zip
+          if-no-files-found: error
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: macos-arm64-dmg
+          path: build/silencer-macos-arm64.dmg
           if-no-files-found: error
 
   build-windows:
@@ -354,16 +400,19 @@ jobs:
           generate_release_notes: true
           files: |
             artifacts/macos-arm64/*
+            artifacts/macos-arm64-dmg/*
             artifacts/windows-x64/*
             artifacts/windows-x64-setup/*
             artifacts/linux-x64/*
           body: |
             ## Downloads
 
-            - **macOS (Apple Silicon):** `silencer-macos-arm64.zip`
+            - **macOS (Apple Silicon):** `silencer-macos-arm64.dmg` (drag to Applications)
             - **Windows (x64) — installer (recommended):** `silencer-windows-x64-setup-*.exe`
             - **Windows (x64) — portable zip:** `silencer-windows-x64.zip`
             - **Linux (x64):** `silencer-linux-x64.tar.gz`
+
+            The macOS `.zip` artifact is consumed by the in-app updater; first-time installs should use the `.dmg`.
 
             ## First-run warnings
 

--- a/clients/silencer/src/updater/updaterstage2.cpp
+++ b/clients/silencer/src/updater/updaterstage2.cpp
@@ -511,6 +511,18 @@ bool Launch(const std::string &zippath) {
         return false;
     }
 
+    // Production-signed binaries have their embedded LC_CODE_SIGNATURE
+    // bound to the bundle's Info.plist (the "Info.plist entries=N" line
+    // in `codesign -dvvv`). Without it, AMFI rejects the binary at
+    // execve() with "The code contains a Team ID, but validating its
+    // signature failed" and SIGKILLs stage-2 before main() — silent,
+    // since the parent's TTY is gone. Mirror Info.plist so the seal
+    // validates. Best-effort: ad-hoc-signed dev builds don't bind it.
+    if (!CopyFile_(install + "/Contents/Info.plist",
+                   stage2_contents + "/Info.plist")) {
+        Logf("copy Info.plist failed (ok for ad-hoc-signed dev builds)");
+    }
+
     // Mirror Frameworks/ from the source bundle so @rpath dylib refs
     // (libSDL3, libSDL3_mixer, libminizip, …) resolve. Local dev builds
     // link against absolute /opt/homebrew paths and have an empty (or


### PR DESCRIPTION
## Summary

- **Bug fix:** stage-2 mirrors `Info.plist` into `/tmp/silencer-stage2.app/Contents/` so AMFI doesn't SIGKILL the binary at `execve()`. This is the actual cause of the "app closes, never restarts" reports — the embedded code signature on production hardened-runtime builds is bound to the bundle's Info.plist, and without it AMFI rejects the binary silently (parent's TTY is gone, so even `Logf`'s stderr write disappears). Companion to 8b4cbbf, which mirrored `Frameworks/` to fix dyld `@rpath` resolution.
- **CI hardening:** `release.yml` now ships `silencer-macos-arm64.dmg` alongside the existing zip. The DMG is the user-facing install (drag to `/Applications/`); the zip stays as the in-app updater channel. New installs land in `/Applications/` instead of `~/Downloads/`, which avoids App Translocation kicking in and breaking the swap.

## Test plan

- [x] Reproduced the SIGKILL locally: signed v00023 client at `/Applications/Silencer.app`, lobby with `-version 00024`, manifest pointing at signed v00024 zip, clicked Update — `~/Library/Logs/Silencer/update.log` empty, exit 137, `amfid` logs "The signature on the file is invalid" against `/private/tmp/silencer-stage2.app/Contents/MacOS/silencer-stage2`.
- [x] Applied the patch, rebuilt + redeployed OLD client to `/Applications/`, reran the same flow — stage-2 logged the `start:` line, hoisted the wrapper dir, swapped `install_dir → install_dir.old` + `install_dir.new/Silencer.app → install_dir`, and relaunched; restarted process is the v00024 build.
- [x] `create-dmg` + sign + verify validated locally against `clients/silencer/build/Silencer.app`. Mounted DMG, verified `Applications` symlink, drag-to-`/Applications/` install works, app launches without translocation.
- [ ] Notarize/staple the DMG via `notarytool` — only runs in CI with `APPLE_*` secrets; unverified locally but the sequence mirrors the existing `.app` notarization flow.
- [ ] First post-merge release tag should produce both `silencer-macos-arm64.dmg` and `silencer-macos-arm64.zip`; the manifest builder in `deploy.yml` continues to point at the zip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/arsia-mons/silencer/pull/146" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->