### PR TITLE
Fix in-game chat legacy overlay

### DIFF
--- a/clients/cli/index.ts
+++ b/clients/cli/index.ts
@@ -18,7 +18,7 @@ function usage(): never {
       `       silencer-cli state\n` +
       `       silencer-cli inspect [--interface-id N]\n` +
       `       silencer-cli world_state\n` +
-      `       silencer-cli ingame_ui_mode --mode chat|buy|tech|playerlist|all|clear|status\n` +
+      `       silencer-cli ingame_ui_mode --mode chat|buy|tech|playerlist|all|clear|status [--chat-line TEXT]\n` +
       `       silencer-cli resize --w 1280 --h 720\n` +
       `       silencer-cli click --label "OPTIONS"\n` +
       `       silencer-cli click_at --x 320 --y 240\n` +
@@ -129,6 +129,7 @@ const STRING_FLAGS: Record<string, Record<string, Set<string>>> = {
 // and abort the silencer process.
 const STRING_FLAGS_NO_SUBOP: Record<string, Set<string>> = {
   click: new Set(["label"]),
+  ingame_ui_mode: new Set(["mode", "chat_line"]),
   set_text: new Set(["label"]),
   select: new Set(["label"]),
   scroll: new Set(["label"]),

--- a/clients/silencer/src/client/ui/hud/HudPayloadArena.cpp
+++ b/clients/silencer/src/client/ui/hud/HudPayloadArena.cpp
@@ -17,6 +17,11 @@ silencer::clay_bridge::TeamEmblemPayload g_teamEmblemPayloads[kTeamEmblemPayload
 silencer::clay_bridge::ClayCustomData    g_teamEmblemCustomData[kTeamEmblemPayloadCapacity];
 int g_teamEmblemPayloadCount = 0;
 
+silencer::clay_bridge::ClayCustomData g_messageBackgroundCustomData{
+	silencer::clay_bridge::CustomKind::MessageBackground,
+	nullptr,
+};
+
 constexpr int kStringArenaCapacity = 65536;
 char g_stringArena[kStringArenaCapacity];
 int g_stringArenaOffset = 0;
@@ -75,6 +80,10 @@ silencer::clay_bridge::ClayCustomData* AllocTeamEmblemCustomData(
 		&hudpayloadarena_detail::g_teamEmblemPayloads[hudpayloadarena_detail::g_teamEmblemPayloadCount],
 	};
 	return &hudpayloadarena_detail::g_teamEmblemCustomData[hudpayloadarena_detail::g_teamEmblemPayloadCount++];
+}
+
+silencer::clay_bridge::ClayCustomData* AllocMessageBackgroundCustomData() {
+	return &hudpayloadarena_detail::g_messageBackgroundCustomData;
 }
 
 }  // namespace client_ui

--- a/clients/silencer/src/client/ui/hud/HudPayloadArena.cpp
+++ b/clients/silencer/src/client/ui/hud/HudPayloadArena.cpp
@@ -17,9 +17,10 @@ silencer::clay_bridge::TeamEmblemPayload g_teamEmblemPayloads[kTeamEmblemPayload
 silencer::clay_bridge::ClayCustomData    g_teamEmblemCustomData[kTeamEmblemPayloadCapacity];
 int g_teamEmblemPayloadCount = 0;
 
+silencer::clay_bridge::MessageBackgroundPayload g_messageBackgroundPayload{};
 silencer::clay_bridge::ClayCustomData g_messageBackgroundCustomData{
 	silencer::clay_bridge::CustomKind::MessageBackground,
-	nullptr,
+	&g_messageBackgroundPayload,
 };
 
 constexpr int kStringArenaCapacity = 65536;
@@ -82,7 +83,9 @@ silencer::clay_bridge::ClayCustomData* AllocTeamEmblemCustomData(
 	return &hudpayloadarena_detail::g_teamEmblemCustomData[hudpayloadarena_detail::g_teamEmblemPayloadCount++];
 }
 
-silencer::clay_bridge::ClayCustomData* AllocMessageBackgroundCustomData() {
+silencer::clay_bridge::ClayCustomData* AllocMessageBackgroundCustomData(
+	silencer::clay_bridge::MessageBackgroundPayload payload) {
+	hudpayloadarena_detail::g_messageBackgroundPayload = payload;
 	return &hudpayloadarena_detail::g_messageBackgroundCustomData;
 }
 

--- a/clients/silencer/src/client/ui/hud/HudPayloadArena.h
+++ b/clients/silencer/src/client/ui/hud/HudPayloadArena.h
@@ -17,6 +17,7 @@ silencer::clay_bridge::ClayCustomData* AllocSpriteCustomData(
 	silencer::clay_bridge::SpritePayload payload);
 silencer::clay_bridge::ClayCustomData* AllocTeamEmblemCustomData(
 	silencer::clay_bridge::TeamEmblemPayload payload);
+silencer::clay_bridge::ClayCustomData* AllocMessageBackgroundCustomData();
 
 }  // namespace client_ui
 }  // namespace silencer

--- a/clients/silencer/src/client/ui/hud/HudPayloadArena.h
+++ b/clients/silencer/src/client/ui/hud/HudPayloadArena.h
@@ -17,7 +17,8 @@ silencer::clay_bridge::ClayCustomData* AllocSpriteCustomData(
 	silencer::clay_bridge::SpritePayload payload);
 silencer::clay_bridge::ClayCustomData* AllocTeamEmblemCustomData(
 	silencer::clay_bridge::TeamEmblemPayload payload);
-silencer::clay_bridge::ClayCustomData* AllocMessageBackgroundCustomData();
+silencer::clay_bridge::ClayCustomData* AllocMessageBackgroundCustomData(
+	silencer::clay_bridge::MessageBackgroundPayload payload);
 
 }  // namespace client_ui
 }  // namespace silencer

