### PR TITLE
feat(silencer): rejoin mid-game with previous team, tech, and character

### DIFF
--- a/clients/silencer/src/net/peer.cpp
+++ b/clients/silencer/src/net/peer.cpp
@@ -17,6 +17,7 @@ Peer::Peer(){
 	isbot = false;
 	firstinputtime = 0;
 	totalinputs = 0;
+	disconnected = false;
 }
 
 void Peer::Serialize(bool write, Serializer & data){

--- a/clients/silencer/src/net/peer.h
+++ b/clients/silencer/src/net/peer.h
@@ -21,6 +21,7 @@ public:
 	bool isready;
 	Uint32 techchoices;
 	Uint32 accountid;
+	bool disconnected;
 	std::list<Uint16> controlledlist;
 
 	// local only

--- a/clients/silencer/src/world/world.cpp
+++ b/clients/silencer/src/world/world.cpp
@@ -279,7 +279,7 @@ void World::DoNetwork_Authority(void){
 				Serializer response;
 				Uint8 code = MSG_CONNECT;
 				response.Put(code);
-				if(gameplaystate == INLOBBY){
+				if(gameplaystate == INLOBBY || gameplaystate == INGAME){
 					char * host = inet_ntoa(senderaddr.sin_addr);
 					unsigned short port = ntohs(senderaddr.sin_port);
 					Uint8 agency;
@@ -306,7 +306,29 @@ void World::DoNetwork_Authority(void){
 							canjoin = false;
 						}
 					}
-					if(canjoin){
+					Peer * rejoinpeer = 0;
+					if(canjoin && accountid != 0){
+						for(unsigned int i = 1; i < maxpeers; i++){
+							if(peerlist[i] && peerlist[i]->disconnected && peerlist[i]->accountid == accountid){
+								rejoinpeer = peerlist[i];
+								break;
+							}
+						}
+					}
+					if(canjoin && gameplaystate == INGAME && !rejoinpeer){
+						// mid-game connects are only for rejoiners
+						canjoin = false;
+					}
+					if(canjoin && rejoinpeer){
+						rejoinpeer->ip = ntohl(inet_addr(host));
+						rejoinpeer->port = port;
+						rejoinpeer->lastpacket = SDL_GetTicks();
+						rejoinpeer->disconnected = false;
+						response.PutBit(true);
+						response.Put(rejoinpeer->id);
+						SendGameInfo(rejoinpeer->id);
+						SendPeerList();
+					}else if(canjoin){
 						Peer * newpeer = AddPeer(host, port, agency, accountid);
 						if(newpeer){
 							if(dedicatedserver.active){
@@ -330,12 +352,6 @@ void World::DoNetwork_Authority(void){
 							//printf("couldnt add peer\n");
 							response.PutBit(false);
 						}
-						/*if(newpeer){
-							SendPeerList();
-							if(!newpeer->ishost){
-								SendGameInfo(newpeer->id);
-							}
-						}*/
 					}else{
 						response.PutBit(false);
 					}
@@ -621,7 +637,7 @@ void World::DoNetwork_Authority(void){
 							if(gameplaystate == World::INGAME){
 								KillByGovt(*p);
 							}
-							HandleDisconnect(p->id);
+							HandleDisconnect(p->id, true);
 							break;
 						}
 					}
@@ -633,7 +649,7 @@ void World::DoNetwork_Authority(void){
 		Uint32 tickcheck = SDL_GetTicks();
 		for(int i = 0; i < maxpeers; i++){
 			if(peerlist[i]){
-				if(i != localpeerid && !peerlist[i]->isbot && peerlist[i]->lastpacket < tickcheck && tickcheck - peerlist[i]->lastpacket >= peertimeout){
+				if(i != localpeerid && !peerlist[i]->isbot && !peerlist[i]->disconnected && peerlist[i]->lastpacket < tickcheck && tickcheck - peerlist[i]->lastpacket >= peertimeout){
 					HandleDisconnect(i);
 				}
 			}
@@ -1219,16 +1235,23 @@ void World::DeleteOldSnapshots(Uint8 peerid){
 	}
 }
 
-void World::HandleDisconnect(Uint8 peerid){
+void World::HandleDisconnect(Uint8 peerid, bool permanent){
 	//printf("peer %d disconnected\n", peerid);
 	if(replay.IsRecording()){
 		replay.WriteDisconnect(peerid);
 	}
+	bool park = (!permanent && mode == AUTHORITY && gameplaystate == INGAME && peerlist[peerid] && peerlist[peerid]->accountid != 0 && !peerlist[peerid]->isbot);
 	for(std::list<Uint16>::iterator i = peerlist[peerid]->controlledlist.begin(); i != peerlist[peerid]->controlledlist.end(); i++){
 		Object * object = GetObjectFromId((*i));
 		if(object){
 			object->HandleDisconnect(*this, peerid);
 		}
+	}
+	if(park){
+		peerlist[peerid]->disconnected = true;
+		peerlist[peerid]->isready = false;
+		SendPeerList();
+		return;
 	}
 	ClearSnapshotQueue();
 	// Capture team before RemovePeer strips the peer from all teams.
@@ -1812,7 +1835,7 @@ bool World::FindTeamForPeer(Peer & peer, Uint8 agency, int start){
 void World::SendSnapshots(void){
 	for(unsigned int i = 0; i < maxpeers; i++){
 		Peer * peer = peerlist[i];
-		if(peer && i != localpeerid && !peer->isbot){
+		if(peer && i != localpeerid && !peer->isbot && !peer->disconnected){
 			Serializer data;
 			Uint8 code = MSG_SNAPSHOT;
 			data.Put(code);

--- a/clients/silencer/src/world/world.cpp
+++ b/clients/silencer/src/world/world.cpp
@@ -300,19 +300,24 @@ void World::DoNetwork_Authority(void){
 							canjoin = false;
 						}
 					}
-					if(dedicatedserver.active){
-						if(dedicatedserver.IsBanned(accountid) || peercount >= gameinfo.maxplayers){
-							//printf("banned or too many players\n");
-							canjoin = false;
-						}
-					}
+					// Find a parked peer to rebind, if any. Done before the
+					// maxplayers gate so a rejoiner reclaiming their existing
+					// slot isn't rejected for a full lobby.
 					Peer * rejoinpeer = 0;
-					if(canjoin && accountid != 0){
+					if(accountid != 0){
 						for(unsigned int i = 1; i < maxpeers; i++){
 							if(peerlist[i] && peerlist[i]->disconnected && peerlist[i]->accountid == accountid){
 								rejoinpeer = peerlist[i];
 								break;
 							}
+						}
+					}
+					if(dedicatedserver.active){
+						if(dedicatedserver.IsBanned(accountid)){
+							canjoin = false;
+						}
+						if(!rejoinpeer && peercount >= gameinfo.maxplayers){
+							canjoin = false;
 						}
 					}
 					if(canjoin && gameplaystate == INGAME && !rejoinpeer){
@@ -1951,7 +1956,7 @@ void World::SendPeerList(Uint8 peerid){
 		}
 		for(unsigned int i = 0; i < maxpeers; i++){
 			Peer * peer = peerlist[i];
-			if(peer && i != localpeerid && (!peerid || peerid == peer->id)){
+			if(peer && i != localpeerid && (!peerid || peerid == peer->id) && !peer->disconnected){
 				SendPacket(peer, data.data, data.BitsToBytes(data.offset));
 			}
 		}

--- a/clients/silencer/src/world/world.cpp
+++ b/clients/silencer/src/world/world.cpp
@@ -334,7 +334,7 @@ void World::DoNetwork_Authority(void){
 								p->health = p->maxhealth;
 								p->shield = p->maxshield;
 								p->state = Player::DEPLOYING;
-								p->state_i = 0;
+								p->state_i = GASLoader::Get().player.deployWaitTicks;
 								p->draw = false;
 								p->collidable = false;
 							}

--- a/clients/silencer/src/world/world.cpp
+++ b/clients/silencer/src/world/world.cpp
@@ -324,6 +324,21 @@ void World::DoNetwork_Authority(void){
 						rejoinpeer->port = port;
 						rejoinpeer->lastpacket = SDL_GetTicks();
 						rejoinpeer->disconnected = false;
+						for(std::list<Uint16>::iterator it = rejoinpeer->controlledlist.begin(); it != rejoinpeer->controlledlist.end(); it++){
+							Object * obj = GetObjectFromId(*it);
+							if(obj && obj->type == ObjectTypes::PLAYER){
+								Player * p = static_cast<Player *>(obj);
+								map.RandomPlayerStartLocation(*this, p->x, p->y);
+								p->oldx = p->x;
+								p->oldy = p->y;
+								p->health = p->maxhealth;
+								p->shield = p->maxshield;
+								p->state = Player::DEPLOYING;
+								p->state_i = 0;
+								p->draw = false;
+								p->collidable = false;
+							}
+						}
 						response.PutBit(true);
 						response.Put(rejoinpeer->id);
 						SendGameInfo(rejoinpeer->id);

--- a/clients/silencer/src/world/world.h
+++ b/clients/silencer/src/world/world.h
@@ -192,7 +192,7 @@ private:
 	void SendPacket(Peer * peer, char * data, unsigned int size);
 	void SwitchToMode(bool newmode);
 	void DeleteOldSnapshots(Uint8 peerid);
-	void HandleDisconnect(Uint8 peerid);
+	void HandleDisconnect(Uint8 peerid, bool permanent = false);
 	bool RelevantToPlayer(class Player * player, Object * object);
 	bool BelongsToTeam(Object & object, Uint16 teamid);
 	void ActivateTerminals(void);


### PR DESCRIPTION
## Summary

- AUTHORITY now accepts `MSG_CONNECT` in INGAME when the joining accountid matches a peer that's currently parked (`disconnected=true`). Rebinds the parked peer's ip/port and resumes. Brand-new joiners mid-game are still rejected — rejoin only, no join-in-progress.
- `HandleDisconnect` parks the peer (keeps slot/team/techchoices/snapshots, calls `SendPeerList`, returns) when AUTHORITY + INGAME + real accountid + not bot + not permanent. `Player::HandleDisconnect → UnDeploy()` still runs so their body disappears while gone. The `Player` object stays alive in the world, retaining credits / inventory / weapons / ammo / tech — on rejoin they redeploy at a deploy station like a normal life with all that intact.
- `MSG_KICK` passes the new `permanent=true` to keep kicks terminal.
- Peer-timeout sweep and `SendSnapshots` skip parked peers.

## Test plan

- [x] Compiles clean (Windows / Ninja / Unity / Release).
- [ ] E2E verification via 2-client CLI harness — **in progress**. Existing `tests/cli-agent` suite has never driven the host-game / join-game flows; a first attempt hit an unrelated `cli select` crash against `GameCreatePanel`'s map selectbox. Follow-up work to fix that crash and add a CLI op to drive game creation is queued separately so this rejoin change isn't blocked on harness scaffolding.
- [ ] Manual smoke test: 2 clients, host + join, INGAME, disconnect one, rejoin, confirm same team / tech / character.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/arsia-mons/silencer/pull/152" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->