### PR TITLE
fix(ui): text input no longer jumps vertically depending on glyph (#175)

### DIFF
--- a/clients/silencer/src/render/clay_ui_compositor.cpp
+++ b/clients/silencer/src/render/clay_ui_compositor.cpp
@@ -1034,17 +1034,12 @@ void RenderInto(::Resources & resources, ::Renderer & renderer,
 						int x = static_cast<int>(c->boundingBox.x);
 						int y = static_cast<int>(c->boundingBox.y);
 						int boxH = static_cast<int>(c->boundingBox.height);
-						TextInkMetrics ink = MeasureInkBounds(
-							g_textMeasureResources,
-							p->text,
-							static_cast<int32_t>(p->textLen),
-							style.bank,
-							style.advance);
-						if(ink.hasInk && ink.height > 0){
-							y += std::max(0, (boxH - ink.height) / 2) - ink.minY;
-						}else{
-							y += std::max(0, (boxH - static_cast<int>(style.lineHeight)) / 2);
-						}
+						// Center on the fixed font line box, never on per-string
+						// ink bounds: ink height/minY change with descenders
+						// (e.g. 'y'), which made the whole string jump up a
+						// pixel or two (issue #175). Legacy DrawTextInput drew
+						// at a fixed y for the same reason.
+						y += std::max(0, (boxH - static_cast<int>(style.lineHeight)) / 2);
 						renderer.DrawText(dst,
 						                  static_cast<Uint16>(x),
 						                  static_cast<Uint16>(y),


### PR DESCRIPTION
Closes #175

## Problem
Text in a TextInput shifted up a pixel or two when the string contained a descender glyph (e.g. typing a `y` in `frankly` vs `frank1` bumped the whole string up).

## Root cause
The Clay `CustomKind::TextInput` render path centered the **per-string ink bounding box**:
```cpp
y += std::max(0, (boxH - ink.height) / 2) - ink.minY;
```
`ink.height` / `ink.minY` are measured over the actual glyphs, so a descender increases `ink.height` and the centering math moves the whole string upward. Legacy `Renderer::DrawTextInput` drew at a fixed `y` precisely to avoid this.

## Fix
Always center on the fixed font line box (`style.lineHeight`) — glyph-independent — which is what the existing no-ink fallback branch already did. Removes the now-unused per-frame `MeasureInkBounds` call in this path (small perf win too).

One-block change in `clay_ui_compositor.cpp`.

## Verification
Reproduced and fixed live via the CLI control socket on the lobby-connect username field at 1280×720:
- **Before:** `frankly` rendered ~2px higher than `frank1` (zoomed before screenshot).
- **After:** `frank1` and `frankly` align at the same vertical position; descender no longer shifts the string.
- `tests/cli-agent/e2e/15_lobbyconnect_scaled_text_focus.sh` and `13_password_modal.sh` pass with this build (no text-input behavior/focus/caret regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)