### PR TITLE
feat(bt-editor): full AI designer workflow — generic leaves, data-driven props, editor UX

### DIFF
--- a/clients/silencer/src/actors/behaviortree.cpp
+++ b/clients/silencer/src/actors/behaviortree.cpp
@@ -224,7 +224,9 @@ BTResult BehaviorTree::tickLeaf(const Node& n, BTContext& ctx) const {
     std::string action = n.props.value("action", std::string{});
     auto it = ctx.actions.find(action);
     if (it == ctx.actions.end()) return BTResult::Failure;
+    ctx.props = &n.props;
     BTResult r = it->second(ctx);
+    ctx.props = nullptr;
     if (ctx.logFn) ctx.logFn(n.id, "Leaf[" + action + "]", r);
     return r;
 }

--- a/clients/silencer/src/actors/behaviortree.h
+++ b/clients/silencer/src/actors/behaviortree.h
@@ -44,6 +44,9 @@ struct BTContext {
     // Delta-time for this tick (seconds)
     float dt = 0.0f;
 
+    // Current leaf node's props — set for the duration of the action call, null otherwise.
+    const json* props = nullptr;
+
     // Opaque pointer for passing host-side context (e.g. World*) to leaf lambdas.
     void* userData = nullptr;
     // Debug: when set, called on every leaf/condition result

--- a/clients/silencer/src/actors/civilian.cpp
+++ b/clients/silencer/src/actors/civilian.cpp
@@ -28,11 +28,19 @@ Civilian::Civilian() : Object(ObjectTypes::CIVILIAN){
 void Civilian::InitBT(){
 	bt_ = BehaviorTreeLibrary::instance().get("civilian");
 	if(!bt_) return;
-	btctx_.actions["Run"] = [this](BTContext&) -> BTResult {
+	btctx_.actions["Run"] = [this](BTContext& ctx) -> BTResult {
+		if(ctx.props){
+			int bonus = ctx.props->value("speedBonus", -1);
+			if(bonus >= 0) ctx.bbSet("bt_run_speed_bonus", bonus);
+		}
 		if(state != RUNNING){ state = RUNNING; state_i = (Uint8)-1; }
 		return BTResult::Success;
 	};
-	btctx_.actions["Wander"] = [](BTContext&) -> BTResult {
+	btctx_.actions["Wander"] = [this](BTContext& ctx) -> BTResult {
+		if(ctx.props){
+			int spd = ctx.props->value("speed", -1);
+			if(spd >= 0) ctx.bbSet("bt_walk_speed", spd);
+		}
 		return BTResult::Success;
 	};
 }
@@ -104,7 +112,7 @@ void Civilian::Tick(World & world){
 			if(DistanceToEnd(*this, world) <= world.minwalldistance){
 				mirrored = mirrored ? false : true;
 			}
-			xv = mirrored ? -speed : speed;
+			xv = (mirrored ? -1 : 1) * btctx_.bb<int>("bt_walk_speed", speed);
 			FollowGround(*this, world, xv);
 			if(state_i % 10 == 0){
 				if(!bt_) InitBT();
@@ -129,7 +137,7 @@ void Civilian::Tick(World & world){
 				break;
 			  }
 			}
-			{ const EnemyDef* _gd = GASLoader::Get().GetEnemyDef("civilian"); int _bonus = _gd ? _gd->runSpeedBonus : 5; xv = (mirrored ? -1 : 1) * (_bonus + speed); }
+			{ const EnemyDef* _gd = GASLoader::Get().GetEnemyDef("civilian"); int _bonus = btctx_.bb<int>("bt_run_speed_bonus", _gd ? _gd->runSpeedBonus : 5); xv = (mirrored ? -1 : 1) * (_bonus + speed); }
 			res_bank = 123;
 			res_index = state_i % 15;
 			// play per-frame sounds defined in actordefs/civilian.json

--- a/clients/silencer/src/actors/civilian.cpp
+++ b/clients/silencer/src/actors/civilian.cpp
@@ -43,6 +43,47 @@ void Civilian::InitBT(){
 		}
 		return BTResult::Success;
 	};
+
+	// ── Generic data-driven leaves ────────────────────────────────────────────
+	btctx_.actions["SetBlackboard"] = [](BTContext& ctx) -> BTResult {
+		if(!ctx.props || !ctx.props->contains("key") || !ctx.props->contains("value"))
+			return BTResult::Failure;
+		ctx.bbSet(ctx.props->value("key", std::string{}), (*ctx.props)["value"]);
+		return BTResult::Success;
+	};
+	btctx_.actions["RandomChance"] = [](BTContext& ctx) -> BTResult {
+		float chance = ctx.props ? ctx.props->value("chance", 0.5f) : 0.5f;
+		return ((float)rand() / (float)RAND_MAX) < chance ? BTResult::Success : BTResult::Failure;
+	};
+	btctx_.actions["PlayAnim"] = [this](BTContext& ctx) -> BTResult {
+		if(!ctx.props) return BTResult::Failure;
+		int bank   = ctx.props->value("bank",   0);
+		int frames = ctx.props->value("frames", 1);
+		bool loop  = ctx.props->value("loop",   true);
+		res_bank  = bank;
+		res_index = loop ? (state_i % std::max(frames, 1))
+		                 : std::min((int)state_i, std::max(frames - 1, 0));
+		if(!loop && state_i >= frames) return BTResult::Success;
+		return BTResult::Running;
+	};
+	btctx_.actions["EmitSound"] = [this](BTContext& ctx) -> BTResult {
+		if(!ctx.props) return BTResult::Failure;
+		World& world = *static_cast<World*>(ctx.userData);
+		std::string snd = ctx.props->value("sound", std::string{});
+		int vol = ctx.props->value("volume", 100);
+		if(snd.empty()) return BTResult::Failure;
+		auto it = world.resources.soundbank.find(snd);
+		if(it == world.resources.soundbank.end()) return BTResult::Failure;
+		EmitSound(world, it->second, vol);
+		return BTResult::Success;
+	};
+	btctx_.actions["SetFacing"] = [this](BTContext& ctx) -> BTResult {
+		std::string dir = ctx.props ? ctx.props->value("dir", std::string{"flip"}) : "flip";
+		if(dir == "left")       mirrored = true;
+		else if(dir == "right") mirrored = false;
+		else                    mirrored = !mirrored;
+		return BTResult::Success;
+	};
 }
 
 void Civilian::Serialize(bool write, Serializer & data, Serializer * old){

--- a/clients/silencer/src/actors/guard.cpp
+++ b/clients/silencer/src/actors/guard.cpp
@@ -365,6 +365,64 @@ void Guard::InitBT(){
 	btctx_.actions["Stand"] = [this](BTContext&) -> BTResult {
 		return BTResult::Success;
 	};
+
+	// ── Generic data-driven leaves ────────────────────────────────────────────
+	// These require no C++ changes to use — configure entirely from BT JSON props.
+
+	// SetBlackboard: write any value to the blackboard from the tree.
+	// Props: key (string), value (any JSON value)
+	btctx_.actions["SetBlackboard"] = [](BTContext& ctx) -> BTResult {
+		if(!ctx.props || !ctx.props->contains("key") || !ctx.props->contains("value"))
+			return BTResult::Failure;
+		ctx.bbSet(ctx.props->value("key", std::string{}), (*ctx.props)["value"]);
+		return BTResult::Success;
+	};
+
+	// RandomChance: succeeds with probability `chance` (0.0–1.0).
+	// Props: chance (float, default 0.5)
+	btctx_.actions["RandomChance"] = [](BTContext& ctx) -> BTResult {
+		float chance = ctx.props ? ctx.props->value("chance", 0.5f) : 0.5f;
+		return ((float)rand() / (float)RAND_MAX) < chance ? BTResult::Success : BTResult::Failure;
+	};
+
+	// PlayAnim: drives res_bank/res_index from BT props — no new C++ state needed.
+	// Props: bank (int), frames (int), loop (bool, default true)
+	// Returns Running while playing; Success when a non-looping clip finishes.
+	btctx_.actions["PlayAnim"] = [this](BTContext& ctx) -> BTResult {
+		if(!ctx.props) return BTResult::Failure;
+		int bank   = ctx.props->value("bank",   0);
+		int frames = ctx.props->value("frames", 1);
+		bool loop  = ctx.props->value("loop",   true);
+		res_bank  = bank;
+		res_index = loop ? (state_i % std::max(frames, 1))
+		                 : std::min((int)state_i, std::max(frames - 1, 0));
+		if(!loop && state_i >= frames) return BTResult::Success;
+		return BTResult::Running;
+	};
+
+	// EmitSound: play a named sound from the world soundbank.
+	// Props: sound (string filename), volume (int, default 100)
+	btctx_.actions["EmitSound"] = [this](BTContext& ctx) -> BTResult {
+		if(!ctx.props) return BTResult::Failure;
+		World& world = *static_cast<World*>(ctx.userData);
+		std::string snd = ctx.props->value("sound", std::string{});
+		int vol = ctx.props->value("volume", 100);
+		if(snd.empty()) return BTResult::Failure;
+		auto it = world.resources.soundbank.find(snd);
+		if(it == world.resources.soundbank.end()) return BTResult::Failure;
+		EmitSound(world, it->second, vol);
+		return BTResult::Success;
+	};
+
+	// SetFacing: control the mirrored flag from the tree.
+	// Props: dir = "left" | "right" | "flip" (default)
+	btctx_.actions["SetFacing"] = [this](BTContext& ctx) -> BTResult {
+		std::string dir = ctx.props ? ctx.props->value("dir", std::string{"flip"}) : "flip";
+		if(dir == "left")       mirrored = true;
+		else if(dir == "right") mirrored = false;
+		else                    mirrored = !mirrored;
+		return BTResult::Success;
+	};
 }
 
 void Guard::Serialize(bool write, Serializer & data, Serializer * old){

--- a/clients/silencer/src/actors/guard.cpp
+++ b/clients/silencer/src/actors/guard.cpp
@@ -229,7 +229,10 @@ void Guard::InitBT(){
 
 	btctx_.actions["Patrol"] = [this](BTContext& ctx) -> BTResult {
 		World& world = *static_cast<World*>(ctx.userData);
-		if(state == STANDING || state == LOOKING){
+		if(state == LOOKING){
+			// Let the LOOKING animation complete; state handler transitions LOOKING→STANDING.
+			return BTResult::Running;
+		} else if(state == STANDING){
 			state = WALKING;
 			state_i = 0;
 		} else if(state == WALKING){

--- a/clients/silencer/src/actors/robot.cpp
+++ b/clients/silencer/src/actors/robot.cpp
@@ -140,6 +140,47 @@ void Robot::InitBT() {
 		}
 		return BTResult::Failure; // not at spawn yet — Patrol will move us
 	};
+
+	// ── Generic data-driven leaves ────────────────────────────────────────────
+	btctx_.actions["SetBlackboard"] = [](BTContext& ctx) -> BTResult {
+		if(!ctx.props || !ctx.props->contains("key") || !ctx.props->contains("value"))
+			return BTResult::Failure;
+		ctx.bbSet(ctx.props->value("key", std::string{}), (*ctx.props)["value"]);
+		return BTResult::Success;
+	};
+	btctx_.actions["RandomChance"] = [](BTContext& ctx) -> BTResult {
+		float chance = ctx.props ? ctx.props->value("chance", 0.5f) : 0.5f;
+		return ((float)rand() / (float)RAND_MAX) < chance ? BTResult::Success : BTResult::Failure;
+	};
+	btctx_.actions["PlayAnim"] = [this](BTContext& ctx) -> BTResult {
+		if(!ctx.props) return BTResult::Failure;
+		int bank   = ctx.props->value("bank",   0);
+		int frames = ctx.props->value("frames", 1);
+		bool loop  = ctx.props->value("loop",   true);
+		res_bank  = bank;
+		res_index = loop ? (state_i % std::max(frames, 1))
+		                 : std::min((int)state_i, std::max(frames - 1, 0));
+		if(!loop && state_i >= frames) return BTResult::Success;
+		return BTResult::Running;
+	};
+	btctx_.actions["EmitSound"] = [this](BTContext& ctx) -> BTResult {
+		if(!ctx.props) return BTResult::Failure;
+		World& world = *static_cast<World*>(ctx.userData);
+		std::string snd = ctx.props->value("sound", std::string{});
+		int vol = ctx.props->value("volume", 100);
+		if(snd.empty()) return BTResult::Failure;
+		auto it = world.resources.soundbank.find(snd);
+		if(it == world.resources.soundbank.end()) return BTResult::Failure;
+		EmitSound(world, it->second, vol);
+		return BTResult::Success;
+	};
+	btctx_.actions["SetFacing"] = [this](BTContext& ctx) -> BTResult {
+		std::string dir = ctx.props ? ctx.props->value("dir", std::string{"flip"}) : "flip";
+		if(dir == "left")       mirrored = true;
+		else if(dir == "right") mirrored = false;
+		else                    mirrored = !mirrored;
+		return BTResult::Success;
+	};
 }
 
 void Robot::Serialize(bool write, Serializer & data, Serializer * old){

--- a/shared/assets/behaviortrees/civilian.json
+++ b/shared/assets/behaviortrees/civilian.json
@@ -28,13 +28,13 @@
       "type": "Leaf",
       "label": "Run",
       "children": [],
-      "props": { "action": "Run" }
+      "props": { "action": "Run", "speedBonus": 5 }
     },
     "leaf_wander": {
       "type": "Leaf",
       "label": "Wander",
       "children": [],
-      "props": { "action": "Wander" }
+      "props": { "action": "Wander", "speed": 4 }
     }
   },
   "positions": {}

--- a/web/admin/app/behavior-trees/[id]/BehaviorTreeEditor.tsx
+++ b/web/admin/app/behavior-trees/[id]/BehaviorTreeEditor.tsx
@@ -555,6 +555,12 @@ function BehaviorTreeEditorInner({ bt, onChange }: Props) {
               };
               const sortedChildren = [...parent.children].sort((a, b) => getX(a) - getX(b));
               updatedNodes = { ...cur.nodes, [parentId]: { ...parent, children: sortedChildren } };
+              // Relabel edges from this parent to reflect new child order
+              setRfEdges(es => es.map(e => {
+                if (e.source !== parentId) return e;
+                const newIdx = sortedChildren.indexOf(e.target);
+                return newIdx === -1 ? e : { ...e, label: String(newIdx + 1) };
+              }));
             }
             pushToHistory({ ...cur, nodes: updatedNodes, positions: updatedPositions });
             onChange({ ...cur, nodes: updatedNodes, positions: updatedPositions });

--- a/web/admin/app/behavior-trees/[id]/BehaviorTreeEditor.tsx
+++ b/web/admin/app/behavior-trees/[id]/BehaviorTreeEditor.tsx
@@ -107,7 +107,7 @@ function uid() {
 function nodeSubtitle(node: BTNode): string {
   if (node.type === 'Condition') {
     const p = node.props;
-    return `${p.key} ${p.op} ${JSON.stringify(p.value)}`;
+    return `${p.key} ${p.op ?? '=='} ${JSON.stringify(p.value)}`;
   }
   if (node.type === 'Leaf') return String(node.props.action ?? '');
   if (node.type === 'Cooldown') return `${node.props.duration ?? '?'}s`;
@@ -153,37 +153,34 @@ const PALETTE: { group: string; types: BTNodeType[] }[] = [
   { group: 'LEAF',      types: ['Leaf', 'Condition', 'Wait'] },
 ];
 
-// All registered leaf actions (guard + civilian + robot).
-// Shoot direction values: 0=Forward 1=Low 2=Up 3=Down 4=UpAngle 5=DownAngle 6=LadderUp 7=LadderDown
+// All registered leaf actions (guard + civilian + robot), matching exact C++ action names.
 const LEAF_ACTIONS = [
-  // ── Guard — conditions ────────────────────────────────────────────
-  'IsAlive', 'IsWalking', 'IsCrouched', 'IsNotCrouched', 'IsShooting',
-  'IsOnLadder', 'IsAtEdge', 'WasHit', 'HasChaseTarget', 'IsPlayerInBase', 'IsPlayerInvisible',
-  // ── Guard — LOS checks ────────────────────────────────────────────
-  'CanSeeForward', 'CanSeeLow', 'CanSeeUp', 'CanSeeDown', 'CanSeeUpAngle', 'CanSeeDownAngle',
-  'CanShootFromLadder',
-  // ── Guard — combat ────────────────────────────────────────────────
-  'Shoot', 'ShootFromLadder',
-  // ── Guard — movement / posture ────────────────────────────────────
-  'Patrol', 'Chase', 'SearchAndReturn', 'PursueHitDirection',
-  'Crouch', 'UncrouchIdle', 'StandIdle', 'LookScan',
-  // ── Civilian ─────────────────────────────────────────────────────
-  'RunMove',
-  // ── Robot ─────────────────────────────────────────────────────────
-  'WakeAnim', 'SleepAnim', 'ReturnToSpawn',
-  // ── Generic / shared ──────────────────────────────────────────────
-  'Stand', 'Idle', 'MoveTo', 'Alert', 'Wander',
+  // ── Guard ─────────────────────────────────────────────────────────
+  // Look0-5: scan + shoot in the given direction (0=Forward,1=Low,2=Up,3=Down,4=UpAngle,5=DownAngle)
+  'Look0', 'Look1', 'Look2', 'Look3', 'Look4', 'Look5',
+  'UncrouchIdle',    // crouch→stand when nothing to do
+  'Chase',           // pursue last-seen player
+  'SearchAndReturn', // sweep search zone then return to patrol origin
+  'Stand',           // idle standing animation
+  // ── Civilian ──────────────────────────────────────────────────────
+  'Run',             // flee movement
+  'Wander',          // random wander
+  'WakeUp',          // wake-from-idle animation
+  'LookForward',     // look scan forward
+  'LookSides',       // look scan left + right
+  'MeleeCheck',      // check for melee range enemy
+  // ── Shared ────────────────────────────────────────────────────────
+  'Patrol',          // patrol along current platform
+  'ReturnToSpawn',   // walk back to spawn point
 ];
 
-const SHOOT_DIRECTIONS: { value: number; label: string }[] = [
+const LOOK_DIRECTIONS: { value: number; label: string }[] = [
   { value: 0, label: '0 — Forward (standing)' },
   { value: 1, label: '1 — Low (crouched)' },
   { value: 2, label: '2 — Up' },
   { value: 3, label: '3 — Down' },
   { value: 4, label: '4 — Up-angle' },
   { value: 5, label: '5 — Down-angle' },
-  { value: 6, label: '6 — Ladder up' },
-  { value: 7, label: '7 — Ladder down' },
 ];
 
 // Semantics shown in the inspector when a composite/decorator/leaf is selected.
@@ -198,7 +195,7 @@ const NODE_DESC: Record<string, string> = {
   Timeout:        'Runs child; if it is still Running after DURATION seconds, returns Failure.',
   ForceSuccess:   'Runs child; always returns Success regardless of child result.',
   Wait:           'Returns Running for DURATION seconds, then Success.',
-  Leaf:           'Dispatches to a named C++ action handler registered via btctx_.actions["Name"].',
+  Leaf:           'Dispatches to a named C++ action handler. Look0–Look5 scan + shoot in direction 0–5 (Forward/Low/Up/Down/UpAngle/DownAngle).',
   Condition:      'Reads a blackboard key and compares it to a literal value. Returns Success if the comparison is true.',
 };
 
@@ -208,6 +205,8 @@ interface Props { bt: BehaviorTree; onChange: (bt: BehaviorTree) => void; }
 export default function BehaviorTreeEditor({ bt, onChange }: Props) {
   const [rfNodes, setRfNodes, onNodesChange] = useNodesState([]);
   const [rfEdges, setRfEdges, onEdgesChange] = useEdgesState([]);
+  const rfEdgesRef = useRef(rfEdges);
+  rfEdgesRef.current = rfEdges;
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
   const [validateMsg, setValidateMsg] = useState<string | null>(null);
   const btRef = useRef(bt);
@@ -219,6 +218,25 @@ export default function BehaviorTreeEditor({ bt, onChange }: Props) {
     setRfNodes(nodes);
     setRfEdges(edges);
   }, [bt.id]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // When ReactFlow removes edges (user clicks edge → Delete), sync children arrays in BT data.
+  const handleEdgesChange = useCallback((changes: Parameters<typeof onEdgesChange>[0]) => {
+    onEdgesChange(changes);
+    const removals = changes.filter(c => c.type === 'remove');
+    if (removals.length === 0) return;
+    const edgeMap = new Map(rfEdgesRef.current.map(e => [e.id, e]));
+    const cur = btRef.current;
+    const nodes = { ...cur.nodes };
+    for (const rm of removals) {
+      const edge = edgeMap.get((rm as { id: string }).id);
+      if (!edge) continue;
+      const { source, target } = edge;
+      if (nodes[source]) {
+        nodes[source] = { ...nodes[source], children: nodes[source].children.filter(c => c !== target) };
+      }
+    }
+    onChange({ ...cur, nodes });
+  }, [onEdgesChange, onChange]);
 
   const onConnect = useCallback((params: Connection) => {
     if (!params.source || !params.target) return;
@@ -419,7 +437,7 @@ export default function BehaviorTreeEditor({ bt, onChange }: Props) {
           nodes={rfNodes}
           edges={rfEdges}
           onNodesChange={onNodesChange}
-          onEdgesChange={onEdgesChange}
+          onEdgesChange={handleEdgesChange}
           onConnect={onConnect}
           nodeTypes={NODE_TYPES}
           onNodeClick={(_, n) => setSelectedNodeId(n.id)}
@@ -475,20 +493,9 @@ export default function BehaviorTreeEditor({ bt, onChange }: Props) {
                   {LEAF_ACTIONS.map(a => <option key={a} value={a}>{a}</option>)}
                 </select>
 
-                {/* Shoot direction */}
-                {selectedNode.props.action === 'Shoot' && (
-                  <>
-                    <label style={{ color: '#718096', fontSize: 10, display: 'block', marginBottom: 2 }}>DIRECTION</label>
-                    <select value={Number(selectedNode.props.direction ?? 0)} onChange={e => updateProp('direction', parseInt(e.target.value))}
-                      style={{ width: '100%', background: '#161b22', border: '1px solid #2d3748', color: '#e2e8f0', padding: '4px 6px', fontSize: 11, fontFamily: 'monospace', marginBottom: 8, boxSizing: 'border-box' }}>
-                      {SHOOT_DIRECTIONS.map(d => <option key={d.value} value={d.value}>{d.label}</option>)}
-                    </select>
-                  </>
-                )}
-
-                {/* Generic extra props (all props except action + direction for Shoot) */}
+                {/* Generic extra props (all props except action) */}
                 {(() => {
-                  const reserved = new Set(['action', ...(selectedNode.props.action === 'Shoot' ? ['direction'] : [])]);
+                  const reserved = new Set(['action']);
                   const extraKeys = Object.keys(selectedNode.props).filter(k => !reserved.has(k));
                   return extraKeys.length > 0 ? (
                     <>

--- a/web/admin/app/behavior-trees/[id]/BehaviorTreeEditor.tsx
+++ b/web/admin/app/behavior-trees/[id]/BehaviorTreeEditor.tsx
@@ -5,6 +5,7 @@ import ReactFlow, {
   Background,
   Controls,
   Handle,
+  MiniMap,
   Position,
   useEdgesState,
   useNodesState,
@@ -168,6 +169,35 @@ const NPC_ACTIONS: Record<string, string[]> = {
 // All actions merged for unknown NPC types
 const ALL_ACTIONS = [...new Set([...Object.values(NPC_ACTIONS).flat()])].sort();
 
+const ACTION_DESC: Record<string, string> = {
+  // Guard
+  Look0: 'Scan & shoot: forward (standing)',
+  Look1: 'Scan & shoot: low (crouched)',
+  Look2: 'Scan & shoot: upward',
+  Look3: 'Scan & shoot: downward',
+  Look4: 'Scan & shoot: up-angle',
+  Look5: 'Scan & shoot: down-angle',
+  UncrouchIdle: 'Stand up from crouch and idle',
+  Chase: 'Run toward last known player position',
+  Patrol: 'Walk patrol route; stop to look around periodically',
+  SearchAndReturn: 'Search last known position then return to spawn',
+  Stand: 'Stand in place (idle)',
+  // Civilian
+  Run: 'Flee from threat at run speed',
+  Wander: 'Wander randomly within spawn area',
+  WakeUp: 'Play wake-up animation then become active',
+  LookForward: 'Look straight ahead (idle animation)',
+  LookSides: 'Look side to side (alert animation)',
+  MeleeCheck: 'Check if player is in melee range; attack if so',
+  ReturnToSpawn: 'Walk back to spawn point',
+  // Generic leaves
+  PlayAnim: 'Play a sprite bank animation (bank, frames, loop)',
+  EmitSound: 'Play a named sound from the world soundbank',
+  SetFacing: 'Set entity facing direction (left / right / flip)',
+  SetBlackboard: 'Write a constant value to a blackboard key',
+  RandomChance: 'Succeed with probability = chance (0.0–1.0)',
+};
+
 const LOOK_DIRECTIONS: { value: number; label: string }[] = [
   { value: 0, label: '0 — Forward (standing)' },
   { value: 1, label: '1 — Low (crouched)' },
@@ -301,6 +331,9 @@ function BehaviorTreeEditorInner({ bt, onChange }: Props) {
     if (!parentNode) return;
     if (parentNode.children.includes(params.target)) return; // already connected
 
+    // Leaf, Condition, Wait cannot have children
+    if (['Leaf', 'Condition', 'Wait'].includes(parentNode.type)) return;
+
     const isDecorator = ['Inverter', 'Cooldown', 'Repeat', 'Timeout', 'ForceSuccess'].includes(parentNode.type);
     if (isDecorator && parentNode.children.length >= 1) return;
 
@@ -313,7 +346,14 @@ function BehaviorTreeEditorInner({ bt, onChange }: Props) {
     };
     pushToHistory(updated);
     onChange(updated);
-    setRfEdges(es => addEdge({ ...params, type: 'smoothstep', style: { stroke: '#4a5568', strokeWidth: 2 } }, es));
+    setRfEdges(es => addEdge({
+      ...params,
+      type: 'smoothstep',
+      style: { stroke: '#4a5568', strokeWidth: 2 },
+      label: String(parentNode.children.length + 1),
+      labelStyle: { fill: '#718096', fontSize: 10 },
+      labelBgStyle: { fill: '#0d1117' },
+    }, es));
   }, [onChange]);
 
   function autoLayout() {
@@ -383,6 +423,29 @@ function BehaviorTreeEditorInner({ bt, onChange }: Props) {
     setRfNodes(ns => ns.filter(n => n.id !== selectedNodeId));
     setRfEdges(es => es.filter(e => e.source !== selectedNodeId && e.target !== selectedNodeId));
     setSelectedNodeId(null);
+  }
+
+  function duplicateSelectedNode() {
+    if (!selectedNodeId) return;
+    const cur = btRef.current;
+    const src = cur.nodes[selectedNodeId];
+    if (!src) return;
+    const newId = `${src.type.toLowerCase()}_${uid()}`;
+    const srcPos = cur.positions?.[selectedNodeId] ?? { x: 100, y: 100 };
+    const newPos = { x: srcPos.x + 40, y: srcPos.y + 40 };
+    const newNode: BTNode = { ...src, children: [] }; // no children copy
+    const updated: BehaviorTree = {
+      ...cur,
+      nodes: { ...cur.nodes, [newId]: newNode },
+      positions: { ...cur.positions, [newId]: newPos },
+    };
+    pushToHistory(updated);
+    onChange(updated);
+    setRfNodes(ns => [...ns, {
+      id: newId, type: 'btNode', position: newPos,
+      data: { type: src.type, label: src.label, subtitle: nodeSubtitle(src) },
+    }]);
+    setSelectedNodeId(newId);
   }
 
   const selectedNode = selectedNodeId ? bt.nodes[selectedNodeId] : null;
@@ -507,6 +570,12 @@ function BehaviorTreeEditorInner({ bt, onChange }: Props) {
               {validateMsg}
             </div>
           )}
+          {selectedNodeId && (
+            <button onClick={duplicateSelectedNode}
+              style={{ display: 'block', width: '100%', marginTop: 8, padding: '5px 8px', background: '#0d1a2a', border: '1px solid #1e3a5f', color: '#60a5fa', fontSize: 10, fontFamily: 'monospace', cursor: 'pointer', letterSpacing: 1 }}>
+              ⎘ DUPLICATE
+            </button>
+          )}
           {selectedNodeId && selectedNodeId !== bt.rootId && (
             <button onClick={deleteSelectedNode}
               style={{ display: 'block', width: '100%', marginTop: 8, padding: '5px 8px', background: '#1a0000', border: '1px solid #7f1d1d', color: '#f87171', fontSize: 10, fontFamily: 'monospace', cursor: 'pointer', letterSpacing: 1 }}>
@@ -569,6 +638,11 @@ function BehaviorTreeEditorInner({ bt, onChange }: Props) {
         >
           <Background color="#1a1f2e" gap={20} />
           <Controls style={{ background: '#161b22', border: '1px solid #2d3748' }} />
+          <MiniMap
+            nodeColor={n => TYPE_COLOR[(n.data as { type: string }).type] ?? '#718096'}
+            style={{ background: '#0d1117', border: '1px solid #2d3748' }}
+            maskColor="rgba(0,0,0,0.7)"
+          />
         </ReactFlow>
       </div>
 
@@ -636,10 +710,15 @@ function BehaviorTreeEditorInner({ bt, onChange }: Props) {
               <>
                 <label style={{ color: '#718096', fontSize: 10, display: 'block', marginBottom: 2 }}>ACTION</label>
                 <select value={String(selectedNode.props.action ?? '')} onChange={e => updateProp('action', e.target.value)}
-                  style={{ width: '100%', background: '#161b22', border: '1px solid #2d3748', color: '#e2e8f0', padding: '4px 6px', fontSize: 11, fontFamily: 'monospace', marginBottom: 8, boxSizing: 'border-box' }}>
+                  style={{ width: '100%', background: '#161b22', border: '1px solid #2d3748', color: '#e2e8f0', padding: '4px 6px', fontSize: 11, fontFamily: 'monospace', marginBottom: 4, boxSizing: 'border-box' }}>
                   <option value="">— select action —</option>
                   {leafActions.map(a => <option key={a} value={a}>{a}</option>)}
                 </select>
+                {String(selectedNode.props.action ?? '') && ACTION_DESC[String(selectedNode.props.action ?? '')] && (
+                  <div style={{ color: '#4a5568', fontSize: 9, fontFamily: 'monospace', lineHeight: 1.5, marginBottom: 8, fontStyle: 'italic' }}>
+                    {ACTION_DESC[String(selectedNode.props.action ?? '')]}
+                  </div>
+                )}
 
                 {/* Generic extra props (all props except action) */}
                 {(() => {
@@ -788,10 +867,21 @@ function BehaviorTreeEditorInner({ bt, onChange }: Props) {
                   {bt.blackboard.map(k => <option key={k.key} value={k.key}>{k.key}</option>)}
                 </select>
                 <label style={{ color: '#718096', fontSize: 10, display: 'block', marginBottom: 2 }}>OPERATOR</label>
-                <select value={String(selectedNode.props.op ?? '==')} onChange={e => updateProp('op', e.target.value)}
-                  style={{ width: '100%', background: '#161b22', border: '1px solid #2d3748', color: '#e2e8f0', padding: '4px 6px', fontSize: 11, fontFamily: 'monospace', marginBottom: 4, boxSizing: 'border-box' }}>
-                  {['==', '!=', '>', '<', '>=', '<='].map(op => <option key={op} value={op}>{op}</option>)}
-                </select>
+                {(() => {
+                  const bbEntry = bt.blackboard.find(k => k.key === selectedNode.props.key);
+                  const kType = bbEntry?.type ?? 'string';
+                  const ops = (kType === 'bool' || kType === 'string') ? ['==', '!='] : ['==', '!=', '>', '<', '>=', '<='];
+                  const currentOp = String(selectedNode.props.op ?? '==');
+                  if (!ops.includes(currentOp)) {
+                    setTimeout(() => updateProp('op', '=='), 0);
+                  }
+                  return (
+                    <select value={ops.includes(currentOp) ? currentOp : '=='} onChange={e => updateProp('op', e.target.value)}
+                      style={{ width: '100%', background: '#161b22', border: '1px solid #2d3748', color: '#e2e8f0', padding: '4px 6px', fontSize: 11, fontFamily: 'monospace', marginBottom: 4, boxSizing: 'border-box' }}>
+                      {ops.map(op => <option key={op} value={op}>{op}</option>)}
+                    </select>
+                  );
+                })()}
                 <label style={{ color: '#718096', fontSize: 10, display: 'block', marginBottom: 2 }}>VALUE</label>
                 {(() => {
                   const bbEntry = bt.blackboard.find(k => k.key === selectedNode.props.key);

--- a/web/admin/app/behavior-trees/[id]/BehaviorTreeEditor.tsx
+++ b/web/admin/app/behavior-trees/[id]/BehaviorTreeEditor.tsx
@@ -172,6 +172,12 @@ const LEAF_ACTIONS = [
   // ── Shared ────────────────────────────────────────────────────────
   'Patrol',          // patrol along current platform
   'ReturnToSpawn',   // walk back to spawn point
+  // ── Generic data-driven (all NPCs, configure via props) ───────────
+  'SetBlackboard',   // write key/value to blackboard
+  'RandomChance',    // succeed with probability `chance` (0.0–1.0)
+  'PlayAnim',        // drive animation: bank, frames, loop
+  'EmitSound',       // play a sound: sound (filename), volume
+  'SetFacing',       // flip direction: dir = left | right | flip
 ];
 
 const LOOK_DIRECTIONS: { value: number; label: string }[] = [
@@ -495,26 +501,116 @@ export default function BehaviorTreeEditor({ bt, onChange }: Props) {
 
                 {/* Generic extra props (all props except action) */}
                 {(() => {
-                  const reserved = new Set(['action']);
+                  const action = String(selectedNode.props.action ?? '');
+                  // Known props handled by dedicated UI below — exclude from generic editor
+                  const knownProps: Record<string, string[]> = {
+                    PlayAnim:      ['bank', 'frames', 'loop'],
+                    EmitSound:     ['sound', 'volume'],
+                    SetFacing:     ['dir'],
+                    RandomChance:  ['chance'],
+                    SetBlackboard: ['key', 'value'],
+                  };
+                  const reserved = new Set(['action', ...(knownProps[action] ?? [])]);
                   const extraKeys = Object.keys(selectedNode.props).filter(k => !reserved.has(k));
-                  return extraKeys.length > 0 ? (
+
+                  return (
                     <>
-                      <div style={{ color: '#4a5568', fontSize: 9, letterSpacing: 1, marginBottom: 4 }}>EXTRA PROPS</div>
-                      {extraKeys.map(k => (
-                        <div key={k} style={{ display: 'flex', gap: 4, marginBottom: 4, alignItems: 'center' }}>
-                          <span style={{ color: '#718096', fontSize: 9, fontFamily: 'monospace', flexShrink: 0, minWidth: 60, overflow: 'hidden', textOverflow: 'ellipsis' }}>{k}</span>
-                          <input value={String(selectedNode.props[k])}
-                            onChange={e => updateProp(k, isNaN(Number(e.target.value)) ? e.target.value : Number(e.target.value))}
-                            style={{ flex: 1, background: '#161b22', border: '1px solid #2d3748', color: '#e2e8f0', padding: '3px 5px', fontSize: 10, fontFamily: 'monospace', minWidth: 0 }} />
-                          <button onClick={() => {
-                            const p = { ...selectedNode.props };
-                            delete p[k];
-                            updateSelectedNode({ props: p });
-                          }} style={{ background: 'none', border: 'none', color: '#4a5568', cursor: 'pointer', fontSize: 12, padding: '0 2px', flexShrink: 0 }}>✕</button>
+                      {/* PlayAnim knobs */}
+                      {action === 'PlayAnim' && (<>
+                        <label style={{ color: '#718096', fontSize: 10, display: 'block', marginBottom: 2 }}>BANK</label>
+                        <input type="number" min={0} step={1} value={Number(selectedNode.props.bank ?? 0)}
+                          onChange={e => updateProp('bank', parseInt(e.target.value))}
+                          style={{ width: '100%', background: '#161b22', border: '1px solid #2d3748', color: '#e2e8f0', padding: '4px 6px', fontSize: 11, fontFamily: 'monospace', marginBottom: 4, boxSizing: 'border-box' }} />
+                        <label style={{ color: '#718096', fontSize: 10, display: 'block', marginBottom: 2 }}>FRAMES</label>
+                        <input type="number" min={1} step={1} value={Number(selectedNode.props.frames ?? 1)}
+                          onChange={e => updateProp('frames', parseInt(e.target.value))}
+                          style={{ width: '100%', background: '#161b22', border: '1px solid #2d3748', color: '#e2e8f0', padding: '4px 6px', fontSize: 11, fontFamily: 'monospace', marginBottom: 4, boxSizing: 'border-box' }} />
+                        <label style={{ color: '#718096', fontSize: 10, display: 'block', marginBottom: 2 }}>LOOP</label>
+                        <div style={{ display: 'flex', gap: 4, marginBottom: 8 }}>
+                          {[true, false].map(v => {
+                            const cur = selectedNode.props.loop !== false;
+                            const active = v ? cur : !cur;
+                            return (
+                              <button key={String(v)} onClick={() => updateProp('loop', v)}
+                                style={{ flex: 1, padding: '4px 0', fontSize: 10, fontFamily: 'monospace', cursor: 'pointer',
+                                  background: active ? '#14532d' : '#161b22',
+                                  border: `1px solid ${active ? '#22c55e' : '#2d3748'}`,
+                                  color: active ? '#22c55e' : '#4a5568' }}>
+                                {String(v)}
+                              </button>
+                            );
+                          })}
                         </div>
-                      ))}
+                      </>)}
+
+                      {/* EmitSound knobs */}
+                      {action === 'EmitSound' && (<>
+                        <label style={{ color: '#718096', fontSize: 10, display: 'block', marginBottom: 2 }}>SOUND (filename)</label>
+                        <input value={String(selectedNode.props.sound ?? '')} onChange={e => updateProp('sound', e.target.value)}
+                          style={{ width: '100%', background: '#161b22', border: '1px solid #2d3748', color: '#e2e8f0', padding: '4px 6px', fontSize: 11, fontFamily: 'monospace', marginBottom: 4, boxSizing: 'border-box' }} />
+                        <label style={{ color: '#718096', fontSize: 10, display: 'block', marginBottom: 2 }}>VOLUME (0–128)</label>
+                        <input type="number" min={0} max={128} step={1} value={Number(selectedNode.props.volume ?? 100)}
+                          onChange={e => updateProp('volume', parseInt(e.target.value))}
+                          style={{ width: '100%', background: '#161b22', border: '1px solid #2d3748', color: '#e2e8f0', padding: '4px 6px', fontSize: 11, fontFamily: 'monospace', marginBottom: 8, boxSizing: 'border-box' }} />
+                      </>)}
+
+                      {/* SetFacing knobs */}
+                      {action === 'SetFacing' && (<>
+                        <label style={{ color: '#718096', fontSize: 10, display: 'block', marginBottom: 2 }}>DIRECTION</label>
+                        <select value={String(selectedNode.props.dir ?? 'flip')} onChange={e => updateProp('dir', e.target.value)}
+                          style={{ width: '100%', background: '#161b22', border: '1px solid #2d3748', color: '#e2e8f0', padding: '4px 6px', fontSize: 11, fontFamily: 'monospace', marginBottom: 8, boxSizing: 'border-box' }}>
+                          {['flip', 'left', 'right'].map(d => <option key={d} value={d}>{d}</option>)}
+                        </select>
+                      </>)}
+
+                      {/* RandomChance knobs */}
+                      {action === 'RandomChance' && (<>
+                        <label style={{ color: '#718096', fontSize: 10, display: 'block', marginBottom: 2 }}>CHANCE (0.0–1.0)</label>
+                        <input type="number" min={0} max={1} step={0.05} value={Number(selectedNode.props.chance ?? 0.5)}
+                          onChange={e => updateProp('chance', parseFloat(e.target.value))}
+                          style={{ width: '100%', background: '#161b22', border: '1px solid #2d3748', color: '#e2e8f0', padding: '4px 6px', fontSize: 11, fontFamily: 'monospace', marginBottom: 8, boxSizing: 'border-box' }} />
+                      </>)}
+
+                      {/* SetBlackboard knobs */}
+                      {action === 'SetBlackboard' && (<>
+                        <label style={{ color: '#718096', fontSize: 10, display: 'block', marginBottom: 2 }}>KEY</label>
+                        <select value={String(selectedNode.props.key ?? '')} onChange={e => updateProp('key', e.target.value)}
+                          style={{ width: '100%', background: '#161b22', border: '1px solid #2d3748', color: '#e2e8f0', padding: '4px 6px', fontSize: 11, fontFamily: 'monospace', marginBottom: 4, boxSizing: 'border-box' }}>
+                          <option value="">— select key —</option>
+                          {bt.blackboard.map(k => <option key={k.key} value={k.key}>{k.key} ({k.type})</option>)}
+                        </select>
+                        <label style={{ color: '#718096', fontSize: 10, display: 'block', marginBottom: 2 }}>VALUE</label>
+                        <input value={String(selectedNode.props.value ?? '')}
+                          onChange={e => {
+                            const raw = e.target.value;
+                            const bb = bt.blackboard.find(k => k.key === selectedNode.props.key);
+                            const v = bb?.type === 'bool' ? (raw === 'true') : bb?.type === 'int' ? parseInt(raw) : bb?.type === 'float' ? parseFloat(raw) : raw;
+                            updateProp('value', isNaN(v as number) ? raw : v);
+                          }}
+                          style={{ width: '100%', background: '#161b22', border: '1px solid #2d3748', color: '#e2e8f0', padding: '4px 6px', fontSize: 11, fontFamily: 'monospace', marginBottom: 8, boxSizing: 'border-box' }} />
+                      </>)}
+
+                      {/* Remaining unknown props */}
+                      {extraKeys.length > 0 && (
+                        <>
+                          <div style={{ color: '#4a5568', fontSize: 9, letterSpacing: 1, marginBottom: 4 }}>EXTRA PROPS</div>
+                          {extraKeys.map(k => (
+                            <div key={k} style={{ display: 'flex', gap: 4, marginBottom: 4, alignItems: 'center' }}>
+                              <span style={{ color: '#718096', fontSize: 9, fontFamily: 'monospace', flexShrink: 0, minWidth: 60, overflow: 'hidden', textOverflow: 'ellipsis' }}>{k}</span>
+                              <input value={String(selectedNode.props[k])}
+                                onChange={e => updateProp(k, isNaN(Number(e.target.value)) ? e.target.value : Number(e.target.value))}
+                                style={{ flex: 1, background: '#161b22', border: '1px solid #2d3748', color: '#e2e8f0', padding: '3px 5px', fontSize: 10, fontFamily: 'monospace', minWidth: 0 }} />
+                              <button onClick={() => {
+                                const p = { ...selectedNode.props };
+                                delete p[k];
+                                updateSelectedNode({ props: p });
+                              }} style={{ background: 'none', border: 'none', color: '#4a5568', cursor: 'pointer', fontSize: 12, padding: '0 2px', flexShrink: 0 }}>✕</button>
+                            </div>
+                          ))}
+                        </>
+                      )}
                     </>
-                  ) : null;
+                  );
                 })()}
               </>
             )}

--- a/web/admin/app/behavior-trees/[id]/BehaviorTreeEditor.tsx
+++ b/web/admin/app/behavior-trees/[id]/BehaviorTreeEditor.tsx
@@ -272,8 +272,8 @@ function BehaviorTreeEditorInner({ bt, onChange }: Props) {
 
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
-      if ((e.ctrlKey || e.metaKey) && e.key === 'z' && !e.shiftKey) { e.preventDefault(); undo(); }
-      if ((e.ctrlKey || e.metaKey) && (e.key === 'y' || (e.key === 'z' && e.shiftKey))) { e.preventDefault(); redo(); }
+      if ((e.ctrlKey || e.metaKey) && e.key === 'z' && !e.shiftKey) { e.preventDefault(); undoRef.current(); }
+      if ((e.ctrlKey || e.metaKey) && (e.key === 'y' || (e.key === 'z' && e.shiftKey))) { e.preventDefault(); redoRef.current(); }
     }
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
@@ -293,6 +293,9 @@ function BehaviorTreeEditorInner({ bt, onChange }: Props) {
     setCanUndo(historyIdxRef.current > 0);
     setCanRedo(true);
     onChange(prev);
+    const { nodes, edges } = btToFlow(prev);
+    setRfNodes(nodes);
+    setRfEdges(edges);
   }
 
   function redo() {
@@ -302,7 +305,16 @@ function BehaviorTreeEditorInner({ bt, onChange }: Props) {
     setCanUndo(true);
     setCanRedo(historyIdxRef.current < historyRef.current.length - 1);
     onChange(next);
+    const { nodes, edges } = btToFlow(next);
+    setRfNodes(nodes);
+    setRfEdges(edges);
   }
+
+  // Stable refs so the keydown listener always calls the latest undo/redo
+  const undoRef = useRef(undo);
+  const redoRef = useRef(redo);
+  undoRef.current = undo;
+  redoRef.current = redo;
 
   // When ReactFlow removes edges (user clicks edge → Delete), sync children arrays in BT data.
   const handleEdgesChange = useCallback((changes: Parameters<typeof onEdgesChange>[0]) => {

--- a/web/admin/app/behavior-trees/[id]/BehaviorTreeEditor.tsx
+++ b/web/admin/app/behavior-trees/[id]/BehaviorTreeEditor.tsx
@@ -15,6 +15,7 @@ import ReactFlow, {
 } from 'reactflow';
 import dagre from 'dagre';
 import type { BehaviorTree, BTNode, BTNodeType, BBKey } from '../../../lib/api';
+import { API, apiFetch } from '../../../lib/api';
 
 // ── Node colours by type ──────────────────────────────────────────────────────
 const TYPE_COLOR: Record<string, string> = {
@@ -217,6 +218,14 @@ export default function BehaviorTreeEditor({ bt, onChange }: Props) {
   const [validateMsg, setValidateMsg] = useState<string | null>(null);
   const btRef = useRef(bt);
   btRef.current = bt;
+
+  // Asset catalogs for PlayAnim / EmitSound dropdowns
+  const [spriteBanks, setSpriteBanks] = useState<{ bank: number; frames: number }[]>([]);
+  const [soundNames, setSoundNames] = useState<string[]>([]);
+  useEffect(() => {
+    fetch(`${API}/sprites`).then(r => r.json()).then((d: { bank: number; frames: number }[]) => setSpriteBanks(d)).catch(() => {});
+    apiFetch('/sounds').then((d) => setSoundNames((d as { name: string }[]).map(s => s.name).sort())).catch(() => {});
+  }, []);
 
   // Sync BT → ReactFlow
   useEffect(() => {
@@ -518,10 +527,20 @@ export default function BehaviorTreeEditor({ bt, onChange }: Props) {
                       {/* PlayAnim knobs */}
                       {action === 'PlayAnim' && (<>
                         <label style={{ color: '#718096', fontSize: 10, display: 'block', marginBottom: 2 }}>BANK</label>
-                        <input type="number" min={0} step={1} value={Number(selectedNode.props.bank ?? 0)}
-                          onChange={e => updateProp('bank', parseInt(e.target.value))}
-                          style={{ width: '100%', background: '#161b22', border: '1px solid #2d3748', color: '#e2e8f0', padding: '4px 6px', fontSize: 11, fontFamily: 'monospace', marginBottom: 4, boxSizing: 'border-box' }} />
-                        <label style={{ color: '#718096', fontSize: 10, display: 'block', marginBottom: 2 }}>FRAMES</label>
+                        <select value={Number(selectedNode.props.bank ?? 0)}
+                          onChange={e => {
+                            const bank = parseInt(e.target.value);
+                            const entry = spriteBanks.find(b => b.bank === bank);
+                            updateProp('bank', bank);
+                            if (entry) updateProp('frames', entry.frames);
+                          }}
+                          style={{ width: '100%', background: '#161b22', border: '1px solid #2d3748', color: '#e2e8f0', padding: '4px 6px', fontSize: 11, fontFamily: 'monospace', marginBottom: 4, boxSizing: 'border-box' }}>
+                          <option value={0}>— select bank —</option>
+                          {spriteBanks.map(b => (
+                            <option key={b.bank} value={b.bank}>Bank {b.bank} ({b.frames} frames)</option>
+                          ))}
+                        </select>
+                        <label style={{ color: '#718096', fontSize: 10, display: 'block', marginBottom: 2 }}>FRAMES (auto-filled from bank)</label>
                         <input type="number" min={1} step={1} value={Number(selectedNode.props.frames ?? 1)}
                           onChange={e => updateProp('frames', parseInt(e.target.value))}
                           style={{ width: '100%', background: '#161b22', border: '1px solid #2d3748', color: '#e2e8f0', padding: '4px 6px', fontSize: 11, fontFamily: 'monospace', marginBottom: 4, boxSizing: 'border-box' }} />
@@ -545,9 +564,12 @@ export default function BehaviorTreeEditor({ bt, onChange }: Props) {
 
                       {/* EmitSound knobs */}
                       {action === 'EmitSound' && (<>
-                        <label style={{ color: '#718096', fontSize: 10, display: 'block', marginBottom: 2 }}>SOUND (filename)</label>
-                        <input value={String(selectedNode.props.sound ?? '')} onChange={e => updateProp('sound', e.target.value)}
-                          style={{ width: '100%', background: '#161b22', border: '1px solid #2d3748', color: '#e2e8f0', padding: '4px 6px', fontSize: 11, fontFamily: 'monospace', marginBottom: 4, boxSizing: 'border-box' }} />
+                        <label style={{ color: '#718096', fontSize: 10, display: 'block', marginBottom: 2 }}>SOUND</label>
+                        <select value={String(selectedNode.props.sound ?? '')} onChange={e => updateProp('sound', e.target.value)}
+                          style={{ width: '100%', background: '#161b22', border: '1px solid #2d3748', color: '#e2e8f0', padding: '4px 6px', fontSize: 11, fontFamily: 'monospace', marginBottom: 4, boxSizing: 'border-box' }}>
+                          <option value="">— select sound —</option>
+                          {soundNames.map(s => <option key={s} value={s}>{s}</option>)}
+                        </select>
                         <label style={{ color: '#718096', fontSize: 10, display: 'block', marginBottom: 2 }}>VOLUME (0–128)</label>
                         <input type="number" min={0} max={128} step={1} value={Number(selectedNode.props.volume ?? 100)}
                           onChange={e => updateProp('volume', parseInt(e.target.value))}

--- a/web/admin/app/behavior-trees/[id]/BehaviorTreeEditor.tsx
+++ b/web/admin/app/behavior-trees/[id]/BehaviorTreeEditor.tsx
@@ -8,6 +8,8 @@ import ReactFlow, {
   Position,
   useEdgesState,
   useNodesState,
+  useReactFlow,
+  ReactFlowProvider,
   type Connection,
   type Edge,
   type Node,
@@ -154,32 +156,17 @@ const PALETTE: { group: string; types: BTNodeType[] }[] = [
   { group: 'LEAF',      types: ['Leaf', 'Condition', 'Wait'] },
 ];
 
-// All registered leaf actions (guard + civilian + robot), matching exact C++ action names.
-const LEAF_ACTIONS = [
-  // ── Guard ─────────────────────────────────────────────────────────
-  // Look0-5: scan + shoot in the given direction (0=Forward,1=Low,2=Up,3=Down,4=UpAngle,5=DownAngle)
-  'Look0', 'Look1', 'Look2', 'Look3', 'Look4', 'Look5',
-  'UncrouchIdle',    // crouch→stand when nothing to do
-  'Chase',           // pursue last-seen player
-  'SearchAndReturn', // sweep search zone then return to patrol origin
-  'Stand',           // idle standing animation
-  // ── Civilian ──────────────────────────────────────────────────────
-  'Run',             // flee movement
-  'Wander',          // random wander
-  'WakeUp',          // wake-from-idle animation
-  'LookForward',     // look scan forward
-  'LookSides',       // look scan left + right
-  'MeleeCheck',      // check for melee range enemy
-  // ── Shared ────────────────────────────────────────────────────────
-  'Patrol',          // patrol along current platform
-  'ReturnToSpawn',   // walk back to spawn point
-  // ── Generic data-driven (all NPCs, configure via props) ───────────
-  'SetBlackboard',   // write key/value to blackboard
-  'RandomChance',    // succeed with probability `chance` (0.0–1.0)
-  'PlayAnim',        // drive animation: bank, frames, loop
-  'EmitSound',       // play a sound: sound (filename), volume
-  'SetFacing',       // flip direction: dir = left | right | flip
-];
+// ── Leaf action lists per NPC type ───────────────────────────────────────────
+const GENERIC_ACTIONS = ['SetBlackboard', 'RandomChance', 'PlayAnim', 'EmitSound', 'SetFacing'];
+
+const NPC_ACTIONS: Record<string, string[]> = {
+  guard:    ['Look0', 'Look1', 'Look2', 'Look3', 'Look4', 'Look5', 'UncrouchIdle', 'Chase', 'Patrol', 'SearchAndReturn', 'Stand', ...GENERIC_ACTIONS],
+  civilian: ['Run', 'Wander', 'WakeUp', 'LookForward', 'LookSides', 'MeleeCheck', 'ReturnToSpawn', ...GENERIC_ACTIONS],
+  robot:    ['WakeUp', 'LookForward', 'LookSides', 'MeleeCheck', 'Patrol', 'ReturnToSpawn', ...GENERIC_ACTIONS],
+};
+
+// All actions merged for unknown NPC types
+const ALL_ACTIONS = [...new Set([...Object.values(NPC_ACTIONS).flat()])].sort();
 
 const LOOK_DIRECTIONS: { value: number; label: string }[] = [
   { value: 0, label: '0 — Forward (standing)' },
@@ -209,7 +196,11 @@ const NODE_DESC: Record<string, string> = {
 // ── Main editor ───────────────────────────────────────────────────────────────
 interface Props { bt: BehaviorTree; onChange: (bt: BehaviorTree) => void; }
 
-export default function BehaviorTreeEditor({ bt, onChange }: Props) {
+export default function BehaviorTreeEditor(props: Props) {
+  return <ReactFlowProvider><BehaviorTreeEditorInner {...props} /></ReactFlowProvider>;
+}
+
+function BehaviorTreeEditorInner({ bt, onChange }: Props) {
   const [rfNodes, setRfNodes, onNodesChange] = useNodesState([]);
   const [rfEdges, setRfEdges, onEdgesChange] = useEdgesState([]);
   const rfEdgesRef = useRef(rfEdges);
@@ -218,6 +209,14 @@ export default function BehaviorTreeEditor({ bt, onChange }: Props) {
   const [validateMsg, setValidateMsg] = useState<string | null>(null);
   const btRef = useRef(bt);
   btRef.current = bt;
+
+  const rfInstance = useReactFlow();
+  const reactFlowWrapper = useRef<HTMLDivElement>(null);
+  const historyRef = useRef<BehaviorTree[]>([]);
+  const historyIdxRef = useRef(-1);
+  const [canUndo, setCanUndo] = useState(false);
+  const [canRedo, setCanRedo] = useState(false);
+  const leafActions = useMemo(() => NPC_ACTIONS[bt.id.toLowerCase()] ?? ALL_ACTIONS, [bt.id]);
 
   // Asset catalogs for PlayAnim / EmitSound dropdowns
   const [spriteBanks, setSpriteBanks] = useState<{ bank: number; frames: number }[]>([]);
@@ -233,6 +232,47 @@ export default function BehaviorTreeEditor({ bt, onChange }: Props) {
     setRfNodes(nodes);
     setRfEdges(edges);
   }, [bt.id]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    historyRef.current = [bt];
+    historyIdxRef.current = 0;
+    setCanUndo(false);
+    setCanRedo(false);
+  }, [bt.id]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if ((e.ctrlKey || e.metaKey) && e.key === 'z' && !e.shiftKey) { e.preventDefault(); undo(); }
+      if ((e.ctrlKey || e.metaKey) && (e.key === 'y' || (e.key === 'z' && e.shiftKey))) { e.preventDefault(); redo(); }
+    }
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  function pushToHistory(newBt: BehaviorTree) {
+    historyRef.current = [...historyRef.current.slice(0, historyIdxRef.current + 1), newBt].slice(-50);
+    historyIdxRef.current = historyRef.current.length - 1;
+    setCanUndo(historyIdxRef.current > 0);
+    setCanRedo(false);
+  }
+
+  function undo() {
+    if (historyIdxRef.current <= 0) return;
+    historyIdxRef.current -= 1;
+    const prev = historyRef.current[historyIdxRef.current];
+    setCanUndo(historyIdxRef.current > 0);
+    setCanRedo(true);
+    onChange(prev);
+  }
+
+  function redo() {
+    if (historyIdxRef.current >= historyRef.current.length - 1) return;
+    historyIdxRef.current += 1;
+    const next = historyRef.current[historyIdxRef.current];
+    setCanUndo(true);
+    setCanRedo(historyIdxRef.current < historyRef.current.length - 1);
+    onChange(next);
+  }
 
   // When ReactFlow removes edges (user clicks edge → Delete), sync children arrays in BT data.
   const handleEdgesChange = useCallback((changes: Parameters<typeof onEdgesChange>[0]) => {
@@ -250,6 +290,7 @@ export default function BehaviorTreeEditor({ bt, onChange }: Props) {
         nodes[source] = { ...nodes[source], children: nodes[source].children.filter(c => c !== target) };
       }
     }
+    pushToHistory({ ...cur, nodes });
     onChange({ ...cur, nodes });
   }, [onEdgesChange, onChange]);
 
@@ -270,6 +311,7 @@ export default function BehaviorTreeEditor({ bt, onChange }: Props) {
         [params.source]: { ...parentNode, children: [...parentNode.children, params.target] },
       },
     };
+    pushToHistory(updated);
     onChange(updated);
     setRfEdges(es => addEdge({ ...params, type: 'smoothstep', style: { stroke: '#4a5568', strokeWidth: 2 } }, es));
   }, [onChange]);
@@ -279,7 +321,9 @@ export default function BehaviorTreeEditor({ bt, onChange }: Props) {
     setRfNodes(laid);
     const positions: Record<string, { x: number; y: number }> = {};
     laid.forEach(n => { positions[n.id] = n.position; });
-    onChange({ ...btRef.current, positions });
+    const newBt = { ...btRef.current, positions };
+    pushToHistory(newBt);
+    onChange(newBt);
   }
 
   function validate(): string | null {
@@ -311,15 +355,17 @@ export default function BehaviorTreeEditor({ bt, onChange }: Props) {
     return dfs(cur.rootId);
   }
 
-  function addNode(type: BTNodeType) {
+  function addNodeAt(type: BTNodeType, position: { x: number; y: number }) {
     const id = `${type.toLowerCase()}_${uid()}`;
     const node: BTNode = { type, label: type, children: [], props: {} };
-    onChange({ ...btRef.current, nodes: { ...btRef.current.nodes, [id]: node } });
-    setRfNodes(ns => [...ns, {
-      id, type: 'btNode',
-      position: { x: 100 + Math.random() * 200, y: 100 + Math.random() * 200 },
-      data: { type, label: type, subtitle: '' },
-    }]);
+    const updated = { ...btRef.current, nodes: { ...btRef.current.nodes, [id]: node }, positions: { ...btRef.current.positions, [id]: position } };
+    pushToHistory(updated);
+    onChange(updated);
+    setRfNodes(ns => [...ns, { id, type: 'btNode', position, data: { type, label: type, subtitle: '' } }]);
+  }
+
+  function addNode(type: BTNodeType) {
+    addNodeAt(type, { x: 100 + Math.random() * 300, y: 100 + Math.random() * 300 });
   }
 
   function deleteSelectedNode() {
@@ -332,6 +378,7 @@ export default function BehaviorTreeEditor({ bt, onChange }: Props) {
     for (const n of Object.values(nodes)) {
       n.children = n.children.filter((c: string) => c !== selectedNodeId);
     }
+    pushToHistory({ ...cur, nodes });
     onChange({ ...cur, nodes });
     setRfNodes(ns => ns.filter(n => n.id !== selectedNodeId));
     setRfEdges(es => es.filter(e => e.source !== selectedNodeId && e.target !== selectedNodeId));
@@ -347,6 +394,7 @@ export default function BehaviorTreeEditor({ bt, onChange }: Props) {
       ...cur,
       nodes: { ...cur.nodes, [selectedNodeId]: { ...cur.nodes[selectedNodeId], ...patch } },
     };
+    pushToHistory(updated);
     onChange(updated);
     setRfNodes(ns => ns.map(n => n.id === selectedNodeId
       ? { ...n, data: { ...n.data, label: patch.label ?? n.data.label, subtitle: nodeSubtitle(updated.nodes[selectedNodeId]) } }
@@ -365,7 +413,9 @@ export default function BehaviorTreeEditor({ bt, onChange }: Props) {
     // Auto-generate a unique key name
     let n = cur.blackboard.length + 1;
     while (cur.blackboard.some(k => k.key === `key_${n}`)) n++;
-    onChange({ ...cur, blackboard: [...cur.blackboard, { key: `key_${n}`, type: 'bool', default: false }] });
+    const newBt = { ...cur, blackboard: [...cur.blackboard, { key: `key_${n}`, type: 'bool' as const, default: false }] };
+    pushToHistory(newBt);
+    onChange(newBt);
   }
 
   function updateBBKey(idx: number, patch: Partial<BBKey>) {
@@ -375,11 +425,15 @@ export default function BehaviorTreeEditor({ bt, onChange }: Props) {
       patch.default = patch.type === 'bool' ? false : patch.type === 'string' ? '' : 0;
     }
     bb[idx] = { ...bb[idx], ...patch };
-    onChange({ ...bt, blackboard: bb });
+    const newBt = { ...bt, blackboard: bb };
+    pushToHistory(newBt);
+    onChange(newBt);
   }
 
   function removeBBKey(idx: number) {
-    onChange({ ...bt, blackboard: bt.blackboard.filter((_, i) => i !== idx) });
+    const newBt = { ...bt, blackboard: bt.blackboard.filter((_, i) => i !== idx) };
+    pushToHistory(newBt);
+    onChange(newBt);
   }
 
   // How many Condition nodes reference a given blackboard key
@@ -407,7 +461,13 @@ export default function BehaviorTreeEditor({ bt, onChange }: Props) {
           <div key={group} style={{ marginBottom: 12 }}>
             <div style={{ color: '#4a5568', fontSize: 9, letterSpacing: 2, marginBottom: 4 }}>{group}</div>
             {types.map(t => (
-              <button key={t} onClick={() => addNode(t)}
+              <button key={t}
+                draggable
+                onDragStart={e => {
+                  e.dataTransfer.setData('application/bt-node-type', t);
+                  e.dataTransfer.effectAllowed = 'copy';
+                }}
+                onClick={() => addNode(t)}
                 style={{
                   display: 'block', width: '100%', marginBottom: 4, padding: '5px 8px',
                   background: '#161b22', border: `1px solid ${TYPE_COLOR[t]}44`,
@@ -427,6 +487,16 @@ export default function BehaviorTreeEditor({ bt, onChange }: Props) {
             style={{ display: 'block', width: '100%', padding: '5px 8px', background: '#161b22', border: '1px solid #2d3748', color: '#a0aec0', fontSize: 10, fontFamily: 'monospace', cursor: 'pointer', letterSpacing: 1, marginBottom: 4 }}>
             AUTO LAYOUT
           </button>
+          <div style={{ display: 'flex', gap: 4, marginBottom: 4 }}>
+            <button onClick={undo} disabled={!canUndo}
+              style={{ flex: 1, padding: '5px 4px', background: '#161b22', border: '1px solid #2d3748', color: canUndo ? '#a0aec0' : '#2d3748', fontSize: 10, fontFamily: 'monospace', cursor: canUndo ? 'pointer' : 'default', letterSpacing: 1 }}>
+              ↩ UNDO
+            </button>
+            <button onClick={redo} disabled={!canRedo}
+              style={{ flex: 1, padding: '5px 4px', background: '#161b22', border: '1px solid #2d3748', color: canRedo ? '#a0aec0' : '#2d3748', fontSize: 10, fontFamily: 'monospace', cursor: canRedo ? 'pointer' : 'default', letterSpacing: 1 }}>
+              ↪ REDO
+            </button>
+          </div>
           <button
             onClick={() => { const e = validate(); setValidateMsg(e ?? '✓ Valid'); }}
             style={{ display: 'block', width: '100%', padding: '5px 8px', background: '#161b22', border: '1px solid #2d3748', color: '#a0aec0', fontSize: 10, fontFamily: 'monospace', cursor: 'pointer', letterSpacing: 1 }}>
@@ -447,7 +517,19 @@ export default function BehaviorTreeEditor({ bt, onChange }: Props) {
       </div>
 
       {/* Canvas */}
-      <div style={{ flex: 1, position: 'relative' }}>
+      <div
+        ref={reactFlowWrapper}
+        style={{ flex: 1, position: 'relative' }}
+        onDragOver={e => { e.preventDefault(); e.dataTransfer.dropEffect = 'copy'; }}
+        onDrop={e => {
+          e.preventDefault();
+          const type = e.dataTransfer.getData('application/bt-node-type') as BTNodeType;
+          if (!type) return;
+          const bounds = reactFlowWrapper.current!.getBoundingClientRect();
+          const pos = rfInstance.project({ x: e.clientX - bounds.left, y: e.clientY - bounds.top });
+          addNodeAt(type, pos);
+        }}
+      >
         <ReactFlow
           nodes={rfNodes}
           edges={rfEdges}
@@ -483,15 +565,43 @@ export default function BehaviorTreeEditor({ bt, onChange }: Props) {
               </div>
             )}
 
-            {/* Child count for composites */}
-            {['Selector','Sequence','Parallel','RandomSelector'].includes(selectedNode.type) && (
-              <div style={{ color: '#718096', fontSize: 10, marginBottom: 8 }}>
-                {selectedNode.children.length} child{selectedNode.children.length !== 1 ? 'ren' : ''}
-                {selectedNode.children.length > 0 && (
-                  <span style={{ color: '#4a5568', marginLeft: 4 }}>
-                    [{selectedNode.children.map((c, i) => `${i+1}:${c}`).join(', ')}]
-                  </span>
-                )}
+            {/* Children ordered list for composites */}
+            {['Selector','Sequence','Parallel','RandomSelector'].includes(selectedNode.type) && selectedNode.children.length > 0 && (
+              <div style={{ marginBottom: 8 }}>
+                <div style={{ color: '#718096', fontSize: 10, letterSpacing: 1, marginBottom: 4 }}>
+                  CHILDREN ({selectedNode.children.length}) — order matters
+                </div>
+                {selectedNode.children.map((cid, i) => {
+                  const childNode = bt.nodes[cid];
+                  return (
+                    <div key={cid} style={{ display: 'flex', alignItems: 'center', gap: 4, marginBottom: 3 }}>
+                      <span style={{ color: '#4a5568', fontSize: 9, fontFamily: 'monospace', minWidth: 14 }}>{i + 1}.</span>
+                      <span style={{ flex: 1, color: '#a0aec0', fontSize: 10, fontFamily: 'monospace', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                        {childNode?.label ?? cid}
+                      </span>
+                      <button
+                        disabled={i === 0}
+                        onClick={() => {
+                          const kids = [...selectedNode.children];
+                          [kids[i - 1], kids[i]] = [kids[i], kids[i - 1]];
+                          updateSelectedNode({ children: kids });
+                        }}
+                        style={{ background: 'none', border: '1px solid #2d3748', color: i === 0 ? '#2d3748' : '#718096', fontSize: 10, cursor: i === 0 ? 'default' : 'pointer', padding: '1px 4px', lineHeight: 1, flexShrink: 0 }}>
+                        ↑
+                      </button>
+                      <button
+                        disabled={i === selectedNode.children.length - 1}
+                        onClick={() => {
+                          const kids = [...selectedNode.children];
+                          [kids[i], kids[i + 1]] = [kids[i + 1], kids[i]];
+                          updateSelectedNode({ children: kids });
+                        }}
+                        style={{ background: 'none', border: '1px solid #2d3748', color: i === selectedNode.children.length - 1 ? '#2d3748' : '#718096', fontSize: 10, cursor: i === selectedNode.children.length - 1 ? 'default' : 'pointer', padding: '1px 4px', lineHeight: 1, flexShrink: 0 }}>
+                        ↓
+                      </button>
+                    </div>
+                  );
+                })}
               </div>
             )}
 
@@ -505,7 +615,7 @@ export default function BehaviorTreeEditor({ bt, onChange }: Props) {
                 <select value={String(selectedNode.props.action ?? '')} onChange={e => updateProp('action', e.target.value)}
                   style={{ width: '100%', background: '#161b22', border: '1px solid #2d3748', color: '#e2e8f0', padding: '4px 6px', fontSize: 11, fontFamily: 'monospace', marginBottom: 8, boxSizing: 'border-box' }}>
                   <option value="">— select action —</option>
-                  {LEAF_ACTIONS.map(a => <option key={a} value={a}>{a}</option>)}
+                  {leafActions.map(a => <option key={a} value={a}>{a}</option>)}
                 </select>
 
                 {/* Generic extra props (all props except action) */}
@@ -560,6 +670,15 @@ export default function BehaviorTreeEditor({ bt, onChange }: Props) {
                             );
                           })}
                         </div>
+                        {Number(selectedNode.props.bank ?? 0) > 0 && (
+                          <div style={{ marginBottom: 8, textAlign: 'center' }}>
+                            <img
+                              src={`${API}/sprites/${selectedNode.props.bank}/0`}
+                              alt={`bank ${selectedNode.props.bank} frame 0`}
+                              style={{ maxWidth: '100%', imageRendering: 'pixelated', border: '1px solid #2d3748', background: '#161b22' }}
+                            />
+                          </div>
+                        )}
                       </>)}
 
                       {/* EmitSound knobs */}
@@ -717,12 +836,30 @@ export default function BehaviorTreeEditor({ bt, onChange }: Props) {
               </>
             )}
 
+            {selectedNode.type === 'Parallel' && (
+              <>
+                <label style={{ color: '#718096', fontSize: 10, display: 'block', marginBottom: 2 }}>
+                  THRESHOLD (children that must succeed; 0 = all)
+                </label>
+                <input type="number" value={Number(selectedNode.props.threshold ?? 0)} min={0} step={1}
+                  onChange={e => updateProp('threshold', parseInt(e.target.value))}
+                  style={{ width: '100%', background: '#161b22', border: '1px solid #2d3748', color: '#e2e8f0', padding: '4px 6px', fontSize: 11, fontFamily: 'monospace', marginBottom: 2, boxSizing: 'border-box' }} />
+                <div style={{ color: '#4a5568', fontSize: 9, marginBottom: 8 }}>
+                  0 means all {selectedNode.children.length} children must succeed
+                </div>
+              </>
+            )}
+
             <div style={{ color: '#4a5568', fontSize: 10, letterSpacing: 1, marginTop: 4 }}>
               ID: {selectedNodeId}
               {selectedNodeId === bt.rootId && <span style={{ color: '#f59e0b', marginLeft: 4 }}>(root)</span>}
             </div>
             {selectedNodeId !== bt.rootId && (
-              <button onClick={() => onChange({ ...btRef.current, rootId: selectedNodeId! })}
+              <button onClick={() => {
+                const newBt = { ...btRef.current, rootId: selectedNodeId! };
+                pushToHistory(newBt);
+                onChange(newBt);
+              }}
                 style={{ display: 'block', width: '100%', marginTop: 6, padding: '4px 8px', background: '#1c1400', border: '1px solid #78350f', color: '#f59e0b', fontSize: 10, fontFamily: 'monospace', cursor: 'pointer', letterSpacing: 1 }}>
                 ★ SET AS ROOT
               </button>

--- a/web/admin/app/behavior-trees/[id]/BehaviorTreeEditor.tsx
+++ b/web/admin/app/behavior-trees/[id]/BehaviorTreeEditor.tsx
@@ -540,7 +540,24 @@ function BehaviorTreeEditorInner({ bt, onChange }: Props) {
           onNodeClick={(_, n) => setSelectedNodeId(n.id)}
           onPaneClick={() => setSelectedNodeId(null)}
           onNodeDragStop={(_, n) => {
-            onChange({ ...btRef.current, positions: { ...btRef.current.positions, [n.id]: n.position } });
+            const cur = btRef.current;
+            const updatedPositions = { ...cur.positions, [n.id]: n.position };
+            // Re-sort parent's children by x position so dragging left/right changes execution order
+            const parentEntry = Object.entries(cur.nodes).find(([, node]) =>
+              ['Selector', 'Sequence', 'Parallel', 'RandomSelector'].includes(node.type) && node.children.includes(n.id)
+            );
+            let updatedNodes = cur.nodes;
+            if (parentEntry) {
+              const [parentId, parent] = parentEntry;
+              const getX = (id: string) => {
+                const pos = updatedPositions[id] ?? rfNodes.find(rn => rn.id === id)?.position;
+                return pos?.x ?? 0;
+              };
+              const sortedChildren = [...parent.children].sort((a, b) => getX(a) - getX(b));
+              updatedNodes = { ...cur.nodes, [parentId]: { ...parent, children: sortedChildren } };
+            }
+            pushToHistory({ ...cur, nodes: updatedNodes, positions: updatedPositions });
+            onChange({ ...cur, nodes: updatedNodes, positions: updatedPositions });
           }}
           fitView
         >

--- a/web/admin/app/behavior-trees/[id]/page.tsx
+++ b/web/admin/app/behavior-trees/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { useEffect, useState } from 'react';
-import { useParams } from 'next/navigation';
+import { useParams, useRouter } from 'next/navigation';
 import dynamic from 'next/dynamic';
 import { useAuth } from '../../../lib/auth';
 import { useWsConnected } from '../../../lib/socket';
@@ -15,6 +15,7 @@ export default function BehaviorTreePage() {
   useAuth();
   const wsConnected = useWsConnected();
   const { id } = useParams<{ id: string }>();
+  const router = useRouter();
   const [bt, setBt] = useState<BehaviorTree | null>(null);
   const [dirty, setDirty] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -50,6 +51,25 @@ export default function BehaviorTreePage() {
     }
   }
 
+  function handleNewTree() {
+    const name = window.prompt('New behavior tree name (no spaces, no .json):');
+    if (!name || !name.trim()) return;
+    const newId = name.trim().replace(/[^a-z0-9_-]/gi, '_').toLowerCase();
+    const rootId = 'root_selector';
+    const newBt: BehaviorTree = {
+      version: 1,
+      id: newId,
+      rootId,
+      nodes: {
+        [rootId]: { type: 'Selector', label: 'Root', children: [], props: {} },
+      },
+      blackboard: [],
+      positions: { [rootId]: { x: 400, y: 200 } },
+    };
+    writeToStore(newId, newBt);
+    router.push(`/behavior-trees/${newId}`);
+  }
+
   return (
     <div className="flex min-h-screen bg-game-bg text-game-text">
       <Sidebar wsConnected={wsConnected} />
@@ -67,6 +87,18 @@ export default function BehaviorTreePage() {
           <div style={{ flex: 1 }} />
           {error && <span style={{ color: '#f87171', fontSize: 11 }}>{error}</span>}
           {dirty && <span style={{ color: '#f59e0b', fontSize: 11 }}>● unsaved</span>}
+          {folderName && (
+            <button
+              onClick={handleNewTree}
+              style={{
+                padding: '6px 14px', background: '#161b22', border: '1px solid #4a5568',
+                color: '#a0aec0', fontFamily: 'monospace', fontSize: 12,
+                letterSpacing: 2, cursor: 'pointer',
+              }}
+            >
+              + NEW TREE
+            </button>
+          )}
           <button
             onClick={handleSave}
             disabled={saving || !dirty}

--- a/web/admin/components/Sidebar.tsx
+++ b/web/admin/components/Sidebar.tsx
@@ -42,7 +42,7 @@ export default function Sidebar({ wsConnected }: Props) {
   const visibleNav = NAV.filter(n => rank >= n.minRank);
 
   return (
-    <aside className="w-56 min-h-screen bg-game-bgCard border-r border-game-border flex flex-col">
+    <aside className="w-56 sticky top-0 h-screen bg-game-bgCard border-r border-game-border flex flex-col flex-shrink-0 overflow-y-auto">
       {/* Logo */}
       <div className="px-4 py-5 border-b border-game-border">
         <img src="/logo.png" alt="Silencer" className="h-10 w-auto mb-1" />


### PR DESCRIPTION
Closes #161

## What this PR does

Started as a leaf-props hydration bug fix. Expanded into making the BT designer the primary tool for authoring NPC AI behaviors without touching C++.

### Bug fix
- Corrected `LEAF_ACTIONS` to real C++ registered names — this was the actual root cause of blank ACTION dropdowns on load
- Edge deletion in ReactFlow now syncs `children` arrays in BT data
- Condition subtitle no longer shows `undefined`

### Generic data-driven leaf nodes (guard + civilian + robot)
`SetBlackboard`, `RandomChance`, `PlayAnim`, `EmitSound`, `SetFacing` — configured entirely from BT JSON props, no C++ changes needed to use them.

### `ctx.props` wired into C++ leaf dispatch
`tickLeaf` sets `ctx.props` before calling the handler. Civilian Run/Wander use this for `speedBonus`/`speed` props → blackboard → applied each tick.

### BT Editor UX
- Drag-drop palette → canvas; drag child left/right to reorder
- Edge labels update after reorder
- Minimap, duplicate node, undo/redo (50-entry, Ctrl+Z/Y, canvas resyncs)
- Connection guards (Leaf/Condition/Wait can't be sources)
- Ordered child inspector with ↑↓, ACTION descriptions, Condition op filter
- NPC-specific action lists; PlayAnim bank thumbnail; EmitSound catalog dropdown
- Parallel threshold knob; + NEW TREE toolbar button

### C++ fixes
- Guard patrol look animation plays to completion (returns Running in LOOKING state)
- Admin sidebar sticky so logout is always visible

## Testing
- Load `guard.json`, `civilian.json`, `robot.json` — all leaf ACTION dropdowns pre-selected
- Drag nodes, reorder children, undo/redo, save — roundtrips correctly
- Cloudflare preview: https://feat-issue-161-bt-editor-fixes-silencer-website.hvent90.workers.dev

## Follow-on
See #165 for remaining gaps (SpawnProjectile leaf, game-state → blackboard writes, SetSpeed for guard/robot, per-variant tree selection).