### PR TITLE
fix: set SDL_HINT_ENABLE_SCREEN_KEYBOARD before SDL_Init (#220)

### DIFF
--- a/clients/silencer/src/game/init/game_init.cpp
+++ b/clients/silencer/src/game/init/game_init.cpp
@@ -188,6 +188,9 @@ bool Game::Load(char * cmdline){
 		}
 	}
 	if(!world.dedicatedserver.active){
+		// Must be set before SDL_Init — tells SDL to show the OS on-screen
+		// keyboard when SDL_StartTextInput is active (handheld Windows, etc.).
+		SDL_SetHint(SDL_HINT_ENABLE_SCREEN_KEYBOARD, "1");
 		// SDL_INIT_GAMEPAD is opt-in; without it SDL_GetGamepads() returns
 		// nothing. Headless builds (CI / control-socket smoke tests) skip it
 		// since they don't need controller input. TUI mode keeps audio so the

--- a/clients/silencer/src/game/loop/game_loop.cpp
+++ b/clients/silencer/src/game/loop/game_loop.cpp
@@ -21,8 +21,8 @@
 
 using namespace GameState;
 
-static const int kLegacyRenderWidth = 640;
-static const int kLegacyRenderHeight = 480;
+static const int kLoopLegacyRenderWidth = 640;
+static const int kLoopLegacyRenderHeight = 480;
 
 bool Game::Loop(void){
 	if(updater.IsStage2Spawned()){
@@ -203,7 +203,7 @@ bool Game::Loop(void){
 			// origin/main rendered one 640x480 paletted frame and let the GPU
 			// present pass stretch it to the window. Keep that path for
 			// gameplay; native-sized CPU frames are too expensive fullscreen.
-			ResizeRenderSurfacePixels(kLegacyRenderWidth, kLegacyRenderHeight);
+			ResizeRenderSurfacePixels(kLoopLegacyRenderWidth, kLoopLegacyRenderHeight);
 			GetScreenBuffer().Clear(0);
 			renderer.Draw(&GetScreenBuffer(), ft);
 			gameUiPipeline.DrawInGameWorldInsets(GetScreenBuffer(), ft);

--- a/clients/silencer/src/game/loop/game_loop.cpp
+++ b/clients/silencer/src/game/loop/game_loop.cpp
@@ -21,8 +21,6 @@
 
 using namespace GameState;
 
-static const int kLoopLegacyRenderWidth = 640;
-static const int kLoopLegacyRenderHeight = 480;
 
 bool Game::Loop(void){
 	if(updater.IsStage2Spawned()){
@@ -203,7 +201,7 @@ bool Game::Loop(void){
 			// origin/main rendered one 640x480 paletted frame and let the GPU
 			// present pass stretch it to the window. Keep that path for
 			// gameplay; native-sized CPU frames are too expensive fullscreen.
-			ResizeRenderSurfacePixels(kLoopLegacyRenderWidth, kLoopLegacyRenderHeight);
+			ResizeRenderSurfacePixels(kLegacyRenderWidth, kLegacyRenderHeight);
 			GetScreenBuffer().Clear(0);
 			renderer.Draw(&GetScreenBuffer(), ft);
 			gameUiPipeline.DrawInGameWorldInsets(GetScreenBuffer(), ft);

--- a/clients/silencer/src/game/render/game_renderer.cpp
+++ b/clients/silencer/src/game/render/game_renderer.cpp
@@ -8,10 +8,6 @@
 #include <algorithm>
 #include <cstring>
 
-namespace {
-static const int kRendererLegacyWidth = 640;
-static const int kRendererLegacyHeight = 480;
-}
 
 GameRenderer::GameRenderer(Game & g)
 : game(g), renderdevice(nullptr), screenbuffer(640, 480), window(nullptr), fade_i(0), fadeStartMs(0) {
@@ -54,7 +50,7 @@ return true;
 
 bool GameRenderer::SyncRenderSurfaceToWindowPixels(){
 if(game.world.map.loaded){
-return ResizeRenderSurfacePixels(kRendererLegacyWidth, kRendererLegacyHeight);
+return ResizeRenderSurfacePixels(kLegacyRenderWidth, kLegacyRenderHeight);
 }
 if(!window) return false;
 int width = 0;
@@ -70,12 +66,12 @@ if(width < 1 || height < 1) return false;
 if(window){
 SDL_SetWindowSize(window, width, height);
 if(game.world.map.loaded){
-return ResizeRenderSurfacePixels(kRendererLegacyWidth, kRendererLegacyHeight);
+return ResizeRenderSurfacePixels(kLegacyRenderWidth, kLegacyRenderHeight);
 }
 return SyncRenderSurfaceToWindowPixels();
 }
 if(game.world.map.loaded){
-return ResizeRenderSurfacePixels(kRendererLegacyWidth, kRendererLegacyHeight);
+return ResizeRenderSurfacePixels(kLegacyRenderWidth, kLegacyRenderHeight);
 }
 return ResizeRenderSurfacePixels(width, height);
 }

--- a/clients/silencer/src/game/render/game_renderer.cpp
+++ b/clients/silencer/src/game/render/game_renderer.cpp
@@ -9,8 +9,8 @@
 #include <cstring>
 
 namespace {
-static const int kLegacyRenderWidth = 640;
-static const int kLegacyRenderHeight = 480;
+static const int kRendererLegacyWidth = 640;
+static const int kRendererLegacyHeight = 480;
 }
 
 GameRenderer::GameRenderer(Game & g)
@@ -54,7 +54,7 @@ return true;
 
 bool GameRenderer::SyncRenderSurfaceToWindowPixels(){
 if(game.world.map.loaded){
-return ResizeRenderSurfacePixels(kLegacyRenderWidth, kLegacyRenderHeight);
+return ResizeRenderSurfacePixels(kRendererLegacyWidth, kRendererLegacyHeight);
 }
 if(!window) return false;
 int width = 0;
@@ -70,12 +70,12 @@ if(width < 1 || height < 1) return false;
 if(window){
 SDL_SetWindowSize(window, width, height);
 if(game.world.map.loaded){
-return ResizeRenderSurfacePixels(kLegacyRenderWidth, kLegacyRenderHeight);
+return ResizeRenderSurfacePixels(kRendererLegacyWidth, kRendererLegacyHeight);
 }
 return SyncRenderSurfaceToWindowPixels();
 }
 if(game.world.map.loaded){
-return ResizeRenderSurfacePixels(kLegacyRenderWidth, kLegacyRenderHeight);
+return ResizeRenderSurfacePixels(kRendererLegacyWidth, kRendererLegacyHeight);
 }
 return ResizeRenderSurfacePixels(width, height);
 }

--- a/clients/silencer/src/game/render/game_renderer.h
+++ b/clients/silencer/src/game/render/game_renderer.h
@@ -5,6 +5,11 @@
 #include "surface.h"
 #include <SDL3/SDL.h>
 
+// Virtual resolution that the game was originally designed for.
+// Used by the renderer, UI pipeline, and game loop to compute scale factors.
+inline constexpr int kLegacyRenderWidth  = 640;
+inline constexpr int kLegacyRenderHeight = 480;
+
 class Game;
 struct SDL_Window;
 

--- a/clients/silencer/src/game/ui/game_ui_pipeline.cpp
+++ b/clients/silencer/src/game/ui/game_ui_pipeline.cpp
@@ -15,19 +15,17 @@
 #include <vector>
 
 namespace {
-static const int kUiPipelineLegacyWidth = 640;
-static const int kUiPipelineLegacyHeight = 480;
 
 static float GameplayUiScaleForSurface(int width, int height) {
-int scaleX = width / kUiPipelineLegacyWidth;
-int scaleY = height / kUiPipelineLegacyHeight;
+int scaleX = width / kLegacyRenderWidth;
+int scaleY = height / kLegacyRenderHeight;
 int uiScale = scaleX < scaleY ? scaleX : scaleY;
 return static_cast<float>(uiScale > 0 ? uiScale : 1);
 }
 
 static float MenuUiScaleForSurface(int width, int height) {
-float scaleX = static_cast<float>(width) / static_cast<float>(kUiPipelineLegacyWidth);
-float scaleY = static_cast<float>(height) / static_cast<float>(kUiPipelineLegacyHeight);
+float scaleX = static_cast<float>(width) / static_cast<float>(kLegacyRenderWidth);
+float scaleY = static_cast<float>(height) / static_cast<float>(kLegacyRenderHeight);
 float uiScale = scaleX < scaleY ? scaleX : scaleY;
 return uiScale > 1.0f ? uiScale : 1.0f;
 }
@@ -49,8 +47,8 @@ float uiScale = game.world.map.loaded
 int virtualW;
 int virtualH;
 if(game.world.map.loaded){
-virtualW = kUiPipelineLegacyWidth;
-virtualH = kUiPipelineLegacyHeight;
+virtualW = kLegacyRenderWidth;
+virtualH = kLegacyRenderHeight;
 }else{
 virtualW = std::max(1, static_cast<int>(surface.w / uiScale));
 virtualH = std::max(1, static_cast<int>(surface.h / uiScale));

--- a/clients/silencer/src/game/ui/game_ui_pipeline.cpp
+++ b/clients/silencer/src/game/ui/game_ui_pipeline.cpp
@@ -15,19 +15,19 @@
 #include <vector>
 
 namespace {
-static const int kLegacyRenderWidth = 640;
-static const int kLegacyRenderHeight = 480;
+static const int kUiPipelineLegacyWidth = 640;
+static const int kUiPipelineLegacyHeight = 480;
 
 static float GameplayUiScaleForSurface(int width, int height) {
-int scaleX = width / kLegacyRenderWidth;
-int scaleY = height / kLegacyRenderHeight;
+int scaleX = width / kUiPipelineLegacyWidth;
+int scaleY = height / kUiPipelineLegacyHeight;
 int uiScale = scaleX < scaleY ? scaleX : scaleY;
 return static_cast<float>(uiScale > 0 ? uiScale : 1);
 }
 
 static float MenuUiScaleForSurface(int width, int height) {
-float scaleX = static_cast<float>(width) / static_cast<float>(kLegacyRenderWidth);
-float scaleY = static_cast<float>(height) / static_cast<float>(kLegacyRenderHeight);
+float scaleX = static_cast<float>(width) / static_cast<float>(kUiPipelineLegacyWidth);
+float scaleY = static_cast<float>(height) / static_cast<float>(kUiPipelineLegacyHeight);
 float uiScale = scaleX < scaleY ? scaleX : scaleY;
 return uiScale > 1.0f ? uiScale : 1.0f;
 }
@@ -49,8 +49,8 @@ float uiScale = game.world.map.loaded
 int virtualW;
 int virtualH;
 if(game.world.map.loaded){
-virtualW = kLegacyRenderWidth;
-virtualH = kLegacyRenderHeight;
+virtualW = kUiPipelineLegacyWidth;
+virtualH = kUiPipelineLegacyHeight;
 }else{
 virtualW = std::max(1, static_cast<int>(surface.w / uiScale));
 virtualH = std::max(1, static_cast<int>(surface.h / uiScale));


### PR DESCRIPTION
Closes #220

Missing `SDL_HINT_ENABLE_SCREEN_KEYBOARD` hint was preventing the OS on-screen keyboard from appearing on ROG Ally / handheld Windows despite `SDL_StartTextInput` being called correctly.