### PR TITLE
feat: trigger OS on-screen keyboard on text input focus (#197)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to Silencer are documented here.
 
 ## [Unreleased]
 
+## [v00053] — 2026-05-18
+
+### Game client
+
+#### On-screen keyboard for handheld Windows (#197)
+
+- `SDL_StartTextInput` / `SDL_StopTextInput` now called on text field focus/blur in `Game::RenderClientUiFrame`, triggering the OS on-screen keyboard on handheld Windows devices (ROG Ally, Steam Deck, etc.).
+- `UiInteractionRegistry::HasTextInputFocus()` added to track which field holds focus.
+
+#### Bug fixes
+
+- Fixed null-pointer dereference on `GameStateObject` after `CreateObject` — was causing a SIGSEGV crash on ALLY10c.
+- Fixed `build.sh` crash when `ninja` is not installed (empty `gen` array with `set -u`).
+
 ## [v00052] — 2026-05-17
 
 ### Game client

--- a/clients/silencer/build.sh
+++ b/clients/silencer/build.sh
@@ -112,7 +112,7 @@ if [ "${#toolchain[@]}" -gt 0 ]; then
 else
     echo "build.sh: VCPKG_ROOT not set; using system CMake/package discovery"
 fi
-cmake -S "$script_dir" -B "$bdir" "${gen[@]}" \
+cmake -S "$script_dir" -B "$bdir" "${gen[@]+"${gen[@]}"}" \
     -DCMAKE_BUILD_TYPE="$btype" \
     -DSILENCER_UNITY_BUILD="$unity" \
     ${toolchain+"${toolchain[@]}"}

--- a/clients/silencer/src/game/game.cpp
+++ b/clients/silencer/src/game/game.cpp
@@ -572,6 +572,15 @@ void Game::RenderClientUiFrame(Surface& surface, float frametime) {
 			inGameUiController.ApplyActions(
 				world.localpeerid, unhandledUiActions, clientUi.Interactions());
 		}
+		// Sync on-screen keyboard visibility with text input focus so handheld
+		// devices (ROG Ally, Steam Deck, touchscreens) show/hide the OS keyboard.
+		bool nowFocused = clientUi.Interactions().HasTextInputFocus();
+		if(nowFocused && !textInputFocused){
+			SDL_StartTextInput(window);
+		}else if(!nowFocused && textInputFocused){
+			SDL_StopTextInput(window);
+		}
+		textInputFocused = nowFocused;
 	}
 }
 

--- a/clients/silencer/src/game/game.h
+++ b/clients/silencer/src/game/game.h
@@ -226,6 +226,7 @@ private:
 	silencer::ui::UiInputState preparedUiInput;
 	bool hasPreparedUiInput = false;
 	Uint64 lastUiAnimationMs = 0;
+	bool textInputFocused = false; // tracks on-screen keyboard state
 	int frames;
 	int fps;
 	Uint64 lasttick;

--- a/clients/silencer/src/render/renderer.cpp
+++ b/clients/silencer/src/render/renderer.cpp
@@ -53,6 +53,7 @@ void Renderer::Draw(Surface * surface, float frametime){
 		camera.w = surface->w;
 		camera.h = surface->h;
 	}
+	// DEBUG: log camera/player state for the first 60 frames while a map is loaded
 	// FPS tracking
 	Uint32 now = SDL_GetTicks();
 	fpsFrameCount++;

--- a/clients/silencer/src/ui/runtime/UiInteractionRegistry.cpp
+++ b/clients/silencer/src/ui/runtime/UiInteractionRegistry.cpp
@@ -334,6 +334,11 @@ bool UiInteractionRegistry::HasFocus() const {
 	return FocusedInteractable() != nullptr;
 }
 
+bool UiInteractionRegistry::HasTextInputFocus() const {
+	const UiInteractable * w = FocusedInteractable();
+	return w && w->kind == UiInteractableKind::TextInput && !w->inactive;
+}
+
 void UiInteractionRegistry::ClearFocus() {
 	focusedUid_ = -1;
 	focusedKind_ = UiInteractableKind::Button;

--- a/clients/silencer/src/ui/runtime/UiInteractionRegistry.h
+++ b/clients/silencer/src/ui/runtime/UiInteractionRegistry.h
@@ -88,6 +88,7 @@ public:
 	bool FocusInteractableById(const std::string& id);
 	bool IsTextInputFocused(int uid) const;
 	bool HasFocus() const;
+	bool HasTextInputFocus() const;
 	void ClearFocus();
 	bool DispatchTextInput(char ascii);
 	bool BackspaceFocusedText();

--- a/clients/silencer/src/world/world.cpp
+++ b/clients/silencer/src/world/world.cpp
@@ -160,7 +160,7 @@ void World::Tick(void){
 		// Create the replicated match-state object once per match on authority.
 		if(gameplaystate == INGAME && objectsbytype[ObjectTypes::GAMESTATEOBJ].empty()){
 			GameStateObject* gso = (GameStateObject*)CreateObject(ObjectTypes::GAMESTATEOBJ);
-			gso->modeId = gameMode ? gameMode->Id() : GAMEMODE_DATA_RETRIEVAL;
+			if(gso) gso->modeId = gameMode ? gameMode->Id() : GAMEMODE_DATA_RETRIEVAL;
 		}
 		for(int i = 0; i < maxpeers; i++){
 			Peer * peer = peerlist[i];


### PR DESCRIPTION
Fixes #197

## What

Call `SDL_StartTextInput(window)` when a `TextInput` widget gains focus and `SDL_StopTextInput(window)` when it loses focus. This signals Windows (and other touch-first OSes) to show/hide the virtual keyboard.

Previously `SDL_StartTextInput` was called once at game startup — enough to receive physical keyboard events, but not enough to trigger the OS on-screen keyboard popup on handheld/touch devices.

## Changes

- **`UiInteractionRegistry`**: new public `HasTextInputFocus()` — returns true if the currently focused interactable is an active TextInput
- **`Game`**: tracks `textInputFocused` bool; after each `DispatchInput` call, compares previous/current state and calls `SDL_StartTextInput`/`SDL_StopTextInput` on transitions

## Testing

- Build clean on macOS (100%)
- Test on ROG Ally: tap a login field → OS keyboard should appear; tap elsewhere → keyboard should dismiss