### PR TITLE
ci: poll deploy smoke checks + apply post-merge Windows cache fix

### DIFF
--- a/.github/actions/build-silencer-windows/action.yml
+++ b/.github/actions/build-silencer-windows/action.yml
@@ -31,9 +31,12 @@ runs:
       with:
         path: ${{ github.workspace }}/.vcpkg-cache
         key: vcpkg-${{ runner.os }}-${{ env.IMAGE_VERSION }}-${{ hashFiles('clients/silencer/vcpkg.json') }}
+        # Only fall back within the same runner image. The broader
+        # `vcpkg-${{ runner.os }}-` prefix matches stale single-dash
+        # caches from before IMAGE_VERSION was in the key, which
+        # contain incompatible ABIs and silently restore 0 packages.
         restore-keys: |
           vcpkg-${{ runner.os }}-${{ env.IMAGE_VERSION }}-
-          vcpkg-${{ runner.os }}-
 
     - name: Cache vcpkg tool downloads
       uses: actions/cache@v4
@@ -41,7 +44,7 @@ runs:
         path: C:\vcpkg\downloads\tools
         key: vcpkg-tools-${{ runner.os }}-${{ env.IMAGE_VERSION }}-v1
         restore-keys: |
-          vcpkg-tools-${{ runner.os }}-
+          vcpkg-tools-${{ runner.os }}-${{ env.IMAGE_VERSION }}-
 
     - name: Setup sccache
       uses: mozilla-actions/sccache-action@v0.0.10

--- a/.github/workflows/deploy-admin-api.yml
+++ b/.github/workflows/deploy-admin-api.yml
@@ -140,6 +140,13 @@ jobs:
           sleep 5
           sudo systemctl is-active silencer-admin-api
 
-          # 6. Smoke-test the sprite endpoint
+          # 6. Smoke-test the sprite endpoint. Poll: systemd reports the
+          # unit active as soon as Docker is launched, but the container
+          # still has to pull a freshly-tagged image and start serving
+          # HTTP. ~30s tolerance covers a cold pull.
+          for i in 1 2 3 4 5 6 7 8 9 10; do
+            curl -sf http://127.0.0.1:24080/api/sprites/121/0 > /dev/null && break
+            sleep 3
+          done
           curl -sf http://127.0.0.1:24080/api/sprites/121/0 > /dev/null
           REMOTE

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -250,6 +250,14 @@ jobs:
           done
           sudo systemctl is-active silencer-admin-api
           sudo systemctl is-active silencer-admin-web
+          # Poll the sprite endpoint: systemd reports the unit active as
+          # soon as Docker is launched, but the container still has to
+          # pull a freshly-tagged image and start serving HTTP. ~30s
+          # tolerance covers a cold pull on staging's link.
+          for i in 1 2 3 4 5 6 7 8 9 10; do
+            curl -sf http://127.0.0.1:24080/api/sprites/121/0 > /dev/null && break
+            sleep 3
+          done
           curl -sf http://127.0.0.1:24080/api/sprites/121/0 > /dev/null
 
           # Prune to last 3 releases.


### PR DESCRIPTION
## Summary

Two follow-ups to PR #149 that didn't make the squash:

1. **`ci(windows)`**: narrow vcpkg cache restore-keys to the same runner image. The broad \`vcpkg-Windows-\` fallback was matching obsolete pre-PR caches (empty IMAGE_VERSION slot, 0 useful ABIs), which silently restored 0 packages and forced vcpkg to rebuild all 10 every run. Pulled in from \`claude/optimistic-brahmagupta-q5ZSP\` after merge.
2. **\`ci(deploy)\`**: wrap the post-restart sprite-endpoint curl in a 10×3s poll loop. \`systemctl is-active silencer-admin-api\` reports active the instant Docker is launched, but the container still has to pull a freshly-tagged image and start serving HTTP — caused exit 7 on \`Deploy staging\` after #149's merge. Same fix to \`deploy-admin-api.yml\`.

## Test plan

- [ ] CI Build (Windows) on this PR hits cache, Configure ~15s, total ~1 min
- [ ] After merge, Deploy staging on the merge commit completes green (no exit 7 from curl)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/arsia-mons/silencer/pull/150" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->