### PR TITLE
docs(skills): add image comparison review skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,10 +60,11 @@ __pycache__/
 .idea/
 cmake-build-*/
 
-# Per-developer Claude Code harness state. Skills live in shared/skills/
-# and are wired in via symlink (e.g. .claude/skills/using-silencer-cli ->
-# ../../shared/skills/cli).
+# Per-developer agent harness state. Skills live in shared/skills/
+# and are wired in via symlink (e.g. .claude/skills/using-silencer-cli or
+# .codex/skills/image-comparison-review -> ../../shared/skills/<name>).
 .claude/
+.codex/
 .mcp.json
 
 clients/silencer/build_test/

--- a/shared/skills/CLAUDE.md
+++ b/shared/skills/CLAUDE.md
@@ -26,6 +26,11 @@ before relying on the skill's content.
   Silencer UI with correct `ClientUi`/`ClayService` lifecycle, responsive
   primitives, `UiInteractionRegistry` actions, stable IDs, render dispatch, and
   runtime verification.
+- `image-comparison-review/` — compare screenshots, video grabs, current
+  captures, design references, and sprite frames by first stitching them into
+  one side-by-side composite for reliable visual review. Harness paths:
+  `.codex/skills/image-comparison-review` and
+  `.claude/skills/image-comparison-review`.
 - `visual-regression-journeys/` — capture every reachable UI surface on the
   current branch and a baseline git ref, build side-by-side composites, and
   diff. Catches regressions invisible to unit tests, E2E scripts, and

--- a/shared/skills/image-comparison-review/SKILL.md
+++ b/shared/skills/image-comparison-review/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: image-comparison-review
+description: Use when Codex must compare screenshots, video grabs, UI captures, sprite references, design mocks, or visual regression outputs. Before judging visual correctness, stitch reference and current images into one side-by-side composite, inspect that single composite, and report concrete mismatches in layout, scale, crop, text, color, focus state, sprites, and missing or extra elements.
+---
+
+# Image Comparison Review
+
+## Rule
+
+Do not rely on memory across separate image views when visual accuracy matters. Build one stitched comparison image first, then inspect that composite with `view_image` at original detail.
+
+## Workflow
+
+1. Put reference images and current images in two directories with matching filenames, or choose one explicit reference/current pair.
+2. Match the viewport before capture whenever possible. For Silencer UI, use the CLI `resize --w W --h H` before `screenshot` when the reference came from a known video or screenshot size.
+3. Run `scripts/stitch_compare.sh` to create a side-by-side sheet.
+4. Open the sheet, not only the individual images.
+5. Review row by row: viewport/crop, overall scale, panel/chrome shape, element positions, selected/hover/focus states, text content, wrapping, colors/brightness, sprite identity, and missing or extra UI.
+6. Report the composite path and the highest-impact mismatches first.
+
+## Script
+
+```bash
+# Directory mode: pairs files by identical basename.
+bash shared/skills/image-comparison-review/scripts/stitch_compare.sh \
+  --left docs/reference/character-creation-flow \
+  --right docs/reference/character-creation-flow/proof/current-1280x800 \
+  --out /tmp/character-create-compare.png \
+  --left-label reference \
+  --right-label current
+
+# Single-pair mode.
+bash shared/skills/image-comparison-review/scripts/stitch_compare.sh \
+  --left ref.png \
+  --right current.png \
+  --out /tmp/ref-vs-current.png
+```
+
+The script uses ImageMagick `magick`, annotates each side, and appends matched pairs into one vertical comparison sheet.

--- a/shared/skills/image-comparison-review/agents/openai.yaml
+++ b/shared/skills/image-comparison-review/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Image Comparison Review"
+  short_description: "Stitch images before visual review."
+  default_prompt: "Use this skill when comparing screenshots, design references, video grabs, current captures, or sprite frames. Build one side-by-side composite first, inspect that single image, then report concrete visual mismatches."

