### PR TITLE
feat: add v00052 and v00053 to changelog page (#218)

### DIFF
--- a/web/admin/lib/changelog.ts
+++ b/web/admin/lib/changelog.ts
@@ -15,6 +15,50 @@ export interface ChangelogRelease {
 
 export const CHANGELOG: ChangelogRelease[] = [
   {
+    version: 'v00053',
+    date: '2026-05-18',
+    title: 'On-screen keyboard for handheld Windows',
+    entries: [
+      {
+        category: 'CLIENT',
+        changes: [
+          'On-screen keyboard for handheld Windows (#197) — SDL_StartTextInput / SDL_StopTextInput now called on text field focus/blur in Game::RenderClientUiFrame, triggering the OS on-screen keyboard on handheld Windows devices (ROG Ally, Steam Deck, etc.). UiInteractionRegistry::HasTextInputFocus() added to track which field holds focus.',
+          'Fix: null-pointer dereference on GameStateObject after CreateObject — was causing a SIGSEGV crash on ALLY10c.',
+          'Fix: build.sh crash when ninja is not installed (empty gen array with set -u).',
+        ],
+      },
+    ],
+  },
+  {
+    version: 'v00052',
+    date: '2026-05-17',
+    title: 'Magistrate boss NPC',
+    entries: [
+      {
+        category: 'CLIENT',
+        changes: [
+          'Magistrate boss NPC (#164) — fully BT-driven boss enemy. Patrols on a platform using the Civilian wall-turn pattern. Activates after a configurable delay, broadcasts a spawn sound on appearance, and broadcasts a death sound + spawns death guards when killed.',
+          'Spawn / death sounds — all clients — spawn sound plays on every client via draw-transition detection in Tick() (NEW state lasts 1 tick). Death sound plays via health-drop detection. Both bypass distance attenuation with EmitGlobalSound.',
+          'DeathFade duration extended from 10 → 120 ticks so the DYING state is reliably snapshotted by clients before the Magistrate is removed.',
+          'SpawnDeathGuards BT leaf is idempotent; safe to run multiple times during the extended DYING window.',
+          'Sound keys fixed — BT JSON sound props now use .wav extension (mgbegin.wav, mgend.wav) matching the soundbank key format.',
+          'EmitSound leaf — new global prop; when true, sound plays at full volume on every client regardless of distance.',
+          'Walk BT leaf — Magistrate Walk leaf checks DistanceToEnd and flips mirrored inline each tick (Civilian pattern), always returning Running.',
+          'Fix: map.cpp case 72 — reads and applies per-actor activationTicks and secretTriggerN from the new packed encoding in actor.type.',
+        ],
+      },
+      {
+        category: 'DASHBOARD',
+        changes: [
+          'BT editor — Magistrate action dropdown — all 8 Magistrate-specific leaf actions (Patrol, Walk, TurnAround, Stand, CheckActivation, EmitSpawnSound, EmitDeathSound, SpawnDeathGuards, DeathFade) now appear in the ACTION selector with descriptions.',
+          'BT editor — EmitSpawnSound / EmitDeathSound inspector — dedicated sound file dropdown prevents free-text key mistakes.',
+          'BT editor — EmitSound inspector — global / spatial toggle added alongside the sound dropdown.',
+          'Map designer — Magistrate spawn conditions — right-click context menu exposes Activation delay (seconds) and Secrets to activate fields. Values are packed into unused high bits of actor.type (bits 8–23 = activationTicks, bits 24–31 = secretTriggerN).',
+        ],
+      },
+    ],
+  },
+  {
     version: 'v00051',
     date: '2026-05-13',
     title: 'Complete NPC behavior tree migration',


### PR DESCRIPTION
Closes #218

Adds missing releases to `lib/changelog.ts`:
- v00053 — On-screen keyboard for handheld Windows
- v00052 — Magistrate boss NPC, BT editor + map designer updates