### PR TITLE
build: canonical build wrapper (build.ps1 / build.sh), CLAUDE.md mandate + slim

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,13 @@ __pycache__/
 # Git worktrees (claude-code superpowers)
 .worktrees/
 
+# Per-developer JetBrains IDE state (CLion/IntelliJ). Config is local-only;
+# clients/silencer/CMakePresets.json is the shared, OS-agnostic build
+# contract. cmake-build-*/ is CLion's ad-hoc profile output — we drive
+# builds through the CMakePresets.json profiles instead.
+.idea/
+cmake-build-*/
+
 # Per-developer Claude Code harness state. Skills live in shared/skills/
 # and are wired in via symlink (e.g. .claude/skills/using-silencer-cli ->
 # ../../shared/skills/cli).

--- a/clients/silencer/CLAUDE.md
+++ b/clients/silencer/CLAUDE.md
@@ -4,10 +4,29 @@ Multiplayer 2D action game (SDL3/C++14). The same binary runs as the
 local client and, when launched with `-s`, as a headless dedicated
 server spawned by the Go lobby in `services/lobby/`.
 
-Build with the local `CMakeLists.txt` (`cmake -B build && cmake --build build`)
-— see top-level `README.md` for platform notes and the
-`-DSILENCER_LOBBY_*` knobs in *Gotchas* below. Source layout under
-`src/` is flat: ~158 files, `.cpp` paired with `.h`, no subdirectories.
+## Building
+
+Build/configure the client **only** through the wrapper — never invoke
+`cmake`/`cl`/`ninja` directly, and never use CLion's bundled MinGW
+(this codebase is MSVC-only; MinGW cannot link it):
+
+- Windows: `clients/silencer/build.ps1 [win-ninja|win-ninja-release|win-ninja-unity]`
+- macOS/Linux: `clients/silencer/build.sh [win-ninja|win-ninja-release|win-ninja-unity]`
+
+Default preset is `win-ninja` (Debug → `build/`). Pass `-Clean`
+(`--clean` on `.sh`) to wipe the CMake cache (keeps `vcpkg_installed`)
+— the correct recovery from a poisoned cache; do not hand-roll
+`rm`/reconfigure loops. The wrapper pins the newest installed Visual
+Studio via `vswhere`, resolves `VCPKG_ROOT` (process env → persisted
+User env → hard error), refuses to run under a concurrent build or a
+running `Silencer` (which locks the link target), and takes a build
+lock so CLion / CLI agents / parallel agents can't corrupt the shared
+CMake cache by configuring concurrently. Idle CLion is fine; don't run
+an IDE build concurrently with a wrapper build into the same dir.
+Lobby host/version are compile-time `-D` knobs (see *Gotchas*).
+
+Source layout under `src/` is flat: ~158 files, `.cpp` paired with
+`.h`, no subdirectories.
 
 ## Object hierarchy
 

--- a/clients/silencer/CLAUDE.md
+++ b/clients/silencer/CLAUDE.md
@@ -6,35 +6,26 @@ server spawned by the Go lobby in `services/lobby/`.
 
 ## Building
 
-Build/configure the client **only** through the wrapper — never invoke
-`cmake`/`cl`/`ninja` directly, and never use CLion's bundled MinGW
-(this codebase is MSVC-only; MinGW cannot link it):
+Build/configure **only** through the wrapper — never raw
+`cmake`/`cl`/`ninja`, never CLion's bundled MinGW (MSVC-only
+codebase; MinGW cannot link it):
 
-- Windows: `clients/silencer/build.ps1 [win-ninja|win-ninja-release|win-ninja-unity]`
-- macOS/Linux: `clients/silencer/build.sh [win-ninja|win-ninja-release|win-ninja-unity]`
+- Windows: `clients/silencer/build.ps1 [preset] [-Clean]`
+- macOS/Linux: `clients/silencer/build.sh [preset] [--clean]`
 