--- a/clients/silencer/src/client/ui/hud/hud_chat_overlay.cpp
+++ b/clients/silencer/src/client/ui/hud/hud_chat_overlay.cpp
@@ -2,19 +2,54 @@
 
 #include "clay/clay.h"
 #include "client/ui/hud/HudClayHelpers.h"
+#include "client/ui/hud/HudPayloadArena.h"
 #include "client/ui/views/HudView.h"
 #include "surface.h"
 #include "ui/primitives/text.h"
-#include "ui/primitives/box.h"
+#include "ui/primitives/text_input.h"
 #include "ui/runtime/UiInteractionRegistry.h"
 
 #include <SDL3/SDL_timer.h>
 
+#include <algorithm>
+#include <cstring>
 #include <string>
 #include <vector>
 
 namespace silencer {
 namespace client_ui {
+
+namespace {
+
+constexpr int kChatX = 400;
+constexpr int kChatY = 280;
+constexpr int kChatW = 231;
+constexpr int kChatBackgroundH = 30;
+constexpr int kTextX = 10;
+constexpr int kTextStartY = 10;
+constexpr int kLineStepY = 10;
+constexpr int kMaxHistoryChars = 36;
+constexpr int kChatInputVisibleChars = 28;
+
+Clay_ElementDeclaration ChatFloatingChild(const char* id, int x, int y, int w, int h) {
+	Clay_String idString{
+		.isStaticallyAllocated = true,
+		.length = static_cast<int32_t>(std::strlen(id)),
+		.chars = id,
+	};
+	return {
+		.id = Clay_GetElementId(idString),
+		.layout = {
+			.sizing = { CLAY_SIZING_FIXED((float)w), CLAY_SIZING_FIXED((float)h) },
+		},
+		.floating = {
+			.offset = { (float)x, (float)y },
+			.attachTo = CLAY_ATTACH_TO_PARENT,
+		},
+	};
+}
+
+}  // namespace
 
 void BuildChatOverlay(const HudView& view,
                       Surface* surface,
@@ -22,81 +57,101 @@ void BuildChatOverlay(const HudView& view,
 	using namespace silencer::ui::primitives;
 
 	const PlayerHudView& player = view.viewedPlayer;
+	if(!player.chatActive && view.showChatTicks <= 0) return;
 
 	std::vector<std::string> lines;
 	for(int i = 0; i < (int)view.chatLines.size(); i++) {
 		if(player.chatActive && i == 0 && view.chatLines.size() == 5) {
 			continue;
 		}
-		lines.push_back(view.chatLines[i].substr(0, 36));
+		lines.push_back(view.chatLines[i].substr(0, kMaxHistoryChars));
 	}
-	std::string inputPrefix;
-	std::string inputText;
-	if(player.chatActive) {
-		inputPrefix = player.chatWithTeam ? "(TEAM):" : "(ALL):";
-		inputText = inputPrefix + player.chatText;
-		if((SDL_GetTicks() / 50) % 32 < 16) {
-			inputText.push_back('|');
-		}
-		lines.push_back(inputText);
-	}
-	if(lines.empty()) return;
+	if(lines.empty() && !player.chatActive) return;
 
-	int panelH = 22 + ((int)lines.size() * 10);
-	if(panelH < 42) panelH = 42;
-	if(player.chatActive){
-		silencer::ui::UiInteractable chat;
-		chat.id = "ingame.chat";
-		chat.labelText = "In-game chat";
-		chat.kind = silencer::ui::UiInteractableKind::TextInput;
-		chat.uid = 9000;
-		chat.value = player.chatText;
-		chat.maxLength = player.chatTextCapacity - 1;
-		chat.clayId = CLAY_ID("InGameChatPanel");
-		chat.hasClayId = true;
-		chat.cancelOnEscape = true;
-		interactions.RegisterInteractable(chat);
+	const int contentLines = (int)lines.size() + (player.chatActive ? 1 : 0);
+	const int panelH = std::max(kChatBackgroundH + 20,
+	                            kTextStartY + contentLines * kLineStepY + 12);
 
-		silencer::ui::UiInteractable channel;
-		channel.id = "ingame.chat.channel";
-		channel.labelText = player.chatWithTeam ? "Team chat" : "All chat";
-		channel.kind = silencer::ui::UiInteractableKind::Toggle;
-		channel.selected = player.chatWithTeam;
-		channel.clayId = CLAY_ID("InGameChatPanel");
-		channel.hasClayId = true;
-		interactions.RegisterInteractable(channel);
-
-		if(!interactions.HasFocus()){
-			interactions.FocusInteractableById("ingame.chat");
-		}
-	}
-
-	CLAY({ .id = CLAY_ID("InGameChatRoot"),
-	       .layout = {
-	           .sizing = { CLAY_SIZING_FIXED((float)surface->w),
-	                       CLAY_SIZING_FIXED((float)surface->h) },
-	           .padding = { 0, 9, 0, 160 },
-	           .childAlignment = { CLAY_ALIGN_X_RIGHT, CLAY_ALIGN_Y_BOTTOM },
-	       },
-	       .floating = {
-	           .attachTo = CLAY_ATTACH_TO_ROOT,
-	       },
-	}) {
-		CLAY(Box(BoxVariants::Chrome, {
-		       .id = CLAY_ID("InGameChatPanel"),
+	(void)surface;
+	CLAY(HudFloatingElement("InGameChatPanel", kChatX, kChatY, kChatW, panelH)) {
+		CLAY({ .id = CLAY_ID("InGameChatBackground"),
 		       .layout = {
-		           .sizing = { CLAY_SIZING_FIXED(231), CLAY_SIZING_FIXED((float)panelH) },
-		           .padding = { 10, 10, 8, 8 },
-		           .childGap = 1,
-		           .layoutDirection = CLAY_TOP_TO_BOTTOM,
+		           .sizing = { CLAY_SIZING_FIXED((float)kChatW),
+		                       CLAY_SIZING_FIXED((float)kChatBackgroundH) },
 		       },
-		       .backgroundColor = { 0, 0, 0, 192 },
-		})) {
-			for(int i = 0; i < (int)lines.size(); i++) {
-				Uint8 brightness = (player.chatActive && i == (int)lines.size() - 1) ? 128 : 136;
+		       .floating = {
+		           .offset = { 0, 0 },
+		           .attachTo = CLAY_ATTACH_TO_PARENT,
+		       },
+		       .custom = {
+		           .customData = AllocMessageBackgroundCustomData(),
+		       } }) {}
+
+		int yoffset = kTextStartY;
+		for(int i = 0; i < (int)lines.size(); i++) {
+			CLAY({ .id = CLAY_IDI("InGameChatLine", i),
+			       .layout = {
+			           .sizing = { CLAY_SIZING_FIT(0), CLAY_SIZING_FIT(0) },
+			       },
+			       .floating = {
+			           .offset = { (float)kTextX, (float)yoffset },
+			           .attachTo = CLAY_ATTACH_TO_PARENT,
+			       } }) {
 				Text(ClayStringFromStd(lines[i]),
 				     { .size = TextSize::Body,
-				       .effect = TextEffect::LegacyPalette(0, brightness) });
+				       .effect = TextEffect::LegacyPalette(0, 136) });
+			}
+			yoffset += kLineStepY;
+		}
+
+		if(player.chatActive){
+			const char* inputPrefix = player.chatWithTeam ? "(TEAM):" : "(ALL):";
+			const int prefixW = static_cast<int>(std::strlen(inputPrefix)) *
+			                    TextAdvance(TextSize::Body);
+			CLAY(ChatFloatingChild("InGameChatInputPrefix",
+			                       kTextX,
+			                       yoffset,
+			                       prefixW,
+			                       TextLineHeight(TextSize::Body))) {
+				Text(ClayStringFromCString(inputPrefix),
+				     { .size = TextSize::Body,
+				       .effect = TextEffect::LegacyPalette(0, 136) });
+			}
+
+			CLAY(ChatFloatingChild("InGameChatInputWrap",
+			                       kTextX + prefixW,
+			                       yoffset,
+			                       kChatInputVisibleChars * TextAdvance(TextSize::Body),
+			                       TextLineHeight(TextSize::Body))) {
+				Clay_String stableChatText = AllocHudString(player.chatText);
+				TextInput(CLAY_STRING("InGameChatInput"),
+				          stableChatText.chars,
+				          { .widthPx = static_cast<Uint16>(
+				                kChatInputVisibleChars * TextAdvance(TextSize::Body)),
+				            .heightPx = TextLineHeight(TextSize::Body),
+				            .textSize = TextSize::Body,
+				            .effect = TextEffect::LegacyPalette(0, 128),
+				            .caretColor = 140,
+				            .showCaret = ((SDL_GetTicks() / 50) % 32 < 16) },
+				          { .actionId = "ingame.chat",
+				            .label = "In-game chat",
+				            .interactions = &interactions,
+				            .uid = 9000,
+				            .maxLength = player.chatTextCapacity - 1,
+				            .cancelOnEscape = true });
+			}
+
+			silencer::ui::UiInteractable channel;
+			channel.id = "ingame.chat.channel";
+			channel.labelText = player.chatWithTeam ? "Team chat" : "All chat";
+			channel.kind = silencer::ui::UiInteractableKind::Toggle;
+			channel.selected = player.chatWithTeam;
+			channel.clayId = CLAY_ID("InGameChatPanel");
+			channel.hasClayId = true;
+			interactions.RegisterInteractable(channel);
+
+			if(!interactions.HasFocus()){
+				interactions.FocusInteractableById("ingame.chat");
 			}
 		}
 	}

--- a/clients/silencer/src/client/ui/hud/hud_chat_overlay.cpp
+++ b/clients/silencer/src/client/ui/hud/hud_chat_overlay.cpp
@@ -24,7 +24,8 @@ namespace {
 constexpr int kChatX = 400;
 constexpr int kChatY = 280;
 constexpr int kChatW = 231;
-constexpr int kChatBackgroundH = 30;
+constexpr int kChatBackgroundInteriorH = 30;
+constexpr int kChatChromeH = 70;
 constexpr int kTextX = 10;
 constexpr int kTextStartY = 10;
 constexpr int kLineStepY = 10;
@@ -69,7 +70,7 @@ void BuildChatOverlay(const HudView& view,
 	if(lines.empty() && !player.chatActive) return;
 
 	const int contentLines = (int)lines.size() + (player.chatActive ? 1 : 0);
-	const int panelH = std::max(kChatBackgroundH + 20,
+	const int panelH = std::max(kChatChromeH,
 	                            kTextStartY + contentLines * kLineStepY + 12);
 
 	(void)surface;
@@ -77,14 +78,15 @@ void BuildChatOverlay(const HudView& view,
 		CLAY({ .id = CLAY_ID("InGameChatBackground"),
 		       .layout = {
 		           .sizing = { CLAY_SIZING_FIXED((float)kChatW),
-		                       CLAY_SIZING_FIXED((float)kChatBackgroundH) },
+		                       CLAY_SIZING_FIXED((float)kChatChromeH) },
 		       },
 		       .floating = {
 		           .offset = { 0, 0 },
 		           .attachTo = CLAY_ATTACH_TO_PARENT,
 		       },
 		       .custom = {
-		           .customData = AllocMessageBackgroundCustomData(),
+		           .customData = AllocMessageBackgroundCustomData(
+		               { static_cast<Uint16>(kChatBackgroundInteriorH) }),
 		       } }) {}
 
 		int yoffset = kTextStartY;

--- a/clients/silencer/src/client/ui/ingame/InGameUiController.cpp
+++ b/clients/silencer/src/client/ui/ingame/InGameUiController.cpp
@@ -208,7 +208,6 @@ InGameUiControlResult InGameUiController::ConfigureForControl(InGameUiControlMod
 		player->chatText[0] = '\0';
 		player->isbuying = false;
 		player->techstationactive = false;
-		world_.messaging.chatlines.clear();
 		world_.messaging.showchat_i = 0;
 		world_.SetShowingPlayerList(false);
 	};
@@ -225,7 +224,6 @@ InGameUiControlResult InGameUiController::ConfigureForControl(InGameUiControlMod
 		player->chatwithteam = false;
 		std::strncpy(player->chatText, "clay chat smoke", sizeof(player->chatText) - 1);
 		player->chatText[sizeof(player->chatText) - 1] = '\0';
-		world_.messaging.chatlines.push_back("- test");
 		world_.messaging.showchat_i = GASLoader::Get().gameengine.chatDisplayTicks;
 	}
 	if(mode == InGameUiControlMode::Buy || mode == InGameUiControlMode::All){

--- a/clients/silencer/src/client/ui/ingame/InGameUiController.cpp
+++ b/clients/silencer/src/client/ui/ingame/InGameUiController.cpp
@@ -208,6 +208,7 @@ InGameUiControlResult InGameUiController::ConfigureForControl(InGameUiControlMod
 		player->chatText[0] = '\0';
 		player->isbuying = false;
 		player->techstationactive = false;
+		world_.messaging.chatlines.clear();
 		world_.messaging.showchat_i = 0;
 		world_.SetShowingPlayerList(false);
 	};
@@ -224,6 +225,7 @@ InGameUiControlResult InGameUiController::ConfigureForControl(InGameUiControlMod
 		player->chatwithteam = false;
 		std::strncpy(player->chatText, "clay chat smoke", sizeof(player->chatText) - 1);
 		player->chatText[sizeof(player->chatText) - 1] = '\0';
+		world_.messaging.chatlines.push_back("- test");
 		world_.messaging.showchat_i = GASLoader::Get().gameengine.chatDisplayTicks;
 	}
 	if(mode == InGameUiControlMode::Buy || mode == InGameUiControlMode::All){

--- a/clients/silencer/src/net/controldispatch.cpp
+++ b/clients/silencer/src/net/controldispatch.cpp
@@ -595,6 +595,18 @@ void HandleImmediate(Game& game, ControlCommand& cmd) {
 					: result.error));
 			return;
 		}
+		using Mode = silencer::client_ui::InGameUiControlMode;
+		if((controlMode == Mode::Chat || controlMode == Mode::All) &&
+		   cmd.args.contains("chat_line")){
+			std::string chatLine = cmd.args.value("chat_line", std::string());
+			if(!chatLine.empty()){
+				auto& chatlines = game.GetWorld().messaging.chatlines;
+				chatlines.push_back(chatLine);
+				while((int)chatlines.size() > GASLoader::Get().gameengine.chatMaxLines){
+					chatlines.pop_front();
+				}
+			}
+		}
 		cmd.reply->set_value(OkResult(cmd.id, InGameUiControlResultToJson(result)));
 		return;
 	}

--- a/clients/silencer/src/render/clay_ui_compositor.cpp
+++ b/clients/silencer/src/render/clay_ui_compositor.cpp
@@ -710,12 +710,14 @@ void BlitMessageBackgroundSprite(::Resources & resources,
 
 void DispatchMessageBackground(::Resources & resources,
                                Surface * dst,
-                               const ::Clay_BoundingBox & bb) {
+                               const ::Clay_BoundingBox & bb,
+                               const MessageBackgroundPayload * payload) {
 	int x = static_cast<int>(bb.x);
 	int y = static_cast<int>(bb.y);
 	int w = static_cast<int>(bb.width);
-	int h = static_cast<int>(bb.height);
-	if(w <= 0 || h <= 0) return;
+	int visibleH = static_cast<int>(bb.height);
+	int interiorH = payload ? static_cast<int>(payload->interiorHeight) : visibleH;
+	if(w <= 0 || visibleH <= 0 || interiorH <= 0) return;
 
 	Renderer::Rect srcRect{0, 0, 0, 0};
 	BlitMessageBackgroundSprite(resources, dst, 0, srcRect, x, y);
@@ -735,7 +737,7 @@ void DispatchMessageBackground(::Resources & resources,
 	BlitMessageBackgroundSprite(resources, dst, 2, srcRect, x + w - rightCapX, y);
 
 	xOffset = SpriteWidth(resources, 188, 6);
-	const int bottomY = y + h;
+	const int bottomY = y + interiorH;
 	BlitMessageBackgroundSprite(resources, dst, 6, srcRect, x, bottomY);
 	while(xOffset < w - SpriteWidth(resources, 188, 8)){
 		int tileW = w - xOffset - rightCapX;
@@ -997,7 +999,9 @@ void RenderInto(::Resources & resources, ::Renderer & renderer,
 						break;
 					}
 					case CustomKind::MessageBackground: {
-						DispatchMessageBackground(resources, dst, c->boundingBox);
+						const auto * p =
+							reinterpret_cast<const MessageBackgroundPayload *>(ccd->payload);
+						DispatchMessageBackground(resources, dst, c->boundingBox, p);
 						break;
 					}
 					case CustomKind::ScrollBar: {

--- a/clients/silencer/src/render/clay_ui_compositor.cpp
+++ b/clients/silencer/src/render/clay_ui_compositor.cpp
@@ -555,6 +555,28 @@ Surface * ResolveSprite(::Resources & resources, Uint8 bank, Uint16 index) {
 	return src;
 }
 
+int SpriteWidth(::Resources & resources, Uint8 bank, Uint16 index) {
+	Surface * src = ResolveSprite(resources, bank, index);
+	return src ? src->w : 0;
+}
+
+int SpriteHeight(::Resources & resources, Uint8 bank, Uint16 index) {
+	Surface * src = ResolveSprite(resources, bank, index);
+	return src ? src->h : 0;
+}
+
+int SpriteOffsetX(::Resources & resources, Uint8 bank, Uint16 index) {
+	if(bank >= resources.spriteoffsetx.size()) return 0;
+	if(index >= resources.spriteoffsetx[bank].size()) return 0;
+	return resources.spriteoffsetx[bank][index];
+}
+
+int SpriteOffsetY(::Resources & resources, Uint8 bank, Uint16 index) {
+	if(bank >= resources.spriteoffsety.size()) return 0;
+	if(index >= resources.spriteoffsety[bank].size()) return 0;
+	return resources.spriteoffsety[bank][index];
+}
+
 bool BlitClipped(Surface * src,
                  Renderer::Rect srcRect,
                  Surface * dst,
@@ -669,6 +691,63 @@ void DispatchButtonNineSlice(::Resources & resources,
 	            dst, x + w - dstRight, y + h - dstBottom);
 
 	if(work != src) delete work;
+}
+
+void BlitMessageBackgroundSprite(::Resources & resources,
+                                 Surface * dst,
+                                 Uint16 index,
+                                 Renderer::Rect srcRect,
+                                 int logicalX,
+                                 int logicalY) {
+	Surface * src = ResolveSprite(resources, 188, index);
+	if(!src) return;
+	if(srcRect.w <= 0) srcRect.w = src->w;
+	if(srcRect.h <= 0) srcRect.h = src->h;
+	BlitClipped(src, srcRect, dst,
+	            logicalX - SpriteOffsetX(resources, 188, index),
+	            logicalY - SpriteOffsetY(resources, 188, index));
+}
+
+void DispatchMessageBackground(::Resources & resources,
+                               Surface * dst,
+                               const ::Clay_BoundingBox & bb) {
+	int x = static_cast<int>(bb.x);
+	int y = static_cast<int>(bb.y);
+	int w = static_cast<int>(bb.width);
+	int h = static_cast<int>(bb.height);
+	if(w <= 0 || h <= 0) return;
+
+	Renderer::Rect srcRect{0, 0, 0, 0};
+	BlitMessageBackgroundSprite(resources, dst, 0, srcRect, x, y);
+
+	int xOffset = SpriteWidth(resources, 188, 0);
+	const int rightCapX = 36;
+	while(xOffset < w - SpriteWidth(resources, 188, 2)){
+		int tileW = w - xOffset - rightCapX;
+		int maxTileW = SpriteWidth(resources, 188, 1);
+		if(maxTileW <= 0) break;
+		if(tileW > maxTileW) tileW = maxTileW;
+		if(tileW <= 0) break;
+		Renderer::Rect tile{tileW, SpriteHeight(resources, 188, 1), 0, 0};
+		BlitMessageBackgroundSprite(resources, dst, 1, tile, x + xOffset, y);
+		xOffset += tileW;
+	}
+	BlitMessageBackgroundSprite(resources, dst, 2, srcRect, x + w - rightCapX, y);
+
+	xOffset = SpriteWidth(resources, 188, 6);
+	const int bottomY = y + h;
+	BlitMessageBackgroundSprite(resources, dst, 6, srcRect, x, bottomY);
+	while(xOffset < w - SpriteWidth(resources, 188, 8)){
+		int tileW = w - xOffset - rightCapX;
+		int maxTileW = SpriteWidth(resources, 188, 7);
+		if(maxTileW <= 0) break;
+		if(tileW > maxTileW) tileW = maxTileW;
+		if(tileW <= 0) break;
+		Renderer::Rect tile{tileW, SpriteHeight(resources, 188, 7), 0, 0};
+		BlitMessageBackgroundSprite(resources, dst, 7, tile, x + xOffset, bottomY);
+		xOffset += tileW;
+	}
+	BlitMessageBackgroundSprite(resources, dst, 8, srcRect, x + w - rightCapX, bottomY);
 }
 
 void OutlineVisiblePixels(::Renderer & renderer,
@@ -915,6 +994,10 @@ void RenderInto(::Resources & resources, ::Renderer & renderer,
 							p->pixels, p->pixels + (static_cast<size_t>(p->width) * p->height));
 						Renderer::Rect dstrect{w, h, x, y};
 						Renderer::BlitSurface(&srcsurface, nullptr, dst, &dstrect);
+						break;
+					}
+					case CustomKind::MessageBackground: {
+						DispatchMessageBackground(resources, dst, c->boundingBox);
 						break;
 					}
 					case CustomKind::ScrollBar: {

--- a/clients/silencer/src/render/clay_ui_payloads.h
+++ b/clients/silencer/src/render/clay_ui_payloads.h
@@ -64,6 +64,10 @@ struct ClayCustomData {
 	void * payload;
 };
 
+struct MessageBackgroundPayload {
+	Uint16 interiorHeight;
+};
+
 struct ButtonSpritePayload {
 	Uint8  bank;
 	Uint16 index;

--- a/clients/silencer/src/render/clay_ui_payloads.h
+++ b/clients/silencer/src/render/clay_ui_payloads.h
@@ -56,6 +56,7 @@ enum class CustomKind : Uint8 {
 	Sprite,
 	TeamEmblem,
 	Surface,
+	MessageBackground,
 };
 
 struct ClayCustomData {


### PR DESCRIPTION
Closes #208

## Summary
- Restores the pre-Clay in-game chat window placement, bank-188 frame, line truncation, text brightness, and input/caret rendering.
- Keeps chat history hidden once its display timer expires, matching the legacy renderer condition.
- Adds an explicit control-only `--chat-line` argument for deterministic chat overlay screenshots without seeding fake chat content in the runtime UI controller.

## Screenshots
Secret gist: https://gist.github.com/hvent90/a81b822163a95c02dff48a4554b84ca2

Pre-Clay reference on the left, fixed runtime capture on the right:

![Pre-Clay vs fixed in-game chat overlay](https://gist.githubusercontent.com/hvent90/a81b822163a95c02dff48a4554b84ca2/raw/d5e9504bca03d4eab18cecbd9fcb4159bb3fd6a4/preclay-vs-fixed-side-by-side.svg)

Fixed runtime crop:

![Fixed runtime in-game chat overlay](https://gist.githubusercontent.com/hvent90/a81b822163a95c02dff48a4554b84ca2/raw/167079a6981fe9b0ef1bde2a839a17359d955fac/fixed-runtime-chat.svg)

## Verification
- `bunx oxfmt --write clients/cli/index.ts`
- `clients/silencer/build.sh`
- `bash tests/cli-agent/e2e/51_ingame_ui_overlays.sh`
- Captured pre-Clay `18e0030c^` versus fixed runtime and sent Discord DM with the side-by-side image.