### PR TITLE
fix(ui): smooth lobby panel chrome lines (#177)

### DIFF
--- a/clients/silencer/src/client/ui/screens/lobby/lobby_main_area.cpp
+++ b/clients/silencer/src/client/ui/screens/lobby/lobby_main_area.cpp
@@ -13,6 +13,7 @@
 #include "lobby_screen.h"
 
 #include "screen_context.h"
+#include "renderdevice.h"
 #include "world.h"
 
 #include <algorithm>
@@ -89,6 +90,71 @@ struct LobbySteppedPaneLayout {
 	int chatW = 0;
 	int chatH = kLegacyBodyH - 121 - 10;
 };
+
+void AddBorderBlurRect(RenderDevice * renderdevice, SDL_Rect rect) {
+	if(!renderdevice || rect.w <= 0 || rect.h <= 0) return;
+	renderdevice->AddLobbyPanelBorderBlurRect(rect);
+}
+
+void AddPanelBorderBlur(RenderDevice * renderdevice,
+                        int x,
+                        int y,
+                        int w,
+                        int h,
+                        Uint8 sides) {
+	if(!renderdevice || w <= 0 || h <= 0) return;
+	if(sides & BoxSides::Top){
+		AddBorderBlurRect(renderdevice, SDL_Rect{ x, y, w, 1 });
+	}
+	if(sides & BoxSides::Bottom){
+		AddBorderBlurRect(renderdevice, SDL_Rect{ x, y + h - 1, w, 1 });
+	}
+	if(sides & BoxSides::Left){
+		AddBorderBlurRect(renderdevice, SDL_Rect{ x, y, 1, h });
+	}
+	if(sides & BoxSides::Right){
+		AddBorderBlurRect(renderdevice, SDL_Rect{ x + w - 1, y, 1, h });
+	}
+}
+
+void QueueLobbyPanelBorderBlurRects(ScreenContext & ctx,
+                                    int bodyX,
+                                    int bodyY,
+                                    const LobbySteppedPaneLayout & layout) {
+	RenderDevice * renderdevice = ctx.renderdevice;
+	if(!renderdevice) return;
+	const int topY = bodyY;
+	const int lowerY = bodyY + layout.upperH + layout.regionGap;
+	const int rightX = bodyX + layout.topRowW;
+	const int characterX = bodyX;
+	const int rightUpperX = bodyX + layout.characterW + layout.regionGap;
+	const int seamX = bodyX + layout.topRowW - layout.regionGap;
+
+	AddPanelBorderBlur(renderdevice,
+	                   characterX, topY,
+	                   layout.characterW, layout.upperH,
+	                   BoxSides::All);
+	AddPanelBorderBlur(renderdevice,
+	                   rightUpperX, topY,
+	                   layout.rightUpperW, layout.upperH,
+	                   static_cast<Uint8>(BoxSides::Top | BoxSides::Bottom | BoxSides::Left));
+	AddPanelBorderBlur(renderdevice,
+	                   seamX, bodyY + layout.upperH,
+	                   layout.regionGap, layout.regionGap,
+	                   BoxSides::Right);
+	AddPanelBorderBlur(renderdevice,
+	                   bodyX, lowerY,
+	                   layout.chatW, layout.chatH,
+	                   BoxSides::All);
+	AddPanelBorderBlur(renderdevice,
+	                   seamX, lowerY,
+	                   layout.regionGap, layout.chatH,
+	                   BoxSides::Right);
+	AddPanelBorderBlur(renderdevice,
+	                   rightX, bodyY,
+	                   layout.rightTallW, layout.rightTallH,
+	                   static_cast<Uint8>(BoxSides::Top | BoxSides::Bottom | BoxSides::Right));
+}
 
 LobbySteppedPaneLayout ResolveSteppedPaneLayout(int bodyW,
                                                 int bodyH,
@@ -331,12 +397,15 @@ void BuildLobbySteppedPane(LobbyMainAreaPanels & panels,
 void BuildLobbyMainArea(LobbyMainAreaPanels & panels,
                         ScreenContext & ctx,
                         LobbyScreen & owner,
+                        int bodyX,
+                        int bodyY,
                         int bodyW,
                         int bodyH,
                         int regionGap,
                         silencer::ui::UiInteractionRegistry& interactions) {
 	const lobby_main_area_detail::LobbySteppedPaneLayout layout =
 		lobby_main_area_detail::ResolveSteppedPaneLayout(bodyW, bodyH, regionGap);
+	lobby_main_area_detail::QueueLobbyPanelBorderBlurRects(ctx, bodyX, bodyY, layout);
 	lobby_main_area_detail::BuildLobbySteppedPane(
 		panels,
 		ctx,

--- a/clients/silencer/src/client/ui/screens/lobby/lobby_main_area.h
+++ b/clients/silencer/src/client/ui/screens/lobby/lobby_main_area.h
@@ -40,6 +40,8 @@ struct LobbyMainAreaPanels {
 void BuildLobbyMainArea(LobbyMainAreaPanels & panels,
                         ScreenContext & ctx,
                         LobbyScreen & owner,
+                        int bodyX,
+                        int bodyY,
                         int bodyW,
                         int bodyH,
                         int regionGap,

--- a/clients/silencer/src/client/ui/screens/lobby/lobby_screen.cpp
+++ b/clients/silencer/src/client/ui/screens/lobby/lobby_screen.cpp
@@ -6,6 +6,7 @@
 
 #include "screen_context.h"
 #include "game.h"
+#include "renderdevice.h"
 #include "world.h"
 #include "renderer.h"
 #include "surface.h"
@@ -38,6 +39,14 @@ int ScaleLegacyPx(int base,
 	if(legacy <= 0) return ClampInt(base, minValue, maxValue);
 	const int scaled = static_cast<int>((static_cast<long long>(base) * actual + legacy / 2) / legacy);
 	return ClampInt(scaled, minValue, maxValue);
+}
+
+void AddPanelBorderBlur(RenderDevice * renderdevice, SDL_Rect rect) {
+	if(!renderdevice || rect.w <= 0 || rect.h <= 0) return;
+	renderdevice->AddLobbyPanelBorderBlurRect({ rect.x, rect.y, rect.w, 1 });
+	renderdevice->AddLobbyPanelBorderBlurRect({ rect.x, rect.y + rect.h - 1, rect.w, 1 });
+	renderdevice->AddLobbyPanelBorderBlurRect({ rect.x, rect.y, 1, rect.h });
+	renderdevice->AddLobbyPanelBorderBlurRect({ rect.x + rect.w - 1, rect.y, 1, rect.h });
 }
 
 }  // namespace lobby_screen_detail
@@ -121,6 +130,18 @@ void LobbyScreen::BuildUi(ScreenContext & ctx, Surface & dst, float frametime, s
 	const int bodyW = std::max(0, layoutWidth - rootPadX * 2);
 	const int bodyH = std::max(0, layoutHeight - rootPadTop - rootPadBottom
 	                              - (int)titleBarH - regionGap);
+	const int bodyX = rootPadX;
+	const int bodyY = rootPadTop + (int)titleBarH + regionGap;
+
+	if(ctx.renderdevice){
+		ctx.renderdevice->BeginLobbyPanelBorderBlur(
+			layoutWidth,
+			layoutHeight,
+			input.uiScale);
+		lobby_screen_detail::AddPanelBorderBlur(
+			ctx.renderdevice,
+			SDL_Rect{ rootPadX, rootPadTop, bodyW, (int)titleBarH });
+	}
 
 	CLAY({ .id = CLAY_ID("LobbyRoot"),
 	       .layout = {
@@ -147,7 +168,8 @@ void LobbyScreen::BuildUi(ScreenContext & ctx, Surface & dst, float frametime, s
 			gameJoinActive,
 			gameTechActive,
 		};
-		BuildLobbyMainArea(panels, ctx, *this, bodyW, bodyH, regionGap, interactions);
+		BuildLobbyMainArea(
+			panels, ctx, *this, bodyX, bodyY, bodyW, bodyH, regionGap, interactions);
 		if(gameCreateActive){
 			BuildGameCreatePreviewOverlay(gameCreateState, ctx);
 		}

--- a/clients/silencer/src/render/clay_ui_compositor.cpp
+++ b/clients/silencer/src/render/clay_ui_compositor.cpp
@@ -1033,20 +1033,26 @@ void RenderInto(::Resources & resources, ::Renderer & renderer,
 						bool sLeft   = (sides & 0x8) != 0;
 						ClipRect clip;
 						if(!CurrentClip(dst->w, dst->h, clip)) break;
-						// Each concentric band (outer halo / stroke / inner
-						// halo) draws as up to four straight runs at the
-						// box's OWN bbox -- no per-box outward extension.
-						// Where two composed boxes meet, each run stops at
-						// its own bbox and pass 1 records the band's four
-						// corner cells with the directions the band
-						// continues in. Pass 2 (RenderStrokeCorners, after
-						// the whole command stream) fills one
-						// band-thickness square at every corner that ended
-						// up connected from two or more directions, so the
-						// shared elbow is contiguous. A plain closed
-						// rectangle's corner cell lands exactly on the old
-						// stepped-ownership overlap, so ordinary chrome is
-						// byte-identical (issue #176).
+						auto effectiveBandThickness = [&](int thickness){
+							int t = thickness;
+							if(t < 1) return 0;
+							if(t * 2 > bw) t = bw / 2;
+							if(t * 2 > bh) t = bh / 2;
+							return t > 0 ? t : 0;
+						};
+						const int kGreenRampFloor = 210;
+						auto glowColorAtStep = [&](int step) -> Uint8 {
+							int c = static_cast<int>(p->strokeColor) - step;
+							if(c < kGreenRampFloor) c = kGreenRampFloor;
+							if(c < 0) c = 0;
+							return static_cast<Uint8>(c);
+						};
+						const int glowW = effectiveBandThickness(p->glowWidth);
+						// Each concentric band, including the #177 glow,
+						// draws as straight runs plus PR #192's pass-2
+						// corner cells. Keeping glow in this model prevents
+						// rectangular overlaps from creating plus-shaped
+						// corner artifacts.
 						auto drawRing = [&](int inset, int thickness, Uint8 color, Uint8 opacity){
 							int t = thickness;
 							if(t < 1) return;
@@ -1118,6 +1124,15 @@ void RenderInto(::Resources & resources, ::Renderer & renderer,
 							    (sRight  ? corner_dir::Up   : (Uint8)0));
 						};
 						int inset = 0;
+						// Outer glow: dimmest ring first (furthest out),
+						// brightening one ramp step per pixel toward the
+						// primary. Step glowW is adjacent to the primary
+						// so the transition into idx 216 is seamless.
+						for(int g = 0; g < glowW; g++){
+							int step = glowW - g;  // glowW (dim) .. 1 (bright)
+							drawRing(inset, 1, glowColorAtStep(step), 255);
+							inset += 1;
+						}
 						if(p->outerHaloWidth > 0){
 							drawRing(inset, p->outerHaloWidth, p->outerHaloColor, p->haloOpacity);
 							inset += p->outerHaloWidth;
@@ -1128,6 +1143,15 @@ void RenderInto(::Resources & resources, ::Renderer & renderer,
 						}
 						if(p->innerHaloWidth > 0){
 							drawRing(inset, p->innerHaloWidth, p->innerHaloColor, p->haloOpacity);
+							inset += p->innerHaloWidth;
+						}
+						// Inner glow: mirror of the outer falloff —
+						// brightest ring adjacent to the primary, fading
+						// one ramp step per pixel inward to the backdrop.
+						for(int g = 0; g < glowW; g++){
+							int step = g + 1;  // 1 (bright) .. glowW (dim)
+							drawRing(inset, 1, glowColorAtStep(step), 255);
+							inset += 1;
 						}
 						break;
 					}

--- a/clients/silencer/src/render/clay_ui_compositor.cpp
+++ b/clients/silencer/src/render/clay_ui_compositor.cpp
@@ -1033,72 +1033,54 @@ void RenderInto(::Resources & resources, ::Renderer & renderer,
 						bool sLeft   = (sides & 0x8) != 0;
 						ClipRect clip;
 						if(!CurrentClip(dst->w, dst->h, clip)) break;
-						auto effectiveBandThickness = [&](int thickness){
-							int t = thickness;
-							if(t < 1) return 0;
-							if(t * 2 > bw) t = bw / 2;
-							if(t * 2 > bh) t = bh / 2;
-							return t > 0 ? t : 0;
-						};
-						const int kGreenRampFloor = 210;
-						auto glowColorAtStep = [&](int step) -> Uint8 {
-							int c = static_cast<int>(p->strokeColor) - step;
-							if(c < kGreenRampFloor) c = kGreenRampFloor;
-							if(c < 0) c = 0;
-							return static_cast<Uint8>(c);
-						};
-						const int glowW = effectiveBandThickness(p->glowWidth);
-						// Each concentric band, including the #177 glow,
-						// draws as straight runs plus PR #192's pass-2
-						// corner cells. Keeping glow in this model prevents
-						// rectangular overlaps from creating plus-shaped
-						// corner artifacts.
+						// Each concentric band (outer halo / stroke / inner
+						// halo) draws as straight runs plus PR #192's pass-2
+						// corner cells.
 						auto drawRing = [&](int inset, int thickness, Uint8 color, Uint8 opacity){
 							int t = thickness;
 							if(t < 1) return;
 							if(t * 2 > bw) t = bw / 2;
 							if(t * 2 > bh) t = bh / 2;
 							if(t < 1) return;
-							// Top-left of each thickness-square corner cell.
-							const int cx0 = bx + inset;           // left
-							const int cx1 = bx + bw - inset - t;   // right
-							const int cy0 = by + inset;            // top
-							const int cy1 = by + bh - inset - t;   // bottom
-							// Classic stepped ownership: a run is trimmed
-							// by `t` at each end that has an active
-							// perpendicular side, leaving the corner cell
-							// for pass 2.
-							int hLeftTrim  = sLeft   ? t : 0;
-							int hRightTrim = sRight  ? t : 0;
-							int vTopTrim   = sTop    ? t : 0;
-							int vBotTrim   = sBottom ? t : 0;
+							const int leftBandX = bx + inset;
+							const int rightBandX = bx + bw - inset - t;
+							const int topBandY = by + inset;
+							const int bottomBandY = by + bh - inset - t;
+							// Closed corners reserve a thickness-square cell
+							// for pass 2. At suppressed sides, extend the
+							// perpendicular run to the real bbox edge so
+							// open L-panel caps remain contiguous.
+							int hStart = sLeft ? leftBandX + t : bx;
+							int hEnd = sRight ? rightBandX : bx + bw;
+							int vStart = sTop ? topBandY + t : by;
+							int vEnd = sBottom ? bottomBandY : by + bh;
 							// Top run.
 							if(sTop){
-								int x = cx0 + hLeftTrim;
-								int w = bw - 2 * inset - hLeftTrim - hRightTrim;
 								FillStrokeStripe(renderer, dst, clip,
-								                 x, cy0, w, t, color, opacity);
+								                 hStart, topBandY,
+								                 hEnd - hStart, t,
+								                 color, opacity);
 							}
 							// Bottom run.
 							if(sBottom){
-								int x = cx0 + hLeftTrim;
-								int w = bw - 2 * inset - hLeftTrim - hRightTrim;
 								FillStrokeStripe(renderer, dst, clip,
-								                 x, cy1, w, t, color, opacity);
+								                 hStart, bottomBandY,
+								                 hEnd - hStart, t,
+								                 color, opacity);
 							}
 							// Left run.
 							if(sLeft){
-								int y = cy0 + vTopTrim;
-								int h = bh - 2 * inset - vTopTrim - vBotTrim;
 								FillStrokeStripe(renderer, dst, clip,
-								                 cx0, y, t, h, color, opacity);
+								                 leftBandX, vStart,
+								                 t, vEnd - vStart,
+								                 color, opacity);
 							}
 							// Right run.
 							if(sRight){
-								int y = cy0 + vTopTrim;
-								int h = bh - 2 * inset - vTopTrim - vBotTrim;
 								FillStrokeStripe(renderer, dst, clip,
-								                 cx1, y, t, h, color, opacity);
+								                 rightBandX, vStart,
+								                 t, vEnd - vStart,
+								                 color, opacity);
 							}
 							// Pass 1: register the band's four corner cells
 							// with the directions this band continues in.
@@ -1110,29 +1092,20 @@ void RenderInto(::Resources & resources, ::Renderer & renderer,
 									AddStrokeCorner(cx, cy, t, color,
 									                opacity, dirs, clip);
 							};
-							reg(cx0, cy0,
+							reg(leftBandX, topBandY,
 							    (sTop  ? corner_dir::Right : (Uint8)0) |
 							    (sLeft ? corner_dir::Down  : (Uint8)0));
-							reg(cx1, cy0,
+							reg(rightBandX, topBandY,
 							    (sTop   ? corner_dir::Left : (Uint8)0) |
 							    (sRight ? corner_dir::Down : (Uint8)0));
-							reg(cx0, cy1,
+							reg(leftBandX, bottomBandY,
 							    (sBottom ? corner_dir::Right : (Uint8)0) |
 							    (sLeft   ? corner_dir::Up    : (Uint8)0));
-							reg(cx1, cy1,
+							reg(rightBandX, bottomBandY,
 							    (sBottom ? corner_dir::Left : (Uint8)0) |
 							    (sRight  ? corner_dir::Up   : (Uint8)0));
 						};
 						int inset = 0;
-						// Outer glow: dimmest ring first (furthest out),
-						// brightening one ramp step per pixel toward the
-						// primary. Step glowW is adjacent to the primary
-						// so the transition into idx 216 is seamless.
-						for(int g = 0; g < glowW; g++){
-							int step = glowW - g;  // glowW (dim) .. 1 (bright)
-							drawRing(inset, 1, glowColorAtStep(step), 255);
-							inset += 1;
-						}
 						if(p->outerHaloWidth > 0){
 							drawRing(inset, p->outerHaloWidth, p->outerHaloColor, p->haloOpacity);
 							inset += p->outerHaloWidth;
@@ -1143,15 +1116,6 @@ void RenderInto(::Resources & resources, ::Renderer & renderer,
 						}
 						if(p->innerHaloWidth > 0){
 							drawRing(inset, p->innerHaloWidth, p->innerHaloColor, p->haloOpacity);
-							inset += p->innerHaloWidth;
-						}
-						// Inner glow: mirror of the outer falloff —
-						// brightest ring adjacent to the primary, fading
-						// one ramp step per pixel inward to the backdrop.
-						for(int g = 0; g < glowW; g++){
-							int step = g + 1;  // 1 (bright) .. glowW (dim)
-							drawRing(inset, 1, glowColorAtStep(step), 255);
-							inset += 1;
 						}
 						break;
 					}

--- a/clients/silencer/src/render/clay_ui_compositor.cpp
+++ b/clients/silencer/src/render/clay_ui_compositor.cpp
@@ -221,6 +221,141 @@ Uint8 AlphaSrcIndex(Uint8 color, Uint8 /*opacity255*/) {
 	return static_cast<Uint8>(rampBase + 8);
 }
 
+// ---------------------------------------------------------------------------
+// Stroke corner join model (issue #176).
+//
+// Composed L / stepped chrome (the lobby right pane) is built from several
+// adjacent `BoxStroke` boxes whose shared edges are suppressed. Each box
+// insets its stroke bands from its OWN bbox, so where two boxes meet the two
+// perpendicular runs of the same band never share a pixel — the elbow notches.
+//
+// Instead of per-box geometry hacks we render strokes in two passes:
+//
+//   Pass 1 (during the command walk): every active band edge a box draws
+//   registers its two endpoints as corners. A corner is keyed by its snapped
+//   pixel position plus the band's visual identity (color/opacity/thickness)
+//   and accumulates a 4-bit mask of the cardinal directions in which that band
+//   continues — across ALL boxes, so a shared junction sees connectivity from
+//   both neighbours.
+//
+//   Pass 2 (after the walk): every collected corner is filled with one
+//   band-thickness square placed by how many directions connect there. Two
+//   perpendicular runs that stopped short of each other now both reach the
+//   shared square, so the join is contiguous. For a plain closed rectangle the
+//   square lands exactly on the existing stepped-ownership overlap, so
+//   ordinary chrome is unchanged.
+namespace corner_dir {
+constexpr Uint8 Up    = 1 << 0;  // a vertical run goes upward from here
+constexpr Uint8 Down  = 1 << 1;
+constexpr Uint8 Left  = 1 << 2;  // a horizontal run goes leftward from here
+constexpr Uint8 Right = 1 << 3;
+}  // namespace corner_dir
+
+struct StrokeCorner {
+	int   x;          // snapped pixel position of the join centre
+	int   y;
+	int   thickness;  // band thickness (square side)
+	Uint8 color;
+	Uint8 opacity;
+	Uint8 dirs;       // OR of corner_dir bits, accumulated across boxes
+	ClipRect clip;    // active clip when the owning edge was emitted
+};
+
+// Per-frame corner set. Cleared at the top of RenderInto and drained by the
+// pass-2 corner render before RenderInto returns.
+std::vector<StrokeCorner> g_strokeCorners;
+
+// Register one band endpoint as a corner. Corners that match position + band
+// identity + clip merge so their direction masks accumulate.
+void AddStrokeCorner(int x, int y, int thickness,
+                     Uint8 color, Uint8 opacity, Uint8 dir,
+                     const ClipRect & clip) {
+	for(StrokeCorner & sc : g_strokeCorners){
+		if(sc.x == x && sc.y == y && sc.thickness == thickness &&
+		   sc.color == color && sc.opacity == opacity &&
+		   sc.clip.x == clip.x && sc.clip.y == clip.y &&
+		   sc.clip.w == clip.w && sc.clip.h == clip.h){
+			sc.dirs |= dir;
+			return;
+		}
+	}
+	g_strokeCorners.push_back(
+		StrokeCorner{x, y, thickness, color, opacity, dir, clip});
+}
+
+// Fill an axis-aligned stripe through `clip`. When `opacity` is 255 it is a
+// solid palette fill; otherwise the colour is alpha-blended against each
+// underlying pixel through the palette's alphaed LUT, with an RGB
+// ClosestMatch fallback for destination indices outside the LUT's [2, 226)
+// range (notably the lobby's pure-black backdrop). Shared by the stroke edge
+// pass and the corner join pass so both blend identically.
+void FillStrokeStripe(::Renderer & renderer, Surface * dst,
+                      const ClipRect & clip,
+                      int x, int y, int w, int h,
+                      Uint8 color, Uint8 opacity) {
+	if(w <= 0 || h <= 0 || !dst) return;
+	int x1 = std::max(x, clip.x);
+	int y1 = std::max(y, clip.y);
+	int x2 = std::min(x + w, clip.x + clip.w);
+	int y2 = std::min(y + h, clip.y + clip.h);
+	if(x2 <= x1 || y2 <= y1) return;
+	x = x1; y = y1; w = x2 - x1; h = y2 - y1;
+	if(opacity == 255){
+		Renderer::DrawFilledRectangle(dst, x, y, x + w, y + h, color);
+		return;
+	}
+	Uint8 srcLUT = AlphaSrcIndex(color, opacity);
+	SDL_Color * colors = renderer.palette.GetColors();
+	SDL_Color srcRgb = colors[color];
+	const float alpha = 0.5f;  // matches LUT quantization
+	Uint8 fallbackCache[256];
+	bool  fallbackCached[256] = {false};
+	for(int py = y; py < y + h; py++){
+		for(int px = x; px < x + w; px++){
+			Uint8 d = Renderer::GetPixel(dst, px, py);
+			Uint8 blended;
+			if(d >= 2 && d < 226){
+				blended = renderer.palette.Alpha(srcLUT, d);
+			}else if(fallbackCached[d]){
+				blended = fallbackCache[d];
+			}else{
+				// Inline RGB lerp — `Palette::Alpha(SDL_Color,...)` is
+				// private. Mirrors palette.cpp:442-447.
+				SDL_Color dstRgb = colors[d];
+				SDL_Color rgb;
+				rgb.r = (Uint8)(srcRgb.r * alpha + dstRgb.r * (1.0f - alpha));
+				rgb.g = (Uint8)(srcRgb.g * alpha + dstRgb.g * (1.0f - alpha));
+				rgb.b = (Uint8)(srcRgb.b * alpha + dstRgb.b * (1.0f - alpha));
+				rgb.a = 255;
+				blended = renderer.palette.ClosestMatch(rgb);
+				fallbackCache[d]  = blended;
+				fallbackCached[d] = true;
+			}
+			Renderer::SetPixel(dst, px, py, blended);
+		}
+	}
+}
+
+// Pass 2: render every collected stroke corner. A corner is one
+// band-thickness square; the connected-direction mask only decides whether
+// this corner actually needs a join (>= 2 directions) — an endpoint cap
+// (1 direction) or stray point (0) does not, since the straight edge pass
+// already covered it. The square is centred so its band sits flush with the
+// runs that feed it, which is exactly the pixel both perpendicular runs of a
+// composed elbow stopped short of.
+void RenderStrokeCorners(::Renderer & renderer, Surface * dst) {
+	for(const StrokeCorner & sc : g_strokeCorners){
+		if(sc.thickness < 1) continue;
+		// Count connected cardinal directions.
+		int n = 0;
+		for(int b = 0; b < 4; b++) if(sc.dirs & (1 << b)) n++;
+		if(n < 2) continue;  // straight edge pass already drew it
+		FillStrokeStripe(renderer, dst, sc.clip,
+		                 sc.x, sc.y, sc.thickness, sc.thickness,
+		                 sc.color, sc.opacity);
+	}
+}
+
 void DispatchRectangle(::Renderer & renderer,
                        Surface * dst,
                        const ::Clay_BoundingBox & bb,
@@ -590,6 +725,7 @@ void SetTextMeasureResources(const Resources * resources) {
 void RenderInto(::Resources & resources, ::Renderer & renderer,
                 Surface * dst, ::Clay_RenderCommandArray cmds) {
 	g_clipStack.clear();
+	g_strokeCorners.clear();
 	if(!dst) return;
 	for(int i = 0; i < cmds.length; i++){
 		::Clay_RenderCommand * c = &cmds.internalArray[i];
@@ -884,136 +1020,91 @@ void RenderInto(::Resources & resources, ::Renderer & renderer,
 						bool sRight  = (sides & 0x2) != 0;
 						bool sBottom = (sides & 0x4) != 0;
 						bool sLeft   = (sides & 0x8) != 0;
-						// Draw the active sides of a 1-band ring at the
-						// given concentric `inset` from the bbox edge.
-						// Closed rectangles keep the classic stepped
-						// corner ownership: horizontal bands inset around
-						// active verticals, and vertical bands inset
-						// around active horizontals.
-						// Fill a stripe at (x, y, w, h) with `color`. When
-						// `opacity` is 255 it's a solid fill; otherwise blend
-						// the color against the underlying pixel so the same
-						// palette entry reads as a dimmer band (the legacy
-						// chrome's halo bands are alpha-blended copies of the
-						// primary, not separate palette indices).
-						//
-						// Fast path: the palette's alphaed LUT covers
-						// `dst ∈ [2, 226)`. Outside that range — notably the
-						// lobby's pure-black backdrop at idx 0 — fall back to
-						// computing the blend in RGB and resolving via
-						// ClosestMatch. Per-pixel cost; reserved for chrome.
-						auto fillStripe = [&](int x, int y, int w, int h, Uint8 color, Uint8 opacity){
-							if(w <= 0 || h <= 0) return;
-							if(!ClipDrawRect(dst->w, dst->h, x, y, w, h)) return;
-							if(opacity == 255){
-								Renderer::DrawFilledRectangle(dst, x, y, x+w, y+h, color);
-								return;
-							}
-							Uint8 srcLUT = AlphaSrcIndex(color, opacity);
-							SDL_Color * colors = renderer.palette.GetColors();
-							SDL_Color srcRgb = colors[color];
-							const float alpha = 0.5f;  // matches LUT quantization
-							// Cache the math fallback per-dst — most chrome
-							// halos draw over uniform backdrop pixels so we
-							// only resolve ClosestMatch a couple of times.
-							Uint8 fallbackCache[256];
-							bool   fallbackCached[256] = {false};
-							for(int py = y; py < y + h; py++){
-								for(int px = x; px < x + w; px++){
-									Uint8 d = Renderer::GetPixel(dst, px, py);
-									Uint8 blended;
-									if(d >= 2 && d < 226){
-										blended = renderer.palette.Alpha(srcLUT, d);
-									}else if(fallbackCached[d]){
-										blended = fallbackCache[d];
-									}else{
-										// Inline RGB lerp — `Palette::Alpha(SDL_Color,...)`
-										// is private. Mirrors palette.cpp:442-447.
-										SDL_Color dstRgb = colors[d];
-										SDL_Color rgb;
-										rgb.r = (Uint8)(srcRgb.r * alpha + dstRgb.r * (1.0f - alpha));
-										rgb.g = (Uint8)(srcRgb.g * alpha + dstRgb.g * (1.0f - alpha));
-										rgb.b = (Uint8)(srcRgb.b * alpha + dstRgb.b * (1.0f - alpha));
-										rgb.a = 255;
-										blended = renderer.palette.ClosestMatch(rgb);
-										fallbackCache[d]  = blended;
-										fallbackCached[d] = true;
-									}
-									Renderer::SetPixel(dst, px, py, blended);
-								}
-							}
-						};
-						auto effectiveBandThickness = [&](int thickness){
-							int t = thickness;
-							if(t < 1) return 0;
-							if(t * 2 > bw) t = bw / 2;
-							if(t * 2 > bh) t = bh / 2;
-							return t > 0 ? t : 0;
-						};
-						const int totalBandDepth =
-							effectiveBandThickness(p->outerHaloWidth) +
-							effectiveBandThickness(p->strokeWidth) +
-							effectiveBandThickness(p->innerHaloWidth);
-						// A suppressed side means an adjacent box owns that
-						// edge of the composed (L / stepped) lobby outline.
-						// Extend the present perpendicular stripes outward
-						// past this bbox by the full band depth so their
-						// stroke + halo bands overlap the neighbour's stroke
-						// and the shared corner stays contiguous. This
-						// generalises the old single-corner special case
-						// (issue #176) and is a no-op for closed boxes (all
-						// extents 0), so plain rectangular chrome is
-						// unchanged.
-						const int extL = sLeft   ? 0 : totalBandDepth;
-						const int extR = sRight  ? 0 : totalBandDepth;
-						const int extT = sTop    ? 0 : totalBandDepth;
-						const int extB = sBottom ? 0 : totalBandDepth;
+						ClipRect clip;
+						if(!CurrentClip(dst->w, dst->h, clip)) break;
+						// Each concentric band (outer halo / stroke / inner
+						// halo) draws as up to four straight runs at the
+						// box's OWN bbox -- no per-box outward extension.
+						// Where two composed boxes meet, each run stops at
+						// its own bbox and pass 1 records the band's four
+						// corner cells with the directions the band
+						// continues in. Pass 2 (RenderStrokeCorners, after
+						// the whole command stream) fills one
+						// band-thickness square at every corner that ended
+						// up connected from two or more directions, so the
+						// shared elbow is contiguous. A plain closed
+						// rectangle's corner cell lands exactly on the old
+						// stepped-ownership overlap, so ordinary chrome is
+						// byte-identical (issue #176).
 						auto drawRing = [&](int inset, int thickness, Uint8 color, Uint8 opacity){
 							int t = thickness;
 							if(t < 1) return;
 							if(t * 2 > bw) t = bw / 2;
 							if(t * 2 > bh) t = bh / 2;
 							if(t < 1) return;
-							int topLeftTrim = sLeft ? inset : 0;
-							int topRightTrim = sRight ? inset : 0;
-							int bottomLeftTrim = sLeft ? inset : 0;
-							int bottomRightTrim = sRight ? inset : 0;
-							int leftTopTrim = sTop ? inset : 0;
-							int leftBottomTrim = sBottom ? inset : 0;
-							int rightTopTrim = sTop ? inset : 0;
-							int rightBottomTrim = sBottom ? inset : 0;
-							// Top stripe.
+							// Top-left of each thickness-square corner cell.
+							const int cx0 = bx + inset;           // left
+							const int cx1 = bx + bw - inset - t;   // right
+							const int cy0 = by + inset;            // top
+							const int cy1 = by + bh - inset - t;   // bottom
+							// Classic stepped ownership: a run is trimmed
+							// by `t` at each end that has an active
+							// perpendicular side, leaving the corner cell
+							// for pass 2.
+							int hLeftTrim  = sLeft   ? t : 0;
+							int hRightTrim = sRight  ? t : 0;
+							int vTopTrim   = sTop    ? t : 0;
+							int vBotTrim   = sBottom ? t : 0;
+							// Top run.
 							if(sTop){
-								int x = bx + topLeftTrim - extL;
-								int y = by + inset;
-								int w = bw - topLeftTrim - topRightTrim + extL + extR;
-								fillStripe(x, y, w, t, color, opacity);
+								int x = cx0 + hLeftTrim;
+								int w = bw - 2 * inset - hLeftTrim - hRightTrim;
+								FillStrokeStripe(renderer, dst, clip,
+								                 x, cy0, w, t, color, opacity);
 							}
-							// Bottom stripe.
+							// Bottom run.
 							if(sBottom){
-								int x = bx + bottomLeftTrim - extL;
-								int y = by + bh - inset - t;
-								int w = bw - bottomLeftTrim - bottomRightTrim + extL + extR;
-								fillStripe(x, y, w, t, color, opacity);
+								int x = cx0 + hLeftTrim;
+								int w = bw - 2 * inset - hLeftTrim - hRightTrim;
+								FillStrokeStripe(renderer, dst, clip,
+								                 x, cy1, w, t, color, opacity);
 							}
-							// Vertical edges. Closed rectangles keep the
-							// classic stepped ownership; an open top/bottom
-							// extends the verticals outward to meet the
-							// neighbour that owns the missing horizontal.
-							int leftVy0 = by + leftTopTrim + (sTop ? t : 0) - extT;
-							int leftVy1 = by + bh - leftBottomTrim - (sBottom ? t : 0) + extB;
-							int leftVh  = leftVy1 - leftVy0;
-							if(sLeft && leftVh > 0){
-								int x = bx + inset;
-								fillStripe(x, leftVy0, t, leftVh, color, opacity);
+							// Left run.
+							if(sLeft){
+								int y = cy0 + vTopTrim;
+								int h = bh - 2 * inset - vTopTrim - vBotTrim;
+								FillStrokeStripe(renderer, dst, clip,
+								                 cx0, y, t, h, color, opacity);
 							}
-							int rightVy0 = by + rightTopTrim + (sTop ? t : 0) - extT;
-							int rightVy1 = by + bh - rightBottomTrim - (sBottom ? t : 0) + extB;
-							int rightVh  = rightVy1 - rightVy0;
-							if(sRight && rightVh > 0){
-								int x = bx + bw - inset - t;
-								fillStripe(x, rightVy0, t, rightVh, color, opacity);
+							// Right run.
+							if(sRight){
+								int y = cy0 + vTopTrim;
+								int h = bh - 2 * inset - vTopTrim - vBotTrim;
+								FillStrokeStripe(renderer, dst, clip,
+								                 cx1, y, t, h, color, opacity);
 							}
+							// Pass 1: register the band's four corner cells
+							// with the directions this band continues in.
+							// The direction mask accumulates across every
+							// box sharing the cell, so a composed junction
+							// sees both neighbours' connectivity.
+							auto reg = [&](int cx, int cy, Uint8 dirs){
+								if(dirs)
+									AddStrokeCorner(cx, cy, t, color,
+									                opacity, dirs, clip);
+							};
+							reg(cx0, cy0,
+							    (sTop  ? corner_dir::Right : (Uint8)0) |
+							    (sLeft ? corner_dir::Down  : (Uint8)0));
+							reg(cx1, cy0,
+							    (sTop   ? corner_dir::Left : (Uint8)0) |
+							    (sRight ? corner_dir::Down : (Uint8)0));
+							reg(cx0, cy1,
+							    (sBottom ? corner_dir::Right : (Uint8)0) |
+							    (sLeft   ? corner_dir::Up    : (Uint8)0));
+							reg(cx1, cy1,
+							    (sBottom ? corner_dir::Left : (Uint8)0) |
+							    (sRight  ? corner_dir::Up   : (Uint8)0));
 						};
 						int inset = 0;
 						if(p->outerHaloWidth > 0){
@@ -1082,6 +1173,11 @@ void RenderInto(::Resources & resources, ::Renderer & renderer,
 				break;
 		}
 	}
+	// Pass 2: bridge every stroke corner that ended up connected from
+	// two or more directions. Runs once after the whole command stream
+	// so a corner shared by adjacent composed boxes has accumulated
+	// connectivity from all of them (issue #176).
+	RenderStrokeCorners(renderer, dst);
 }
 
 // Clay lays out in a virtual coordinate space (the native surface size

--- a/clients/silencer/src/render/clay_ui_compositor.cpp
+++ b/clients/silencer/src/render/clay_ui_compositor.cpp
@@ -954,8 +954,20 @@ void RenderInto(::Resources & resources, ::Renderer & renderer,
 							effectiveBandThickness(p->outerHaloWidth) +
 							effectiveBandThickness(p->strokeWidth) +
 							effectiveBandThickness(p->innerHaloWidth);
-						const bool openRightBottomLeftCorner =
-							sLeft && !sRight && sBottom;
+						// A suppressed side means an adjacent box owns that
+						// edge of the composed (L / stepped) lobby outline.
+						// Extend the present perpendicular stripes outward
+						// past this bbox by the full band depth so their
+						// stroke + halo bands overlap the neighbour's stroke
+						// and the shared corner stays contiguous. This
+						// generalises the old single-corner special case
+						// (issue #176) and is a no-op for closed boxes (all
+						// extents 0), so plain rectangular chrome is
+						// unchanged.
+						const int extL = sLeft   ? 0 : totalBandDepth;
+						const int extR = sRight  ? 0 : totalBandDepth;
+						const int extT = sTop    ? 0 : totalBandDepth;
+						const int extB = sBottom ? 0 : totalBandDepth;
 						auto drawRing = [&](int inset, int thickness, Uint8 color, Uint8 opacity){
 							int t = thickness;
 							if(t < 1) return;
@@ -966,45 +978,37 @@ void RenderInto(::Resources & resources, ::Renderer & renderer,
 							int topRightTrim = sRight ? inset : 0;
 							int bottomLeftTrim = sLeft ? inset : 0;
 							int bottomRightTrim = sRight ? inset : 0;
-							const int fullStackTrim = std::max(0, totalBandDepth - t);
-							if(openRightBottomLeftCorner){
-								bottomLeftTrim = 0;
-							}
 							int leftTopTrim = sTop ? inset : 0;
 							int leftBottomTrim = sBottom ? inset : 0;
-							if(openRightBottomLeftCorner){
-								leftBottomTrim = fullStackTrim;
-							}
 							int rightTopTrim = sTop ? inset : 0;
 							int rightBottomTrim = sBottom ? inset : 0;
 							// Top stripe.
 							if(sTop){
-								int x = bx + topLeftTrim;
+								int x = bx + topLeftTrim - extL;
 								int y = by + inset;
-								int w = bw - topLeftTrim - topRightTrim;
+								int w = bw - topLeftTrim - topRightTrim + extL + extR;
 								fillStripe(x, y, w, t, color, opacity);
 							}
 							// Bottom stripe.
 							if(sBottom){
-								int x = bx + bottomLeftTrim;
+								int x = bx + bottomLeftTrim - extL;
 								int y = by + bh - inset - t;
-								int w = bw - bottomLeftTrim - bottomRightTrim;
+								int w = bw - bottomLeftTrim - bottomRightTrim + extL + extR;
 								fillStripe(x, y, w, t, color, opacity);
 							}
 							// Vertical edges. Closed rectangles keep the
-							// classic stepped ownership. The upper-shelf
-							// bottom-left corner in the lobby instead hands
-							// the whole lower stack to the bottom run so the
-							// elbow stays continuous without brightening.
-							int leftVy0 = by + leftTopTrim + (sTop ? t : 0);
-							int leftVy1 = by + bh - leftBottomTrim - (sBottom ? t : 0);
+							// classic stepped ownership; an open top/bottom
+							// extends the verticals outward to meet the
+							// neighbour that owns the missing horizontal.
+							int leftVy0 = by + leftTopTrim + (sTop ? t : 0) - extT;
+							int leftVy1 = by + bh - leftBottomTrim - (sBottom ? t : 0) + extB;
 							int leftVh  = leftVy1 - leftVy0;
 							if(sLeft && leftVh > 0){
 								int x = bx + inset;
 								fillStripe(x, leftVy0, t, leftVh, color, opacity);
 							}
-							int rightVy0 = by + rightTopTrim + (sTop ? t : 0);
-							int rightVy1 = by + bh - rightBottomTrim - (sBottom ? t : 0);
+							int rightVy0 = by + rightTopTrim + (sTop ? t : 0) - extT;
+							int rightVy1 = by + bh - rightBottomTrim - (sBottom ? t : 0) + extB;
 							int rightVh  = rightVy1 - rightVy0;
 							if(sRight && rightVh > 0){
 								int x = bx + bw - inset - t;

--- a/clients/silencer/src/render/clay_ui_payloads.h
+++ b/clients/silencer/src/render/clay_ui_payloads.h
@@ -161,7 +161,6 @@ struct BoxStrokePayload {
 	Uint8 innerHaloColor;
 	Uint8 innerHaloWidth;
 	Uint8 haloOpacity;
-	Uint8 glowWidth;
 	Uint8 sides;
 };
 

--- a/clients/silencer/src/render/clay_ui_payloads.h
+++ b/clients/silencer/src/render/clay_ui_payloads.h
@@ -161,6 +161,7 @@ struct BoxStrokePayload {
 	Uint8 innerHaloColor;
 	Uint8 innerHaloWidth;
 	Uint8 haloOpacity;
+	Uint8 glowWidth;
 	Uint8 sides;
 };
 

--- a/clients/silencer/src/render/renderdevice.h
+++ b/clients/silencer/src/render/renderdevice.h
@@ -38,6 +38,13 @@ public:
 	// Nearest-pixel is always used for the indexed→palette remap step regardless.
 	virtual void SetScaleFilter(bool linear) = 0;
 
+	// Queue post-process blur around already-rendered lobby panel border pixels.
+	// Backends that do not implement post-processing ignore these.
+	virtual void BeginLobbyPanelBorderBlur(int /*virtualWidth*/,
+	                                       int /*virtualHeight*/,
+	                                       float /*uiScale*/) {}
+	virtual void AddLobbyPanelBorderBlurRect(const SDL_Rect & /*rect*/) {}
+
 	// Returns false if the backend has lost its presentation target and can no
 	// longer render (e.g. TUI frame socket closed by the frontend). Game loop
 	// uses this to exit cleanly instead of spinning on broken writes.

--- a/clients/silencer/src/render/sdl3gpubackend.cpp
+++ b/clients/silencer/src/render/sdl3gpubackend.cpp
@@ -1,5 +1,6 @@
 #include "sdl3gpubackend.h"
 #include <string.h>
+#include <vector>
 
 // DXIL bytecode generated from the HLSL sources in clients/silencer/shaders/
 // at build time by dxc. The headers define `static const unsigned char
@@ -57,6 +58,63 @@ fragment float4 frag_upscale(VOut in [[stage_in]],
     texture2d<float> scene [[texture(0)]],
     sampler samp [[sampler(0)]]) {
     return scene.sample(samp, in.uv);
+}
+)msl";
+
+// Lobby panel-border post-process. This intentionally samples the rendered
+// scene texture, spreading the existing border pixels outward without tying
+// the effect to any palette index.
+static const char *kFragLobbyPanelBlurMSL = R"msl(
+#include <metal_stdlib>
+using namespace metal;
+struct VOut { float4 pos [[position]]; float2 uv; };
+fragment float4 frag_upscale(VOut in [[stage_in]],
+    texture2d<float> scene  [[texture(0)]],
+    texture2d<float> border [[texture(1)]],
+    sampler samp [[sampler(0)]]) {
+    const float2 texel = 1.0 / float2(scene.get_width(), scene.get_height());
+    float4 base = scene.sample(samp, in.uv);
+    float3 accum = float3(0.0);
+    float alpha = 0.0;
+    const float radiusLimit = 10.0;
+
+    for (int i = 1; i <= 10; ++i) {
+        float radius = float(i) - 0.35;
+        float diagonal = radius * 0.70710678;
+        float falloff = 1.0 - (float(i) / (radiusLimit + 1.0));
+        float weight = falloff * falloff * 0.18;
+
+        float4 tap = border.sample(samp, in.uv + float2( radius, 0.0) * texel);
+        accum += tap.rgb * tap.a * weight;
+        alpha += tap.a * weight;
+        tap = border.sample(samp, in.uv + float2(-radius, 0.0) * texel);
+        accum += tap.rgb * tap.a * weight;
+        alpha += tap.a * weight;
+        tap = border.sample(samp, in.uv + float2(0.0,  radius) * texel);
+        accum += tap.rgb * tap.a * weight;
+        alpha += tap.a * weight;
+        tap = border.sample(samp, in.uv + float2(0.0, -radius) * texel);
+        accum += tap.rgb * tap.a * weight;
+        alpha += tap.a * weight;
+        tap = border.sample(samp, in.uv + float2( diagonal,  diagonal) * texel);
+        accum += tap.rgb * tap.a * weight;
+        alpha += tap.a * weight;
+        tap = border.sample(samp, in.uv + float2(-diagonal,  diagonal) * texel);
+        accum += tap.rgb * tap.a * weight;
+        alpha += tap.a * weight;
+        tap = border.sample(samp, in.uv + float2( diagonal, -diagonal) * texel);
+        accum += tap.rgb * tap.a * weight;
+        alpha += tap.a * weight;
+        tap = border.sample(samp, in.uv + float2(-diagonal, -diagonal) * texel);
+        accum += tap.rgb * tap.a * weight;
+        alpha += tap.a * weight;
+    }
+
+    if (alpha <= 0.0001) {
+        return base;
+    }
+    float3 blurred = accum / alpha;
+    return float4(mix(base.rgb, blurred, saturate(alpha)), base.a);
 }
 )msl";
 
@@ -153,10 +211,101 @@ kernel void update_particles(
 static const ShaderBundle kVertScreen   = { kVertScreenMSL,   kVertScreenDXIL,   sizeof(kVertScreenDXIL),   "vert_screen"      };
 static const ShaderBundle kFragRemap    = { kFragRemapMSL,    kFragRemapDXIL,    sizeof(kFragRemapDXIL),    "frag_remap"       };
 static const ShaderBundle kFragUpscale  = { kFragUpscaleMSL,  kFragUpscaleDXIL,  sizeof(kFragUpscaleDXIL),  "frag_upscale"     };
+static const ShaderBundle kFragLobbyPanelBlur = { kFragLobbyPanelBlurMSL, kFragUpscaleDXIL, sizeof(kFragUpscaleDXIL), "frag_upscale" };
 static const ShaderBundle kFragLight    = { kFragLightMSL,    kFragLightDXIL,    sizeof(kFragLightDXIL),    "frag_light"       };
 static const ShaderBundle kVertParticle = { kVertParticleMSL, kVertParticleDXIL, sizeof(kVertParticleDXIL), "vert_particle"    };
 static const ShaderBundle kFragParticle = { kFragParticleMSL, kFragParticleDXIL, sizeof(kFragParticleDXIL), "frag_particle"    };
 static const ShaderBundle kCompParticle = { kComputeParticleMSL, kCompParticleDXIL, sizeof(kCompParticleDXIL), "update_particles" };
+
+namespace {
+
+constexpr int kLobbyPanelBlurRadius = 10;
+
+struct LobbyPanelBlurRects {
+	std::vector<SDL_Rect> blur;
+	std::vector<SDL_Rect> restore;
+};
+
+SDL_Rect ClampRect(SDL_Rect r, int w, int h) {
+	if (r.x < 0) {
+		r.w += r.x;
+		r.x = 0;
+	}
+	if (r.y < 0) {
+		r.h += r.y;
+		r.y = 0;
+	}
+	if (r.x + r.w > w) r.w = w - r.x;
+	if (r.y + r.h > h) r.h = h - r.y;
+	if (r.w < 0) r.w = 0;
+	if (r.h < 0) r.h = 0;
+	return r;
+}
+
+int CeilScaled(float value) {
+	return static_cast<int>(value + 0.9999f);
+}
+
+SDL_Rect ScaleLobbyPanelRect(SDL_Rect rect,
+                             int virtualW,
+                             int virtualH,
+                             float scale,
+                             int targetW,
+                             int targetH) {
+	if (virtualW <= 0 || virtualH <= 0 || scale <= 0.0f) {
+		return ClampRect(rect, targetW, targetH);
+	}
+	const int scaledW = static_cast<int>((float)virtualW * scale + 0.5f);
+	const int scaledH = static_cast<int>((float)virtualH * scale + 0.5f);
+	const int offsetX = scaledW < targetW ? (targetW - scaledW) / 2 : 0;
+	const int offsetY = scaledH < targetH ? (targetH - scaledH) / 2 : 0;
+	const int x0 = offsetX + static_cast<int>((float)rect.x * scale);
+	const int y0 = offsetY + static_cast<int>((float)rect.y * scale);
+	const int x1 = offsetX + CeilScaled((float)(rect.x + rect.w) * scale);
+	const int y1 = offsetY + CeilScaled((float)(rect.y + rect.h) * scale);
+	return ClampRect(SDL_Rect{ x0, y0, x1 - x0, y1 - y0 }, targetW, targetH);
+}
+
+void AddLobbyPanelBlurRect(LobbyPanelBlurRects &rects,
+                           SDL_Rect exact,
+                           int blurRadius,
+                           int w,
+                           int h) {
+	exact = ClampRect(exact, w, h);
+	if (exact.w <= 0 || exact.h <= 0) return;
+	rects.restore.push_back(exact);
+
+	SDL_Rect blur = {
+		exact.x - blurRadius,
+		exact.y - blurRadius,
+		exact.w + blurRadius * 2,
+		exact.h + blurRadius * 2,
+	};
+	blur = ClampRect(blur, w, h);
+	if (blur.w > 0 && blur.h > 0) rects.blur.push_back(blur);
+}
+
+LobbyPanelBlurRects BuildLobbyPanelBlurRects(const std::vector<SDL_Rect> & source,
+                                             int w,
+                                             int h,
+                                             int virtualW,
+                                             int virtualH,
+                                             float scale,
+                                             int blurRadius) {
+	LobbyPanelBlurRects rects;
+	if (w <= 0 || h <= 0) return rects;
+	for (const SDL_Rect & rect : source) {
+		AddLobbyPanelBlurRect(
+			rects,
+			ScaleLobbyPanelRect(rect, virtualW, virtualH, scale, w, h),
+			blurRadius,
+			w,
+			h);
+	}
+	return rects;
+}
+
+}  // namespace
 
 // ---------------------------------------------------------------------------
 SDL3GPUBackend::SDL3GPUBackend() = default;
@@ -223,8 +372,12 @@ void SDL3GPUBackend::Shutdown() {
 	if (frame_tex)         { SDL_ReleaseGPUTexture(device, frame_tex);          frame_tex         = nullptr; }
 	if (palette_tex)       { SDL_ReleaseGPUTexture(device, palette_tex);        palette_tex       = nullptr; }
 	if (scene_tex)         { SDL_ReleaseGPUTexture(device, scene_tex);          scene_tex         = nullptr; }
+	if (lobby_panel_source_tex) { SDL_ReleaseGPUTexture(device, lobby_panel_source_tex); lobby_panel_source_tex = nullptr; }
+	if (lobby_panel_mask_tex) { SDL_ReleaseGPUTexture(device, lobby_panel_mask_tex); lobby_panel_mask_tex = nullptr; }
 	if (remap_pipeline)    { SDL_ReleaseGPUGraphicsPipeline(device, remap_pipeline);   remap_pipeline   = nullptr; }
 	if (upscale_pipeline)  { SDL_ReleaseGPUGraphicsPipeline(device, upscale_pipeline); upscale_pipeline = nullptr; }
+	if (lobby_panel_blur_pipeline) { SDL_ReleaseGPUGraphicsPipeline(device, lobby_panel_blur_pipeline); lobby_panel_blur_pipeline = nullptr; }
+	if (lobby_panel_copy_pipeline) { SDL_ReleaseGPUGraphicsPipeline(device, lobby_panel_copy_pipeline); lobby_panel_copy_pipeline = nullptr; }
 	if (light_pipeline)    { SDL_ReleaseGPUGraphicsPipeline(device, light_pipeline);   light_pipeline   = nullptr; }
 	if (particle_pipeline) { SDL_ReleaseGPUGraphicsPipeline(device, particle_pipeline); particle_pipeline = nullptr; }
 	if (particle_compute)  { SDL_ReleaseGPUComputePipeline(device, particle_compute);  particle_compute  = nullptr; }
@@ -329,6 +482,64 @@ bool SDL3GPUBackend::CreatePipelines() {
 		}
 	}
 
+	return CreateLobbyPanelBlurPipeline();
+}
+
+bool SDL3GPUBackend::CreateLobbyPanelBlurPipeline() {
+	const Uint32 blurSamplers =
+		chosen_format == SDL_GPU_SHADERFORMAT_MSL ? 2u : 1u;
+	SDL_GPUShader *vs = LoadShader(SDL_GPU_SHADERSTAGE_VERTEX,   kVertScreen,  0);
+	SDL_GPUShader *fs = LoadShader(SDL_GPU_SHADERSTAGE_FRAGMENT,
+	                               kFragLobbyPanelBlur,
+	                               blurSamplers);
+	if (!vs || !fs) {
+		SDL_Log("SDL3GPUBackend: lobby panel blur shaders failed: %s", SDL_GetError());
+		if (vs) SDL_ReleaseGPUShader(device, vs);
+		if (fs) SDL_ReleaseGPUShader(device, fs);
+		return false;
+	}
+
+	SDL_GPUColorTargetDescription ct = {};
+	ct.format = SDL_GPU_TEXTUREFORMAT_R8G8B8A8_UNORM;
+
+	SDL_GPUGraphicsPipelineCreateInfo pi = {};
+	pi.vertex_shader   = vs;
+	pi.fragment_shader = fs;
+	pi.primitive_type  = SDL_GPU_PRIMITIVETYPE_TRIANGLELIST;
+	pi.target_info.color_target_descriptions = &ct;
+	pi.target_info.num_color_targets         = 1;
+
+	lobby_panel_blur_pipeline = SDL_CreateGPUGraphicsPipeline(device, &pi);
+	SDL_ReleaseGPUShader(device, vs);
+	SDL_ReleaseGPUShader(device, fs);
+	if (!lobby_panel_blur_pipeline) {
+		SDL_Log("SDL3GPUBackend: lobby panel blur pipeline failed: %s", SDL_GetError());
+		return false;
+	}
+
+	vs = LoadShader(SDL_GPU_SHADERSTAGE_VERTEX,   kVertScreen,  0);
+	fs = LoadShader(SDL_GPU_SHADERSTAGE_FRAGMENT, kFragUpscale, 1);
+	if (!vs || !fs) {
+		SDL_Log("SDL3GPUBackend: lobby panel copy shaders failed: %s", SDL_GetError());
+		if (vs) SDL_ReleaseGPUShader(device, vs);
+		if (fs) SDL_ReleaseGPUShader(device, fs);
+		return false;
+	}
+
+	pi = {};
+	pi.vertex_shader   = vs;
+	pi.fragment_shader = fs;
+	pi.primitive_type  = SDL_GPU_PRIMITIVETYPE_TRIANGLELIST;
+	pi.target_info.color_target_descriptions = &ct;
+	pi.target_info.num_color_targets         = 1;
+
+	lobby_panel_copy_pipeline = SDL_CreateGPUGraphicsPipeline(device, &pi);
+	SDL_ReleaseGPUShader(device, vs);
+	SDL_ReleaseGPUShader(device, fs);
+	if (!lobby_panel_copy_pipeline) {
+		SDL_Log("SDL3GPUBackend: lobby panel copy pipeline failed: %s", SDL_GetError());
+		return false;
+	}
 	return true;
 }
 
@@ -473,6 +684,20 @@ void SDL3GPUBackend::SetScaleFilter(bool linear) {
 	use_linear = linear;
 }
 
+void SDL3GPUBackend::BeginLobbyPanelBorderBlur(int virtualWidth,
+                                               int virtualHeight,
+                                               float uiScale) {
+	pending_lobby_panel_border_blur_rects.clear();
+	pending_lobby_panel_blur_virtual_w = virtualWidth;
+	pending_lobby_panel_blur_virtual_h = virtualHeight;
+	pending_lobby_panel_blur_scale = uiScale > 0.0f ? uiScale : 1.0f;
+}
+
+void SDL3GPUBackend::AddLobbyPanelBorderBlurRect(const SDL_Rect & rect) {
+	if (rect.w <= 0 || rect.h <= 0) return;
+	pending_lobby_panel_border_blur_rects.push_back(rect);
+}
+
 // Phase 3 — lighting
 void SDL3GPUBackend::BeginLighting() {
 	pending_light_count = 0;
@@ -593,6 +818,42 @@ void SDL3GPUBackend::Present() {
 			scene_tex_w = pending_w;
 			scene_tex_h = pending_h;
 		}
+
+		if (!lobby_panel_source_tex ||
+		    lobby_panel_source_w != pending_w ||
+		    lobby_panel_source_h != pending_h) {
+			if (lobby_panel_source_tex) SDL_ReleaseGPUTexture(device, lobby_panel_source_tex);
+			SDL_GPUTextureCreateInfo ti = {};
+			ti.type                 = SDL_GPU_TEXTURETYPE_2D;
+			ti.format               = SDL_GPU_TEXTUREFORMAT_R8G8B8A8_UNORM;
+			ti.usage                = SDL_GPU_TEXTUREUSAGE_SAMPLER |
+			                          SDL_GPU_TEXTUREUSAGE_COLOR_TARGET;
+			ti.width                = (Uint32)pending_w;
+			ti.height               = (Uint32)pending_h;
+			ti.layer_count_or_depth = 1;
+			ti.num_levels           = 1;
+			lobby_panel_source_tex = SDL_CreateGPUTexture(device, &ti);
+			lobby_panel_source_w = pending_w;
+			lobby_panel_source_h = pending_h;
+		}
+
+		if (!lobby_panel_mask_tex ||
+		    lobby_panel_mask_w != pending_w ||
+		    lobby_panel_mask_h != pending_h) {
+			if (lobby_panel_mask_tex) SDL_ReleaseGPUTexture(device, lobby_panel_mask_tex);
+			SDL_GPUTextureCreateInfo ti = {};
+			ti.type                 = SDL_GPU_TEXTURETYPE_2D;
+			ti.format               = SDL_GPU_TEXTUREFORMAT_R8G8B8A8_UNORM;
+			ti.usage                = SDL_GPU_TEXTUREUSAGE_SAMPLER |
+			                          SDL_GPU_TEXTUREUSAGE_COLOR_TARGET;
+			ti.width                = (Uint32)pending_w;
+			ti.height               = (Uint32)pending_h;
+			ti.layer_count_or_depth = 1;
+			ti.num_levels           = 1;
+			lobby_panel_mask_tex = SDL_CreateGPUTexture(device, &ti);
+			lobby_panel_mask_w = pending_w;
+			lobby_panel_mask_h = pending_h;
+		}
 	}
 
 	// Lazily create palette texture.
@@ -618,11 +879,22 @@ void SDL3GPUBackend::Present() {
 	SDL_GPUCommandBuffer *cmd = SDL_AcquireGPUCommandBuffer(device);
 	if (!cmd) return;
 
+	LobbyPanelBlurRects lobby_blur_rects =
+		BuildLobbyPanelBlurRects(
+			pending_lobby_panel_border_blur_rects,
+			pending_w,
+			pending_h,
+			pending_lobby_panel_blur_virtual_w,
+			pending_lobby_panel_blur_virtual_h,
+			pending_lobby_panel_blur_scale,
+			kLobbyPanelBlurRadius);
+
 	// ---- 1. Copy pass: upload frame + palette ----
-	if ((frame_dirty && pending_pixels && frame_tex && frame_tbuf) || palette_dirty) {
+	bool upload_frame = frame_dirty && pending_pixels && frame_tex && frame_tbuf;
+	if (upload_frame || palette_dirty) {
 		SDL_GPUCopyPass *copy = SDL_BeginGPUCopyPass(cmd);
 
-		if (frame_dirty && pending_pixels && frame_tex && frame_tbuf) {
+		if (upload_frame) {
 			Uint8 *dst = (Uint8 *)SDL_MapGPUTransferBuffer(device, frame_tbuf, false);
 			if (dst) {
 				memcpy(dst, pending_pixels, (size_t)(pending_w * pending_h));
@@ -705,7 +977,80 @@ void SDL3GPUBackend::Present() {
 		}
 	}
 
-	// ---- 4. Effects pass: particles + lights → scene_tex (LOAD, additive) ----
+	// ---- 4. Lobby panel blur pass: scene-sampled border blur → scene_tex ----
+	if (!lobby_blur_rects.blur.empty() &&
+	    lobby_panel_source_tex &&
+	    lobby_panel_mask_tex &&
+	    lobby_panel_blur_pipeline &&
+	    lobby_panel_copy_pipeline &&
+	    scene_tex) {
+		SDL_GPUBlitInfo copyInfo = {};
+		copyInfo.source.texture = scene_tex;
+		copyInfo.source.w = (Uint32)scene_tex_w;
+		copyInfo.source.h = (Uint32)scene_tex_h;
+		copyInfo.destination.texture = lobby_panel_source_tex;
+		copyInfo.destination.w = (Uint32)scene_tex_w;
+		copyInfo.destination.h = (Uint32)scene_tex_h;
+		copyInfo.load_op = SDL_GPU_LOADOP_DONT_CARE;
+		copyInfo.filter = SDL_GPU_FILTER_NEAREST;
+		SDL_BlitGPUTexture(cmd, &copyInfo);
+
+		SDL_GPUColorTargetInfo maskCt = {};
+		maskCt.texture = lobby_panel_mask_tex;
+		maskCt.load_op = SDL_GPU_LOADOP_CLEAR;
+		maskCt.store_op = SDL_GPU_STOREOP_STORE;
+		maskCt.clear_color = {0, 0, 0, 0};
+
+		bool maskReady = false;
+		SDL_GPURenderPass *maskPass = SDL_BeginGPURenderPass(cmd, &maskCt, 1, nullptr);
+		if (maskPass) {
+			SDL_BindGPUGraphicsPipeline(maskPass, lobby_panel_copy_pipeline);
+			SDL_GPUTextureSamplerBinding sourceBind = {lobby_panel_source_tex, nearest_sampler};
+			SDL_BindGPUFragmentSamplers(maskPass, 0, &sourceBind, 1);
+			for (const SDL_Rect &rect : lobby_blur_rects.restore) {
+				SDL_SetGPUScissor(maskPass, &rect);
+				SDL_DrawGPUPrimitives(maskPass, 3, 1, 0, 0);
+			}
+			SDL_EndGPURenderPass(maskPass);
+			maskReady = true;
+		}
+
+		SDL_GPUColorTargetInfo ct = {};
+		ct.texture  = scene_tex;
+		ct.load_op  = SDL_GPU_LOADOP_LOAD;
+		ct.store_op = SDL_GPU_STOREOP_STORE;
+
+		SDL_GPURenderPass *pass = maskReady
+			? SDL_BeginGPURenderPass(cmd, &ct, 1, nullptr)
+			: nullptr;
+		if (pass) {
+			SDL_BindGPUGraphicsPipeline(pass, lobby_panel_blur_pipeline);
+			SDL_GPUTextureSamplerBinding blurBinds[2] = {
+				{lobby_panel_source_tex, linear_sampler},
+				{lobby_panel_mask_tex,   linear_sampler},
+			};
+			SDL_BindGPUFragmentSamplers(
+				pass,
+				0,
+				blurBinds,
+				chosen_format == SDL_GPU_SHADERFORMAT_MSL ? 2 : 1);
+			for (const SDL_Rect &rect : lobby_blur_rects.blur) {
+				SDL_SetGPUScissor(pass, &rect);
+				SDL_DrawGPUPrimitives(pass, 3, 1, 0, 0);
+			}
+
+			SDL_BindGPUGraphicsPipeline(pass, lobby_panel_copy_pipeline);
+			SDL_GPUTextureSamplerBinding sourceBind = {lobby_panel_source_tex, nearest_sampler};
+			SDL_BindGPUFragmentSamplers(pass, 0, &sourceBind, 1);
+			for (const SDL_Rect &rect : lobby_blur_rects.restore) {
+				SDL_SetGPUScissor(pass, &rect);
+				SDL_DrawGPUPrimitives(pass, 3, 1, 0, 0);
+			}
+			SDL_EndGPURenderPass(pass);
+		}
+	}
+
+	// ---- 5. Effects pass: particles + lights → scene_tex (LOAD, additive) ----
 	bool has_particles = (pending_particle_draw_count > 0) && particle_pipeline;
 	bool has_lights    = (pending_light_count > 0) && lighting_active;
 
@@ -771,8 +1116,9 @@ void SDL3GPUBackend::Present() {
 	pending_particle_draw_count = 0;
 	pending_light_count         = 0;
 	lighting_active             = false;
+	pending_lobby_panel_border_blur_rects.clear();
 
-	// ---- 5. Acquire swapchain — null when minimized ----
+	// ---- 6. Acquire swapchain — null when minimized ----
 	SDL_GPUTexture *swapchain = nullptr;
 	Uint32 sw_w = 0, sw_h = 0;
 	SDL_WaitAndAcquireGPUSwapchainTexture(cmd, window, &swapchain, &sw_w, &sw_h);
@@ -781,7 +1127,7 @@ void SDL3GPUBackend::Present() {
 		return;
 	}
 
-	// ---- 6. Upscale pass: scene_tex → swapchain ----
+	// ---- 7. Upscale pass: scene_tex → swapchain ----
 	if (scene_tex) {
 		SDL_GPUColorTargetInfo ct = {};
 		ct.texture     = swapchain;

--- a/clients/silencer/src/render/sdl3gpubackend.h
+++ b/clients/silencer/src/render/sdl3gpubackend.h
@@ -3,6 +3,8 @@
 
 #include "renderdevice.h"
 
+#include <vector>
+
 // SDL3 GPU API backend — Metal on macOS, D3D12 on Windows.
 //
 // Phase 2 — palette remap shader: frame_tex (R8_UNORM) → scene_tex (RGBA8)
@@ -12,6 +14,7 @@
 //   copy pass   — upload frame_tex and palette_tex (dirty-flagged)
 //   compute pass — advance particle positions (one dispatch per pending update)
 //   remap pass  — indexed frame → scene_tex  (CLEAR, remap_pipeline)
+//   lobby panel blur pass — scene-sampled border blur → scene_tex (LOAD)
 //   effects pass — particles + lights → scene_tex  (LOAD, additive blend)
 //   upscale pass — scene_tex → swapchain  (CLEAR, nearest or bilinear)
 //
@@ -44,6 +47,8 @@ public:
 	void UploadFrame(const Uint8 *indexed_pixels, int w, int h) override;
 	void Present() override;
 	void SetScaleFilter(bool linear) override;
+	void BeginLobbyPanelBorderBlur(int virtualWidth, int virtualHeight, float uiScale) override;
+	void AddLobbyPanelBorderBlurRect(const SDL_Rect & rect) override;
 
 	// Phase 3 — lighting
 	void BeginLighting() override;
@@ -61,6 +66,7 @@ private:
 	bool CreatePipelines();
 	bool CreateLightPipeline();
 	bool CreateParticlePipelines();
+	bool CreateLobbyPanelBlurPipeline();
 	SDL_GPUShader *LoadShader(SDL_GPUShaderStage stage,
 	                          const ShaderBundle &b,
 	                          Uint32 num_samplers,
@@ -89,9 +95,19 @@ private:
 	int             scene_tex_w = 0;
 	int             scene_tex_h = 0;
 
+	// --- Lobby panel-border blur source ---
+	SDL_GPUTexture *lobby_panel_source_tex = nullptr; // full-res scene copy
+	SDL_GPUTexture *lobby_panel_mask_tex = nullptr; // border pixels only
+	int             lobby_panel_source_w   = 0;
+	int             lobby_panel_source_h   = 0;
+	int             lobby_panel_mask_w     = 0;
+	int             lobby_panel_mask_h     = 0;
+
 	// --- Pipelines ---
 	SDL_GPUGraphicsPipeline *remap_pipeline    = nullptr; // indexed → scene_tex
 	SDL_GPUGraphicsPipeline *upscale_pipeline  = nullptr; // scene_tex → swapchain
+	SDL_GPUGraphicsPipeline *lobby_panel_blur_pipeline = nullptr; // scene taps → scene_tex
+	SDL_GPUGraphicsPipeline *lobby_panel_copy_pipeline = nullptr; // source → scene_tex
 	SDL_GPUGraphicsPipeline *light_pipeline    = nullptr; // additive disc → scene_tex
 	SDL_GPUGraphicsPipeline *particle_pipeline = nullptr; // particles → scene_tex
 	SDL_GPUComputePipeline  *particle_compute  = nullptr; // update particle positions
@@ -134,6 +150,11 @@ private:
 	PendingParticleDraw   pending_particle_draws[kMaxParticleBuffers];
 	int pending_particle_update_count = 0;
 	int pending_particle_draw_count   = 0;
+
+	std::vector<SDL_Rect> pending_lobby_panel_border_blur_rects;
+	int pending_lobby_panel_blur_virtual_w = 0;
+	int pending_lobby_panel_blur_virtual_h = 0;
+	float pending_lobby_panel_blur_scale = 1.0f;
 };
 
 #endif

--- a/clients/silencer/src/ui/primitives/box.cpp
+++ b/clients/silencer/src/ui/primitives/box.cpp
@@ -25,7 +25,6 @@ AllocPayload(const BoxStrokeStyle & s) {
 	p->innerHaloColor = s.innerHaloColor;
 	p->innerHaloWidth = s.innerHaloWidth;
 	p->haloOpacity    = s.haloOpacity;
-	p->glowWidth      = s.glowWidth;
 	p->sides          = s.sides;
 	return p;
 }
@@ -47,14 +46,15 @@ void BoxBeginFrame() {
 }
 
 Clay_ElementDeclaration Box(BoxStrokeStyle style, Clay_ElementDeclaration extras) {
-	bool haveHalos = (style.outerHaloWidth > 0) || (style.innerHaloWidth > 0) ||
-	                 (style.glowWidth > 0);
+	Uint8 sides = style.sides ? style.sides : BoxSides::All;
+	bool haveHalos = (style.outerHaloWidth > 0) || (style.innerHaloWidth > 0);
+	bool customStroke = haveHalos || (sides != BoxSides::All);
 
-	if(haveHalos){
-		// Route the entire stroke (primary + halos/glow) through
+	if(customStroke){
+		// Route the entire stroke (primary + halos) through
 		// CustomKind::BoxStroke so the bridge renders concentric rings.
-		// Native .border stays untouched — the CUSTOM command supplies
-		// the stroke.
+		// Side-masked strokes also use this path so composed L corners
+		// join as one contiguous line.
 		auto * payload = AllocPayload(style);
 		auto * ccd     = AllocCustomData(
 			silencer::clay_bridge::CustomKind::BoxStroke, payload);
@@ -66,7 +66,6 @@ Clay_ElementDeclaration Box(BoxStrokeStyle style, Clay_ElementDeclaration extras
 		// No halos → Clay's native .border path (cheap; no CUSTOM
 		// dispatch). Per-side widths come from the side mask; suppressed
 		// sides get width 0. The bridge reads palette idx from `.r`.
-		Uint8 sides = style.sides ? style.sides : BoxSides::All;
 		Uint16 w = style.strokeWidth;
 		extras.border.color = {
 			/*r=*/static_cast<float>(style.strokeColor),

--- a/clients/silencer/src/ui/primitives/box.cpp
+++ b/clients/silencer/src/ui/primitives/box.cpp
@@ -25,6 +25,7 @@ AllocPayload(const BoxStrokeStyle & s) {
 	p->innerHaloColor = s.innerHaloColor;
 	p->innerHaloWidth = s.innerHaloWidth;
 	p->haloOpacity    = s.haloOpacity;
+	p->glowWidth      = s.glowWidth;
 	p->sides          = s.sides;
 	return p;
 }
@@ -46,10 +47,11 @@ void BoxBeginFrame() {
 }
 
 Clay_ElementDeclaration Box(BoxStrokeStyle style, Clay_ElementDeclaration extras) {
-	bool haveHalos = (style.outerHaloWidth > 0) || (style.innerHaloWidth > 0);
+	bool haveHalos = (style.outerHaloWidth > 0) || (style.innerHaloWidth > 0) ||
+	                 (style.glowWidth > 0);
 
 	if(haveHalos){
-		// Route the entire stroke (primary + halos) through
+		// Route the entire stroke (primary + halos/glow) through
 		// CustomKind::BoxStroke so the bridge renders concentric rings.
 		// Native .border stays untouched — the CUSTOM command supplies
 		// the stroke.

--- a/clients/silencer/src/ui/primitives/box.h
+++ b/clients/silencer/src/ui/primitives/box.h
@@ -88,15 +88,18 @@ struct BoxStrokeStyle {
 namespace BoxVariants {
 
 // Lobby chrome look. Bright primary stroke (palette idx 216) flanked
-// by 1-px halo bands of the SAME color at reduced opacity — the
-// alpha-blend resolves to a dimmer green against any backdrop
-// (including pure black, via the bridge's math fallback). Matches the
-// legacy lobby BG sprite's bright-bracketed-by-dim-green stroke rule.
+// by 1-px halo bands of discrete dark-green palette entries at full
+// opacity — exactly what the legacy lobby BG sprite baked in (bright
+// 216 bracketed by solid dark-green). The previous alpha-blended
+// 216@50% halo routed through the RGB math fallback over the lobby's
+// pure-black backdrop, which resolved to a muddy/rough flank instead
+// of a crisp line (issue #177). Solid discrete entries keep the line
+// smooth and match legacy.
 constexpr BoxStrokeStyle Chrome{
 	/*strokeColor=*/216, /*strokeWidth=*/1,
-	/*outerHaloColor=*/216, /*outerHaloWidth=*/1,
-	/*innerHaloColor=*/216, /*innerHaloWidth=*/1,
-	/*haloOpacity=*/128,
+	/*outerHaloColor=*/75, /*outerHaloWidth=*/1,
+	/*innerHaloColor=*/77, /*innerHaloWidth=*/1,
+	/*haloOpacity=*/255,
 };
 
 // Single 1-px stroke at idx 216, no halo. Use for non-chrome borders

--- a/clients/silencer/src/ui/primitives/box.h
+++ b/clients/silencer/src/ui/primitives/box.h
@@ -20,14 +20,15 @@
 //
 // Halo rendering: when either halo width is non-zero, the stroke routes
 // through a CUSTOM render command (`CustomKind::BoxStroke`) that paints
-// concentric inset rings: outer halo, primary, inner halo. When both
-// halo widths are zero the primitive falls through to Clay's native
-// `.border` path (cheap; no CUSTOM dispatch). `strokeWidth == 0` with
-// zero halo widths emits no stroke at all.
+// concentric inset rings: outer halo, primary, inner halo. Side-masked
+// strokes also use the CUSTOM path so composed L corners join cleanly.
+// Plain full-box strokes fall through to Clay's native `.border` path
+// (cheap; no CUSTOM dispatch). `strokeWidth == 0` with zero halo widths
+// emits no stroke at all.
 //
-// Halo-using variants MUST be preceded by `BoxBeginFrame()` once per
+// CUSTOM-using variants MUST be preceded by `BoxBeginFrame()` once per
 // layout pass before `Clay_BeginLayout()` to reset the per-frame payload
-// arena. No-halo callers can skip it — that path doesn't touch the arena.
+// arena. Plain full-box strokes can skip it — that path doesn't touch the arena.
 //
 // Fill: pass `extras.backgroundColor` directly. The bridge alpha-blends
 // non-{0,255} opacities through the palette LUT (`palette.cpp`). The
@@ -73,16 +74,6 @@ constexpr Uint8 All    = Top | Right | Bottom | Left;
 // disappear against pure-black backgrounds — keep `haloOpacity == 255`
 // (solid) unless there's a non-black backdrop under the chrome.
 //
-// `glowWidth` is an alternative to the halo bands that reproduces the
-// soft, photoshop-style blur the legacy lobby BG sprite baked into the
-// chrome line (issue #177). When non-zero, the renderer brackets the
-// bright primary with `glowWidth` 1-px rings on each side that step
-// down the palette's green ramp (216 → 215 → … toward black), so the
-// edge fades smoothly to the pure-black backdrop instead of ending in
-// a hard 1-px stroke. Solid discrete entries (no alpha LUT), so it is
-// correct over black. The step uses descending palette indices from
-// `strokeColor`, matching the contiguous green ramp at idx 210..218.
-// `glowWidth` and the halo bands are independent; Chrome uses glow.
 struct BoxStrokeStyle {
 	Uint8 strokeColor      = 0;
 	Uint8 strokeWidth      = 0;
@@ -91,25 +82,19 @@ struct BoxStrokeStyle {
 	Uint8 innerHaloColor   = 0;
 	Uint8 innerHaloWidth   = 0;
 	Uint8 haloOpacity      = 255;
-	Uint8 glowWidth        = 0;
 	Uint8 sides            = BoxSides::All;
 };
 
 namespace BoxVariants {
 
-// Lobby chrome look. Bright primary stroke (palette idx 216) wrapped
-// in a soft green glow that fades to the black backdrop over a few
-// pixels on each side — reproducing the photoshop-style blur the
-// legacy lobby BG sprite baked into the line (issue #177). The glow
-// steps down the contiguous green palette ramp (216 → 215 → … → 210)
-// with solid discrete entries, so it stays smooth and correct over
-// pure black (no broken alpha path). No halo bands — `glowWidth`
-// supplies the entire soft edge.
+// Lobby chrome look: a single solid 1-px stroke at palette idx 216.
+// The SDL3GPU backend applies the legacy soft edge as a post-process
+// over lobby panel borders; the indexed UI draw itself stays solid.
 constexpr BoxStrokeStyle Chrome{
 	/*strokeColor=*/216, /*strokeWidth=*/1,
 	/*outerHaloColor=*/0, /*outerHaloWidth=*/0,
 	/*innerHaloColor=*/0, /*innerHaloWidth=*/0,
-	/*haloOpacity=*/255, /*glowWidth=*/6,
+	/*haloOpacity=*/255,
 };
 
 // Single 1-px stroke at idx 216, no halo. Use for non-chrome borders
@@ -133,7 +118,7 @@ constexpr BoxStrokeStyle None{};
 
 // Reset the Box primitive's per-frame BoxStroke payload arena. Call
 // once before `Clay_BeginLayout()` in any layout pass that uses a
-// halo-bearing variant. Safe to call when no halos are used.
+// custom stroke. Safe to call when no custom strokes are used.
 void BoxBeginFrame();
 
 // Build a Clay element declaration with the variant's stroke baked in.

--- a/clients/silencer/src/ui/primitives/box.h
+++ b/clients/silencer/src/ui/primitives/box.h
@@ -63,9 +63,7 @@ constexpr Uint8 All    = Top | Right | Bottom | Left;
 // `innerHaloColor`). They CAN be the same as `strokeColor` — paired
 // with `haloOpacity < 255`, that gives the "same color, less opacity"
 // look. With `haloOpacity == 255` (the default) halo bands draw as
-// solid palette entries, which is what the legacy lobby BG sprite
-// actually contains (discrete dark-green entries 75/77 flanking the
-// bright 216 primary).
+// solid palette entries.
 //
 // `haloOpacity` routes the halo pixels through the palette's alphaed
 // LUT (`palette.cpp` `Palette::Alpha`). The LUT collapses any
@@ -74,6 +72,17 @@ constexpr Uint8 All    = Top | Right | Bottom | Left;
 // (e.g. the screen-clear value 0) blend to 0, so alpha-blended halos
 // disappear against pure-black backgrounds — keep `haloOpacity == 255`
 // (solid) unless there's a non-black backdrop under the chrome.
+//
+// `glowWidth` is an alternative to the halo bands that reproduces the
+// soft, photoshop-style blur the legacy lobby BG sprite baked into the
+// chrome line (issue #177). When non-zero, the renderer brackets the
+// bright primary with `glowWidth` 1-px rings on each side that step
+// down the palette's green ramp (216 → 215 → … toward black), so the
+// edge fades smoothly to the pure-black backdrop instead of ending in
+// a hard 1-px stroke. Solid discrete entries (no alpha LUT), so it is
+// correct over black. The step uses descending palette indices from
+// `strokeColor`, matching the contiguous green ramp at idx 210..218.
+// `glowWidth` and the halo bands are independent; Chrome uses glow.
 struct BoxStrokeStyle {
 	Uint8 strokeColor      = 0;
 	Uint8 strokeWidth      = 0;
@@ -82,24 +91,25 @@ struct BoxStrokeStyle {
 	Uint8 innerHaloColor   = 0;
 	Uint8 innerHaloWidth   = 0;
 	Uint8 haloOpacity      = 255;
+	Uint8 glowWidth        = 0;
 	Uint8 sides            = BoxSides::All;
 };
 
 namespace BoxVariants {
 
-// Lobby chrome look. Bright primary stroke (palette idx 216) flanked
-// by 1-px halo bands of discrete dark-green palette entries at full
-// opacity — exactly what the legacy lobby BG sprite baked in (bright
-// 216 bracketed by solid dark-green). The previous alpha-blended
-// 216@50% halo routed through the RGB math fallback over the lobby's
-// pure-black backdrop, which resolved to a muddy/rough flank instead
-// of a crisp line (issue #177). Solid discrete entries keep the line
-// smooth and match legacy.
+// Lobby chrome look. Bright primary stroke (palette idx 216) wrapped
+// in a soft green glow that fades to the black backdrop over a few
+// pixels on each side — reproducing the photoshop-style blur the
+// legacy lobby BG sprite baked into the line (issue #177). The glow
+// steps down the contiguous green palette ramp (216 → 215 → … → 210)
+// with solid discrete entries, so it stays smooth and correct over
+// pure black (no broken alpha path). No halo bands — `glowWidth`
+// supplies the entire soft edge.
 constexpr BoxStrokeStyle Chrome{
 	/*strokeColor=*/216, /*strokeWidth=*/1,
-	/*outerHaloColor=*/75, /*outerHaloWidth=*/1,
-	/*innerHaloColor=*/77, /*innerHaloWidth=*/1,
-	/*haloOpacity=*/255,
+	/*outerHaloColor=*/0, /*outerHaloWidth=*/0,
+	/*innerHaloColor=*/0, /*innerHaloWidth=*/0,
+	/*haloOpacity=*/255, /*glowWidth=*/6,
 };
 
 // Single 1-px stroke at idx 216, no halo. Use for non-chrome borders


### PR DESCRIPTION
Closes #177

Depends on / includes #192's stroke-corner compositor work for #176.

## Problem
Lobby panel border/divider lines rendered rough or muddy compared to the legacy baked chrome, and the later true-color overlay attempt made panel corners visibly worse by painting overlapping rectangular glow stripes at junctions.

## Root cause
The lobby chrome needs a soft green falloff, but it has to share the same geometry model as the stroke core. PR #192 introduced a two-pass `BoxStroke` corner-join model for composed L/stepped panels. Drawing glow outside that model creates plus-shaped corner artifacts because horizontal and vertical glow rectangles overlap beyond the actual corner ownership.

## Fix
Rebased this branch on top of `fix/issue-176-panel-corners` / PR #192 and integrated #177 smoothing into that compositor path:

- `BoxStrokePayload` carries `glowWidth`.
- `Box` routes glow-bearing chrome through the custom `BoxStroke` path.
- `BoxVariants::Chrome` uses a 1px bright core with 6px paletted green falloff.
- `clay_ui_compositor.cpp` draws outer glow, core, and inner glow as concentric bands that all participate in PR #192's two-pass corner joining.

This keeps the softened line treatment while avoiding the failed true-color overlay corner artifacts.

## Verification
- `clients/silencer/build.sh win-ninja`
- `tests/cli-agent/e2e/40_lobby_basic.sh`

Both pass locally. Build still emits existing `sprintf` deprecation warnings unrelated to this change.

🤖 Generated with Codex