### PR TITLE
fix(silencer): repopulate world.gameinfo on create-game so Ready can progress

### DIFF
--- a/clients/silencer/src/ui/screens/lobby/lobby_screen.cpp
+++ b/clients/silencer/src/ui/screens/lobby/lobby_screen.cpp
@@ -6,6 +6,7 @@
 #include "world.h"
 #include "lobby.h"
 #include "lobbygame.h"
+#include "serializer.h"
 #include "config.h"
 #include "interface.h"
 #include "overlay.h"
@@ -169,6 +170,14 @@ void LobbyScreen::Tick(ScreenContext & ctx)
 			world.lobby.creategamestatus = 0;
 			LobbyGame * lobbygame = world.lobby.GetGameById(world.lobby.createdgameid);
 			if(lobbygame){
+				// Populate world.gameinfo from the lobby's record so the host can
+				// SendGameInfo to the dedicated server. Without this the host's
+				// gameinfo.loaded stays false (world.cpp:709 gate), gameinfo never
+				// reaches the dedicated server, AllPeersLoadedGameInfo never trips,
+				// and Ready can't progress the shared state to INGAME.
+				Serializer data;
+				lobbygame->Serialize(Serializer::WRITE, data);
+				world.gameinfo.Serialize(Serializer::READ, data);
 				game.JoinGame(*lobbygame, lobbygame->password);
 				mapDownloader.LoadMapData(mapDownloader.FindMap(lobbygame->mapname, &lobbygame->maphash).c_str());
 				game.currentlobbygameid = lobbygame->id;


### PR DESCRIPTION
## Summary

Regression from #140 (game.cpp split). When a host creates a game, pressing **Ready** never advances to INGAME — the client appears to never connect to the new dedicated server.

## Root cause

The post-create handler was moved from `game.cpp` into `LobbyScreen::Tick`, but the `lobbygame → world.gameinfo` Serialize roundtrip was dropped:

**Before #140** (`game.cpp`):
```cpp
Serializer data;
lobbygame->Serialize(Serializer::WRITE, data);
world.gameinfo.Serialize(Serializer::READ, data);   // populates gameinfo + sets loaded=true
```

**After #140** (`lobby_screen.cpp`): missing — only `JoinGame()` is called, which doesn't touch `world.gameinfo`.

`LobbyGame::Serialize(READ)` sets `loaded = true` (`lobbygame.cpp:73-74`). Without that path, the host's `world.gameinfo.loaded` stays false, so:

1. `world.cpp:709` gate `localpeer->ishost && !GetAuthorityPeer()->gameinfoloaded && gameinfo.loaded` never fires → host never sends `MSG_GAMEINFO` to the dedicated server.
2. Dedicated server's `AllPeersLoadedGameInfo()` returns false forever.
3. The shared state in `Game::Tick` never flips to `1`, so the client never receives the state delta and never `GoToState(INGAME)`.

User-visible: dedicated server starts (verified on prod infra), Ready button works, `SendReady()` fires — but nothing transitions.

## Fix

Re-add the Serialize roundtrip before `JoinGame` in the create-game path.

## Test plan

- [ ] Local: create a game on host A, join from client B, both press Ready → game transitions to INGAME.
- [ ] Production: same flow against the prod lobby/dedicated infra.
- [ ] Confirm the host's `world.gameinfo.mapname` / `maphash` / `id` are populated after Create (was previously zeroed).

## Audit context

A broader audit of the #140 extraction was run for similar lost-side-effect regressions — none found beyond this one. Other panels/screens/tick bodies preserve their original side effects, member resets, thread joins, palette/screenbuffer setup, and Config saves.

---
_Generated by [Claude Code](https://claude.ai/code/session_016hULc9TipewnpzPEnVFSLu)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/arsia-mons/silencer/pull/147" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->