### PR TITLE
chore: add repo-level line-ending policy via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,25 @@
+# Repo-level line-ending policy.
+#
+# Normalize all text to LF in the repository and let Git pick the
+# working-tree ending per platform, except where a tool requires a
+# specific ending regardless of platform.
+* text=auto
+
+# Shell / Bash scripts must be LF everywhere. CRLF breaks them on
+# every platform (bad interpreter, `\r` in arguments), including
+# Windows checkouts with core.autocrlf=true.
+*.sh   text eol=lf
+*.bash text eol=lf
+
+# Windows command scripts must stay CRLF.
+*.bat text eol=crlf
+*.cmd text eol=crlf
+
+# Binary assets — never run EOL conversion or diff as text.
+*.png  binary
+*.jpg  binary
+*.jpeg binary
+*.gif  binary
+*.ico  binary
+*.wav  binary
+*.mp3  binary


### PR DESCRIPTION
## What

Adds a root `.gitattributes` that codifies a repo-wide line-ending policy.

| Pattern | Rule | Why |
|---|---|---|
| `* text=auto` | normalize text to LF in-repo | consistent blobs across OSes |
| `*.sh` / `*.bash` | `text eol=lf` | shell scripts break with CRLF on **every** platform |
| `*.bat` / `*.cmd` | `text eol=crlf` | Windows command scripts expect CRLF |
| `*.png *.jpg *.jpeg *.gif *.ico *.wav *.mp3` | `binary` | never run EOL conversion / text diff |

## Why

The repo had **no `.gitattributes`**. On Windows with `core.autocrlf=true` (the default many contributors have), every tracked shell script was silently checked out as **CRLF** — verified on a fresh `origin/main` checkout, all 13 `.sh` files came out CRLF. CRLF in a shell script causes `bad interpreter` errors and stray `\r` in arguments. This change forces LF on checkout regardless of platform/config.

## Scope / safety

- All 13 tracked `.sh` blobs were **already LF** on `origin/main`, so `git add --renormalize '*.sh'` produced **zero in-repo content changes**. The only change is the new `.gitattributes`.
- `git diff --check` clean.
- Verified `tests/cli-agent/e2e/lib.sh` is LF in both the staged blob and the working tree after the policy applies.
- Branched off `origin/main`; no unrelated changes included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)