--- a/shared/skills/image-comparison-review/scripts/stitch_compare.sh
+++ b/shared/skills/image-comparison-review/scripts/stitch_compare.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Build one annotated side-by-side comparison sheet from either:
+#   --left ref.png --right current.png
+# or:
+#   --left ref_dir --right current_dir
+# In directory mode, files are paired by identical basename.
+
+set -euo pipefail
+
+LEFT=""
+RIGHT=""
+OUT=""
+GLOB="*.png"
+LEFT_LABEL="reference"
+RIGHT_LABEL="current"
+SIDE_WIDTH="640"
+
+usage() {
+  cat >&2 <<'EOF'
+usage: stitch_compare.sh --left PATH --right PATH --out FILE [options]
+
+options:
+  --glob PATTERN          directory mode filename glob (default: *.png)
+  --left-label TEXT       label over left image (default: reference)
+  --right-label TEXT      label over right image (default: current)
+  --side-width PX         resize each side to this width (default: 640)
+
+examples:
+  stitch_compare.sh --left refs --right current --out compare.png
+  stitch_compare.sh --left ref.png --right actual.png --out pair.png
+EOF
+  exit 2
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --left) LEFT="${2:-}"; shift 2 ;;
+    --right) RIGHT="${2:-}"; shift 2 ;;
+    --out) OUT="${2:-}"; shift 2 ;;
+    --glob) GLOB="${2:-}"; shift 2 ;;
+    --left-label) LEFT_LABEL="${2:-}"; shift 2 ;;
+    --right-label) RIGHT_LABEL="${2:-}"; shift 2 ;;
+    --side-width) SIDE_WIDTH="${2:-}"; shift 2 ;;
+    -h|--help) usage ;;
+    *) echo "unknown argument: $1" >&2; usage ;;
+  esac
+done
+
+[ -n "$LEFT" ] && [ -n "$RIGHT" ] && [ -n "$OUT" ] || usage
+command -v magick >/dev/null 2>&1 || {
+  echo "ImageMagick 'magick' is required. Install with: brew install imagemagick" >&2
+  exit 1
+}
+
+FONT="/System/Library/Fonts/Supplemental/Arial.ttf"
+[ -f "$FONT" ] || FONT="/System/Library/Fonts/Helvetica.ttc"
+
+TMP="$(mktemp -d)"
+cleanup() { rm -rf "$TMP"; }
+trap cleanup EXIT
+
+mkdir -p "$(dirname "$OUT")"
+
+make_row() {
+  local left_file="$1"
+  local right_file="$2"
+  local name="$3"
+  local row="$4"
+
+  magick \
+    \( "$left_file" -resize "${SIDE_WIDTH}x" -gravity North -background black -splice 0x30 -font "$FONT" -fill white -pointsize 16 -annotate +0+8 "$LEFT_LABEL" \) \
+    \( "$right_file" -resize "${SIDE_WIDTH}x" -gravity North -background black -splice 0x30 -font "$FONT" -fill white -pointsize 16 -annotate +0+8 "$RIGHT_LABEL" \) \
+    +append \
+    -gravity North -background "#202020" -splice 0x34 \
+    -font "$FONT" -fill white -pointsize 18 -annotate +0+8 "$name" \
+    "$row"
+}
+
+declare -a rows=()
+
+if [ -f "$LEFT" ] && [ -f "$RIGHT" ]; then
+  row="$TMP/row_0000.png"
+  make_row "$LEFT" "$RIGHT" "$(basename "$LEFT")" "$row"
+  rows+=("$row")
+elif [ -d "$LEFT" ] && [ -d "$RIGHT" ]; then
+  count=0
+  while IFS= read -r left_file; do
+    base="$(basename "$left_file")"
+    right_file="$RIGHT/$base"
+    if [ ! -f "$right_file" ]; then
+      echo "warning: missing right image for $base" >&2
+      continue
+    fi
+    printf -v row '%s/row_%04d.png' "$TMP" "$count"
+    make_row "$left_file" "$right_file" "$base" "$row"
+    rows+=("$row")
+    count=$((count + 1))
+  done < <(find "$LEFT" -maxdepth 1 -type f -name "$GLOB" | sort)
+else
+  echo "--left and --right must both be files or both be directories" >&2
+  exit 2
+fi
+
+if [ ${#rows[@]} -eq 0 ]; then
+  echo "no comparable image pairs found" >&2
+  exit 1
+fi
+
+magick "${rows[@]}" -append "$OUT"
+echo "$OUT"


### PR DESCRIPTION
Closes #206

## Summary
- add a shared image-comparison-review skill for screenshot/video/sprite visual reviews
- include a helper script that stitches reference and current images into one annotated side-by-side composite
- document both .claude and .codex skill symlink paths while keeping local .codex harness state ignored

## Verification
- git diff --cached --check
- generated a temporary comparison PNG with shared/skills/image-comparison-review/scripts/stitch_compare.sh