-Default preset is `win-ninja` (Debug → `build/`). Pass `-Clean`
-(`--clean` on `.sh`) to wipe the CMake cache (keeps `vcpkg_installed`)
-— the correct recovery from a poisoned cache; do not hand-roll
-`rm`/reconfigure loops. The wrapper pins the newest installed Visual
-Studio via `vswhere`, resolves `VCPKG_ROOT` (process env → persisted
-User env → hard error), refuses to run under a concurrent build or a
-running `Silencer` (which locks the link target), and takes a build
-lock so CLion / CLI agents / parallel agents can't corrupt the shared
-CMake cache by configuring concurrently. Idle CLion is fine; don't run
-an IDE build concurrently with a wrapper build into the same dir.
-Lobby host/version are compile-time `-D` knobs (see *Gotchas*).
-
-Source layout under `src/` is flat: ~158 files, `.cpp` paired with
-`.h`, no subdirectories.
+Default preset `win-ninja` → Debug → `build/`. `-Clean` is the cache-
+poisoning recovery (don't hand-roll `rm`/reconfigure). Presets,
+compile-time lobby/version knobs, vcpkg deps, per-platform artifacts,
+and what the wrapper enforces:
+[`../../docs/silencer-client-build.md`](../../docs/silencer-client-build.md).
 
 ## Object hierarchy
 
 `Object` is mixin multiple inheritance of five bases — `Sprite`,
 `Physical`, `Hittable`, `Bipedal`, `Projectile` (`object.h:14`).
-41 leaf classes inherit directly from `Object` (actors,
-projectiles, stations, UI widgets); two-deep tree, no further
-subclassing. Full breakdown in
+Leaf classes inherit directly from `Object` (actors, projectiles,
+stations, UI widgets) in a two-deep tree, no further subclassing.
+Full breakdown in
 [`../../docs/silencer-client-architecture.md`](../../docs/silencer-client-architecture.md).
 
 Type registry / factory: `objecttypes.cpp`. Live objects replicate
@@ -66,56 +57,15 @@ silencer -s <lobbyaddr> <lobbyport> <gameid> <accountid>
 - Heartbeats UDP to the lobby: `[0x00][gameid u32][port u16][state u8]`.
   No heartbeat in 30 s → lobby aborts the create.
 
-## Actor definition system (`actordef.h` / `actordef.cpp`)
+## Data-driven NPCs (actordefs + behavior trees)
 
-Actordefs are JSON files in `shared/assets/actordefs/<id>.json`. They
-define per-NPC animation sequences, per-frame hurtboxes, and per-frame
-sounds — everything that used to be hardcoded in the NPC `.cpp` files.
-
-**Key types:**
-- `FrameDef` — one sprite frame: `bank`, `index`, `duration` (ticks),
-  `hurtbox` (`x1/y1/x2/y2` relative to feet), `sound` (filename), `soundVolume`
-  (0 = default 128).
-- `AnimSequence` — ordered list of `FrameDef`s + `loop` flag.
-- `ActorDef` — keyed map of sequence name → `AnimSequence`.
-
-**Playing sounds from actordefs** — two helpers on `AnimSequence`:
-- `GetFrameSound(state_i, …)` — use when the state machine accumulates
-  ticks (correct for tick-duration-based states).
-- `GetFrameSoundByIndex(frameIdx, …)` — use when `res_index = state_i % N`
-  (sprite frame index driven, not tick-accumulated). Guards and civilians use
-  this path.
-
-**Client reload** — `LoadActorDefs()` in `actordef.cpp` reads all `*.json`
-files via `GLOB_RECURSE`. It is called on each map load (async fetch from the
-admin API via `adminapiurl`). Adding or removing actordef files requires
-`cmake -B build -S .` to regenerate the file list.
-
-**Per-weapon guard actordefs** — `guard-blaster.json`, `guard-laser.json`,
-`guard-rocket.json` replace the old single `guard.json`. `ActorDefName(weapon)`
-in `guard.cpp` maps weapon integer (0/1/2/3) to the correct file name.
-
-## Behavior tree system (`behaviortree.h` / `behaviortree.cpp`)
-
-Tick-based interpreter. Trees are loaded from
-`shared/assets/behaviortrees/<id>.json` and shared across all instances of
-a given NPC type. Per-instance state lives in `BTContext`.
-
-**Node types:** `Selector`, `Sequence`, `Parallel`, `RandomSelector`,
-`Inverter`, `Cooldown`, `Repeat`, `Timeout`, `ForceSuccess`, `Wait`,
-`Leaf` (dispatches to a named C++ lambda), `Condition` (compares a
-blackboard key to a literal value).
-
-**Blackboard** — `unordered_map<string, json>` on `BTContext`. Leaf
-lambdas read/write it via `ctx.bb<T>(key, default)` / `ctx.bbSet(key, val)`.
-
-**Wiring an NPC:**
-1. Create `shared/assets/behaviortrees/<npc>.json` (edit in the admin BT editor).
-2. In the NPC's `.cpp` constructor, call `bt_.Load("npc_id")` and register
-   action lambdas with `bt_.Register("ActionName", [](BTContext& ctx) { … })`.
-3. In the tick function, call `bt_.Tick(ctx_)` once per frame.
-
-**Currently wired:** `guard.cpp`, `robot.cpp`, `civilian.cpp`.
+NPC animation/hurtbox/sound (`actordef.{h,cpp}`,
+`shared/assets/actordefs/`) and AI (`behaviortree.{h,cpp}`,
+`shared/assets/behaviortrees/`) are JSON-driven, hot-fetched from the
+admin API on each map load and edited in the admin BT editor.
+`guard.cpp`, `robot.cpp`, `civilian.cpp` are currently wired. Type/
+field reference, the two sound-helper variants, and NPC-wiring steps:
+[`../../docs/silencer-client-architecture.md`](../../docs/silencer-client-architecture.md).
 
 ## Where to look
 
@@ -141,17 +91,6 @@ lambdas read/write it via `ctx.bb<T>(key, default)` / `ctx.bbSet(key, val)`.
 - Stations: `src/healmachine.cpp`, `src/creditmachine.cpp`,
   `src/inventorystation.cpp`, `src/techstation.cpp`, `src/walldefense.cpp`,
   `src/fixedcannon.cpp`, `src/terminal.cpp`.
-
-## Build artifacts
-
-- Linux: binary `silencer` (lowercase, GNU convention).
-- macOS: `Silencer.app` bundle (`MACOSX_BUNDLE`); runtime asset path
-  inside the bundle is `Contents/assets/` (loaded via `src/main.cpp`
-  `CDResDir`). The Xcode project was retired — CMake `MACOSX_BUNDLE`
-  is the only macOS build path.
-- Windows: `Silencer.exe`. Runtime expects `assets\` next to the
-  exe (`src/os.cpp` `GetResDir`). Resources / icon are wired through
-  `resources.rc` (auto-included on Windows builds).
 
 ## CLI agent control
 
@@ -199,15 +138,10 @@ usage patterns.
 
 ## Gotchas
 
-- **Lobby host is a compile-time constant.** Baked in via
-  `-DSILENCER_LOBBY_HOST=<host> -DSILENCER_LOBBY_PORT=<port>`. Default is
-  `127.0.0.1:517`. CI sets it to `lobby.arsiamons.com`. Rebuild
-  the client to point at a different lobby.
-- **Version string must match the lobby.** Set via
-  `-DSILENCER_VERSION=...` (default in `CMakeLists.txt`); the lobby's
-  `-version` flag defaults to the same. Bump both together.
-  `CPACK_PACKAGE_VERSION` is installer metadata only — unrelated to
-  the wire handshake.
+- **Build-time config is baked at configure.** Lobby host/port and
+  the wire-handshake version string are compile-time knobs (default
+  local lobby; version must match the lobby or the handshake fails) —
+  see [`../../docs/silencer-client-build.md`](../../docs/silencer-client-build.md).
 - **macOS data dir.** Client `chdir`s to
   `~/Library/Application Support/Silencer` at startup
   (`src/main.cpp` `CDDataDir`) — copy `../../shared/assets/` contents
@@ -218,10 +152,6 @@ usage patterns.
 - **Android/Ouya code paths exist** in `src/main.cpp` but are not
   actively maintained; don't rely on them. JNI symbols use the
   `com.silencer.game.Silencer` package convention.
-- **`libmodplug` removed from vcpkg.json.** `sdl3-mixer` no longer
-  builds with the MOD/XM/IT music plugin — the game uses IMA ADPCM
-  (`sound.bin`) and MP3 (`CLOSER2.mp3`) only. This cuts build time and
-  removes an unused dependency.
 - **`adminapiurl` config key** (`src/config.h`) — URL the client fetches
   actordefs and behavior trees from on each map load. Defaults to
   `http://localhost:24000/api` for local dev; set it to the production

--- a/clients/silencer/build.ps1
+++ b/clients/silencer/build.ps1
@@ -1,0 +1,102 @@
+#!/usr/bin/env pwsh
+# Canonical Silencer client build entry point (Windows).
+#
+# All agents and humans build/configure the client ONLY through this
+# script. It pins the newest installed Visual Studio (this codebase is
+# MSVC-only — CLion's bundled MinGW cannot link it), resolves
+# VCPKG_ROOT, and serializes against concurrent builds so CLion, CLI
+# agents, and parallel agents can't corrupt the shared CMake cache.
+#
+# Usage:  ./build.ps1 [win-ninja|win-ninja-release|win-ninja-unity] [-Clean]
+#   default preset : win-ninja (Debug)
+#   -Clean         : wipe CMakeCache.txt + CMakeFiles (keep vcpkg_installed) first
+
+[CmdletBinding()]
+param(
+    [ValidateSet('win-ninja', 'win-ninja-release', 'win-ninja-unity')]
+    [string]$Preset = 'win-ninja',
+    [switch]$Clean
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+function Fail($msg) { Write-Host "build.ps1: $msg" -ForegroundColor Red; exit 1 }
+
+$silencerDir = $PSScriptRoot
+$binaryDir = switch ($Preset) {
+    'win-ninja'         { Join-Path $silencerDir 'build' }
+    'win-ninja-release' { Join-Path $silencerDir 'build-release' }
+    'win-ninja-unity'   { Join-Path $silencerDir 'build-unity' }
+}
+
+# --- Resolve Visual Studio: newest install with the C++ x64 toolset ---
+$vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
+if (-not (Test-Path $vswhere)) { Fail "vswhere.exe not found at $vswhere — install Visual Studio (2022 BuildTools or newer)." }
+$vsPath = (& $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath | Select-Object -First 1)
+if (-not $vsPath) { Fail "No Visual Studio install with the C++ x64 toolset found (vswhere)." }
+$vcvars = Join-Path $vsPath 'VC\Auxiliary\Build\vcvars64.bat'
+if (-not (Test-Path $vcvars)) { Fail "vcvars64.bat not found under $vsPath." }
+
+# --- Resolve VCPKG_ROOT: process env -> persisted User env -> error ---
+$vcpkgRoot = $env:VCPKG_ROOT
+if (-not $vcpkgRoot) { $vcpkgRoot = [Environment]::GetEnvironmentVariable('VCPKG_ROOT', 'User') }
+if (-not $vcpkgRoot -or -not (Test-Path (Join-Path $vcpkgRoot 'scripts\buildsystems\vcpkg.cmake'))) {
+    Fail "VCPKG_ROOT is not set or invalid. Set it persistently, then reopen your shell:`n  [Environment]::SetEnvironmentVariable('VCPKG_ROOT','<path-to-vcpkg>','User')"
+}
+
+# --- Abort if a build is actively running (idle CLion is fine; only a
+#     live configure/compile corrupts the shared cache) ---
+$busy = Get-Process -Name 'cmake', 'ninja', 'cl', 'MSBuild' -ErrorAction SilentlyContinue
+if ($busy) {
+    Fail ("a build is already running (" + (($busy | ForEach-Object Name | Sort-Object -Unique) -join ', ') + ") — wait for it to finish; concurrent configures corrupt the CMake cache.")
+}
+
+# --- Refuse if a previously-built instance is running: it locks the
+#     link target, so a full compile would die at a cryptic LNK1168 ---
+$running = @(Get-Process -Name 'Silencer' -ErrorAction SilentlyContinue |
+    Where-Object { $_.Path -eq (Join-Path $binaryDir 'Silencer.exe') })
+if ($running) {
+    Fail ("Silencer.exe from $binaryDir is running (PID " + (($running | ForEach-Object Id) -join ', ') + ") — it locks the link target. Stop that instance, then rebuild.")
+}
+
+# --- Cooperative build lock (atomic create; reclaim if owner is dead) ---
+New-Item -ItemType Directory -Force -Path $binaryDir | Out-Null
+$lockFile = Join-Path $binaryDir '.silencer-build.lock'
+$lockStream = $null
+$code = 1
+try {
+    try {
+        $lockStream = [System.IO.File]::Open($lockFile, [System.IO.FileMode]::CreateNew, [System.IO.FileAccess]::Write, [System.IO.FileShare]::None)
+    } catch [System.IO.IOException] {
+        $owner = Get-Content $lockFile -ErrorAction SilentlyContinue | Select-Object -First 1
+        if ($owner -and (Get-Process -Id ([int]$owner) -ErrorAction SilentlyContinue)) {
+            Fail "another build holds the lock (PID $owner) on $binaryDir — wait for it to finish."
+        }
+        Write-Host "build.ps1: stale lock from dead PID $owner — reclaiming." -ForegroundColor Yellow
+        Remove-Item $lockFile -Force
+        $lockStream = [System.IO.File]::Open($lockFile, [System.IO.FileMode]::CreateNew, [System.IO.FileAccess]::Write, [System.IO.FileShare]::None)
+    }
+    $writer = New-Object System.IO.StreamWriter($lockStream)
+    $writer.WriteLine($PID); $writer.WriteLine((Get-Date -Format o)); $writer.Flush()
+
+    if ($Clean) {
+        Write-Host "build.ps1: cleaning cache in $binaryDir (keeping vcpkg_installed)" -ForegroundColor Cyan
+        Remove-Item (Join-Path $binaryDir 'CMakeCache.txt') -Force -ErrorAction SilentlyContinue
+        Remove-Item (Join-Path $binaryDir 'CMakeFiles') -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    Write-Host "build.ps1: VS         = $vsPath" -ForegroundColor DarkGray
+    Write-Host "build.ps1: VCPKG_ROOT = $vcpkgRoot" -ForegroundColor DarkGray
+    Write-Host "build.ps1: $Preset -> $binaryDir" -ForegroundColor DarkGray
+    $inner = 'call "{0}" >nul && set "VCPKG_ROOT={1}" && cd /d "{2}" && cmake --preset {3} && cmake --build --preset {3}' -f $vcvars, $vcpkgRoot, $silencerDir, $Preset
+    & cmd /c $inner
+    $code = $LASTEXITCODE
+}
+finally {
+    if ($lockStream) { $lockStream.Close() }
+    Remove-Item $lockFile -Force -ErrorAction SilentlyContinue
+}
+
+if ($code -ne 0) { Fail "build failed (exit $code)." }
+Write-Host "build.ps1: OK ($Preset)" -ForegroundColor Green

--- a/clients/silencer/build.sh
+++ b/clients/silencer/build.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Canonical Silencer client build entry point (macOS/Linux).
+#
+# Mirror of build.ps1: all agents and humans build/configure the client
+# ONLY through this script. It resolves VCPKG_ROOT and serializes
+# against concurrent builds so parallel agents / an IDE can't corrupt
+# the shared CMake cache by configuring at the same time.
+#
+# Usage:  ./build.sh [win-ninja|win-ninja-release|win-ninja-unity] [--clean]
+#   default preset : win-ninja (Debug)
+#   --clean        : wipe CMakeCache.txt + CMakeFiles (keep vcpkg_installed) first
+set -euo pipefail
+
+fail() { echo "build.sh: $*" >&2; exit 1; }
+
+preset="win-ninja"
+if [ "${1:-}" ] && [ "${1#-}" = "${1:-}" ]; then preset="$1"; fi
+clean=0
+for a in "$@"; do [ "$a" = "--clean" ] && clean=1; done
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+case "$preset" in
+    win-ninja)         bdir="$script_dir/build";         btype=Debug;   unity=OFF ;;
+    win-ninja-release) bdir="$script_dir/build-release"; btype=Release; unity=OFF ;;
+    win-ninja-unity)   bdir="$script_dir/build-unity";   btype=Release; unity=ON  ;;
+    *) fail "unknown preset '$preset' (use win-ninja | win-ninja-release | win-ninja-unity)" ;;
+esac
+
+# --- VCPKG_ROOT (exported in your shell profile on macOS/Linux) ---
+: "${VCPKG_ROOT:?build.sh: VCPKG_ROOT is not set — export it to your vcpkg checkout}"
+[ -f "$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" ] \
+    || fail "VCPKG_ROOT=$VCPKG_ROOT has no scripts/buildsystems/vcpkg.cmake"
+
+# --- Abort if a build is actively running (idle IDE is fine) ---
+for p in cmake ninja cc1plus clang; do
+    if pgrep -x "$p" >/dev/null 2>&1; then
+        fail "a build is already running ($p) — wait for it to finish; concurrent configures corrupt the CMake cache"
+    fi
+done
+
+# --- Refuse if a previously-built instance is running (locks the link target) ---
+if pgrep -f "$bdir/.*[Ss]ilencer" >/dev/null 2>&1; then
+    fail "a built Silencer instance from $bdir is running — it locks the link target; stop it, then rebuild"
+fi
+
+# --- Cooperative build lock (mkdir is atomic on POSIX) ---
+mkdir -p "$bdir"
+lock="$bdir/.silencer-build.lock"
+if ! mkdir "$lock" 2>/dev/null; then
+    owner="$(cat "$lock/pid" 2>/dev/null || true)"
+    if [ -n "$owner" ] && kill -0 "$owner" 2>/dev/null; then
+        fail "another build holds the lock (PID $owner) on $bdir — wait for it to finish"
+    fi
+    echo "build.sh: stale lock (PID ${owner:-?}) — reclaiming" >&2
+    rm -rf "$lock"; mkdir "$lock"
+fi
+echo "$$" > "$lock/pid"
+trap 'rm -rf "$lock"' EXIT
+
+if [ "$clean" = 1 ]; then
+    echo "build.sh: cleaning cache in $bdir (keeping vcpkg_installed)"
+    rm -f "$bdir/CMakeCache.txt"
+    rm -rf "$bdir/CMakeFiles"
+fi
+
+gen=()
+command -v ninja >/dev/null 2>&1 && gen=(-G Ninja)
+
+echo "build.sh: VCPKG_ROOT = $VCPKG_ROOT"
+echo "build.sh: $preset -> $bdir"
+cmake -S "$script_dir" -B "$bdir" "${gen[@]}" \
+    -DCMAKE_BUILD_TYPE="$btype" \
+    -DSILENCER_UNITY_BUILD="$unity" \
+    -DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake"
+cmake --build "$bdir"
+echo "build.sh: OK ($preset)"

--- a/docs/silencer-client-architecture.md
+++ b/docs/silencer-client-architecture.md
@@ -150,3 +150,61 @@ only non-`Object` inheritance edge in the codebase).
 | Top-level | `game.{h,cpp}`, `main.cpp` |
 | Third-party (vendored) | `zlib/` |
 
+## Actor definition system (`actordef.{h,cpp}`)
+
+Actordefs are JSON files in `shared/assets/actordefs/<id>.json`. They
+define per-NPC animation sequences, per-frame hurtboxes, and per-frame
+sounds — everything that used to be hardcoded in the NPC `.cpp` files.
+
+**Key types** (authoritative in `actordef.h`):
+- `FrameDef` — one sprite frame: `bank`, `index`, `duration` (ticks),
+  `hurtbox` (`x1/y1/x2/y2` relative to feet), `sound` (filename),
+  `soundVolume` (0 = default 128).
+- `AnimSequence` — ordered list of `FrameDef`s + `loop` flag.
+- `ActorDef` — keyed map of sequence name → `AnimSequence`.
+
+**Playing sounds from actordefs** — two helpers on `AnimSequence`:
+- `GetFrameSound(state_i, …)` — use when the state machine accumulates
+  ticks (correct for tick-duration-based states).
+- `GetFrameSoundByIndex(frameIdx, …)` — use when
+  `res_index = state_i % N` (sprite frame index driven, not
+  tick-accumulated). Guards and civilians use this path.
+
+**Client reload** — `LoadActorDefs()` in `actordef.cpp` reads all
+`*.json` files via `GLOB_RECURSE`, called on each map load (async
+fetch from the admin API via `adminapiurl`). Adding or removing
+actordef files requires re-running the build wrapper so the GLOB file
+list regenerates.
+
+**Per-weapon guard actordefs** — `guard-blaster.json`,
+`guard-laser.json`, `guard-rocket.json` replace the old single
+`guard.json`. `ActorDefName(weapon)` in `guard.cpp` maps the weapon
+integer (0/1/2/3) to the correct file name.
+
+## Behavior tree system (`behaviortree.{h,cpp}`)
+
+Tick-based interpreter. Trees are loaded from
+`shared/assets/behaviortrees/<id>.json` and shared across all
+instances of a given NPC type. Per-instance state lives in
+`BTContext`.
+
+**Node types** (authoritative list in `behaviortree.cpp`):
+`Selector`, `Sequence`, `Parallel`, `RandomSelector`, `Inverter`,
+`Cooldown`, `Repeat`, `Timeout`, `ForceSuccess`, `Wait`, `Leaf`
+(dispatches to a named C++ lambda), `Condition` (compares a
+blackboard key to a literal value).
+
+**Blackboard** — `unordered_map<string, json>` on `BTContext`. Leaf
+lambdas read/write it via `ctx.bb<T>(key, default)` /
+`ctx.bbSet(key, val)`.
+
+**Wiring an NPC:**
+1. Create `shared/assets/behaviortrees/<npc>.json` (edit in the admin
+   BT editor).
+2. In the NPC's `.cpp` constructor, call `bt_.Load("npc_id")` and
+   register action lambdas with
+   `bt_.Register("ActionName", [](BTContext& ctx) { … })`.
+3. In the tick function, call `bt_.Tick(ctx_)` once per frame.
+
+**Currently wired:** `guard.cpp`, `robot.cpp`, `civilian.cpp`.
+

--- a/docs/silencer-client-build.md
+++ b/docs/silencer-client-build.md
@@ -1,0 +1,88 @@
+# Silencer Client — Building
+
+Reference for building `clients/silencer/`. The one rule that belongs
+in CLAUDE.md: **build/configure only through the wrapper, never raw
+`cmake`/`cl`/`ninja`, never CLion's bundled MinGW** (MSVC-only
+codebase — MinGW cannot link it). Everything below is on-demand
+detail.
+
+## Commands
+
+```
+# Windows
+clients/silencer/build.ps1 [preset] [-Clean]
+# macOS / Linux
+clients/silencer/build.sh  [preset] [--clean]
+```
+
+`-Clean` / `--clean` wipes `CMakeCache.txt` + `CMakeFiles` (keeps
+`vcpkg_installed`) before configuring — the correct recovery from a
+poisoned cache. Don't hand-roll `rm`/reconfigure loops.
+
+## Presets
+
+| Preset | Build type | Dir | Notes |
+|--------|-----------|-----|-------|
+| `win-ninja` (default) | Debug | `build/` | day-to-day |
+| `win-ninja-release` | Release | `build-release/` | |
+| `win-ninja-unity` | Release + `SILENCER_UNITY_BUILD=ON` | `build-unity/` | fastest clean build |
+
+Names are shared across platforms even though `win-` is a misnomer
+off Windows. On Windows the preset is a real `CMakePresets.json`
+entry (Ninja generator, `x64-windows` triplet, vcpkg toolchain); the
+presets carry a `hostSystemName == Windows` condition, so `build.sh`
+does **not** use them — it maps the preset name to
+`-DCMAKE_BUILD_TYPE` / `-DSILENCER_UNITY_BUILD` and invokes `cmake`
+directly with `-G Ninja` (if `ninja` is on `PATH`).
+
+## What the wrapper enforces
+
+- **Visual Studio (Windows only).** Pins the newest install carrying
+  the C++ x64 toolset via `vswhere` and runs the build under its
+  `vcvars64.bat`. No VS with that toolset → hard error.
+- **`VCPKG_ROOT`.** Windows resolves it process env → persisted User
+  env → hard error (with the `SetEnvironmentVariable` hint). macOS/
+  Linux requires it exported in your shell profile. Either way it
+  must contain `scripts/buildsystems/vcpkg.cmake`.
+- **No concurrent configures.** Aborts if a build tool is already
+  running (`cmake`/`ninja`/`cl`/`MSBuild` on Windows;
+  `cmake`/`ninja`/`cc1plus`/`clang` elsewhere) — concurrent
+  configures corrupt the shared CMake cache. Idle CLion is fine; just
+  don't run an IDE build into the same dir at the same time.
+- **No running target.** Refuses if a `Silencer` built from that dir
+  is running — it locks the link target (Windows: cryptic `LNK1168`).
+- **Cooperative lock.** Atomic `.silencer-build.lock` in the build
+  dir; a stale lock from a dead PID is reclaimed automatically.
+
+## Compile-time config knobs
+
+These are CMake cache variables baked at configure time. Defaults
+live in `CMakeLists.txt`; CI overrides them in its own configure
+step (the wrapper takes no pass-through args, so changing them for a
+local build means reconfiguring with the `-D` set).
+
+- **`SILENCER_LOBBY_HOST` / `SILENCER_LOBBY_PORT`** — default
+  `127.0.0.1:517`; CI sets `lobby.arsiamons.com`. Rebuild to point
+  the client at a different lobby.
+- **`SILENCER_VERSION`** — the wire-handshake version string. Must
+  match the lobby's `-version` (which defaults to the same value);
+  bump both together or the handshake fails. `CPACK_PACKAGE_VERSION`
+  is installer metadata only — unrelated to the handshake.
+
+## vcpkg dependencies
+
+`libmodplug` was removed from `vcpkg.json`: `sdl3-mixer` no longer
+builds the MOD/XM/IT music plugin. The game uses IMA ADPCM
+(`sound.bin`) and MP3 (`CLOSER2.mp3`) only. Cuts build time, removes
+an unused dependency.
+
+## Build artifacts
+
+- **Linux** — binary `silencer` (lowercase, GNU convention).
+- **macOS** — `Silencer.app` bundle (`MACOSX_BUNDLE`); runtime asset
+  path inside the bundle is `Contents/assets/` (loaded via
+  `src/main.cpp` `CDResDir`). The Xcode project was retired — CMake
+  `MACOSX_BUNDLE` is the only macOS build path.
+- **Windows** — `Silencer.exe`; runtime expects `assets\` next to the
+  exe (`src/os.cpp` `GetResDir`). Resources / icon are wired through
+  `resources.rc` (auto-included on Windows builds).


### PR DESCRIPTION
## What

Adds a single sanctioned entry point for building the Silencer client:

- `clients/silencer/build.ps1` (Windows)
- `clients/silencer/build.sh` (macOS/Linux)

…and updates `clients/silencer/CLAUDE.md` to require it (never raw
`cmake`/`cl`/`ninja`, never CLion's bundled MinGW). `.gitignore` now
ignores per-developer IDE state (`.idea/`, `cmake-build-*/`).

A follow-up commit then **slims `CLAUDE.md` via progressive
disclosure** — see the *Docs* section below.

## Why

Multiple agents + CLion building into the same dir with **different
toolchains** (CLion's MinGW vs two MSVC installs) and **differing
`VCPKG_ROOT`** repeatedly corrupted the shared CMake cache. The
failures looked like code/conformance bugs and were misdiagnosed
several times. Convention (a prose prompt) didn't hold — agents still
hand-rolled invocations and got them wrong. The wrapper removes the
improvisation surface entirely.

## What the wrapper enforces

- Resolves the **newest installed Visual Studio via `vswhere`** (no
  hardcoded path → safe to commit; MSVC-only, MinGW can't link this).
- Resolves `VCPKG_ROOT`: process env → persisted User env → hard error
  (the exact failure that tripped a prior agent — now impossible).
- Refuses to run under a **concurrent build** or a **running Silencer**
  binary (which locks the link target → cryptic `LNK1168`), failing
  fast and legibly with the offending PID.
- Holds an **atomic build lock** so concurrent configures can't corrupt
  the cache (stale-lock reclaim if the owner is dead).
- `-Clean` / `--clean` wipes the cache (keeps `vcpkg_installed`) as the
  sanctioned recovery from a poisoned cache.

## Docs: progressive-disclosure slim

`clients/silencer/CLAUDE.md` was audited against
`docs/writing-a-good-claude-md.md`. The content was strong but ~4×
the recommended length; the only defect was conciseness, not
accuracy. Task-specific deep-dives were moved behind on-demand docs
with tight pointers left in place:

- Actor-def + behavior-tree internals →
  `docs/silencer-client-architecture.md` (appended).
- Build mechanism, presets, compile-time lobby/version knobs, vcpkg
  deps, per-platform artifacts → **`docs/silencer-client-build.md`**
  (new).

`CLAUDE.md`: **229 → 127 lines**, zero information lost. The
`AGENTS.md` symlink resolves byte-identical.

## Scope / isolation

Branched off `origin/main`. **6 files**: `.gitignore`,
`clients/silencer/CLAUDE.md`, `build.ps1`, `build.sh`,
`docs/silencer-client-architecture.md`,
`docs/silencer-client-build.md` — no unrelated clay-migration work
from the branch it originated on.

## Verification

- Wrapper (prior session, end-to-end): auto-resolved VS2026,
  recovered `VCPKG_ROOT` from User env with process env nulled,
  `-Clean` wipe, full 178/178 compile, lock acquire/release, and the
  running-instance guard failing fast instead of dying at `LNK1168`.
- This session (docs delta): both scripts re-parse clean
  (`Parser::ParseFile` / `bash -n`); every CLAUDE.md cross-link
  resolves to a real file; no dangling references to removed
  sections; `AGENTS.md` symlink == `CLAUDE.md` (127 lines). No new
  full build run — the delta is documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)