### PR TITLE
Keep chat chrome rendering in HUD layer

### DIFF
--- a/clients/silencer/src/client/ui/hud/HudPayloadArena.cpp
+++ b/clients/silencer/src/client/ui/hud/HudPayloadArena.cpp
@@ -17,12 +17,6 @@ silencer::clay_bridge::TeamEmblemPayload g_teamEmblemPayloads[kTeamEmblemPayload
 silencer::clay_bridge::ClayCustomData    g_teamEmblemCustomData[kTeamEmblemPayloadCapacity];
 int g_teamEmblemPayloadCount = 0;
 
-silencer::clay_bridge::MessageBackgroundPayload g_messageBackgroundPayload{};
-silencer::clay_bridge::ClayCustomData g_messageBackgroundCustomData{
-	silencer::clay_bridge::CustomKind::MessageBackground,
-	&g_messageBackgroundPayload,
-};
-
 constexpr int kStringArenaCapacity = 65536;
 char g_stringArena[kStringArenaCapacity];
 int g_stringArenaOffset = 0;
@@ -81,12 +75,6 @@ silencer::clay_bridge::ClayCustomData* AllocTeamEmblemCustomData(
 		&hudpayloadarena_detail::g_teamEmblemPayloads[hudpayloadarena_detail::g_teamEmblemPayloadCount],
 	};
 	return &hudpayloadarena_detail::g_teamEmblemCustomData[hudpayloadarena_detail::g_teamEmblemPayloadCount++];
-}
-
-silencer::clay_bridge::ClayCustomData* AllocMessageBackgroundCustomData(
-	silencer::clay_bridge::MessageBackgroundPayload payload) {
-	hudpayloadarena_detail::g_messageBackgroundPayload = payload;
-	return &hudpayloadarena_detail::g_messageBackgroundCustomData;
 }
 
 }  // namespace client_ui

--- a/clients/silencer/src/client/ui/hud/HudPayloadArena.h
+++ b/clients/silencer/src/client/ui/hud/HudPayloadArena.h
@@ -17,8 +17,6 @@ silencer::clay_bridge::ClayCustomData* AllocSpriteCustomData(
 	silencer::clay_bridge::SpritePayload payload);
 silencer::clay_bridge::ClayCustomData* AllocTeamEmblemCustomData(
 	silencer::clay_bridge::TeamEmblemPayload payload);
-silencer::clay_bridge::ClayCustomData* AllocMessageBackgroundCustomData(
-	silencer::clay_bridge::MessageBackgroundPayload payload);
 
 }  // namespace client_ui
 }  // namespace silencer

--- a/clients/silencer/src/client/ui/hud/InGameHud.cpp
+++ b/clients/silencer/src/client/ui/hud/InGameHud.cpp
@@ -62,7 +62,7 @@ void BuildInGameHudUi(Renderer& renderer, const Resources& resources,
 	}
 
 	if(view.showChatTicks || player.chatActive){
-		BuildChatOverlay(view, surface, interactions);
+		BuildChatOverlay(view, resources, surface, interactions);
 	}
 }
 

--- a/clients/silencer/src/client/ui/hud/hud_chat_overlay.cpp
+++ b/clients/silencer/src/client/ui/hud/hud_chat_overlay.cpp
@@ -4,6 +4,7 @@
 #include "client/ui/hud/HudClayHelpers.h"
 #include "client/ui/hud/HudPayloadArena.h"
 #include "client/ui/views/HudView.h"
+#include "resources.h"
 #include "surface.h"
 #include "ui/primitives/text.h"
 #include "ui/primitives/text_input.h"
@@ -26,11 +27,13 @@ constexpr int kChatY = 280;
 constexpr int kChatW = 231;
 constexpr int kChatBackgroundInteriorH = 30;
 constexpr int kChatChromeH = 70;
+constexpr Uint8 kChatBackgroundBank = 188;
 constexpr int kTextX = 10;
 constexpr int kTextStartY = 10;
 constexpr int kLineStepY = 10;
 constexpr int kMaxHistoryChars = 36;
 constexpr int kChatInputVisibleChars = 28;
+constexpr int kRightCapX = 36;
 
 Clay_ElementDeclaration ChatFloatingChild(const char* id, int x, int y, int w, int h) {
 	Clay_String idString{
@@ -50,9 +53,94 @@ Clay_ElementDeclaration ChatFloatingChild(const char* id, int x, int y, int w, i
 	};
 }
 
+void EmitChatBackgroundSprite(const Resources& resources,
+                              int& ordinal,
+                              Uint16 spriteIndex,
+                              int logicalX,
+                              int logicalY,
+                              int srcW = 0,
+                              int srcH = 0) {
+	const int spriteW = SpriteWidth(resources, kChatBackgroundBank, spriteIndex);
+	const int spriteH = SpriteHeight(resources, kChatBackgroundBank, spriteIndex);
+	if(spriteW <= 0 || spriteH <= 0) return;
+	if(srcW <= 0) srcW = spriteW;
+	if(srcH <= 0) srcH = spriteH;
+
+	CLAY({ .id = CLAY_IDI("InGameChatBackgroundSprite", ordinal++),
+	       .layout = {
+	           .sizing = { CLAY_SIZING_FIXED((float)srcW),
+	                       CLAY_SIZING_FIXED((float)srcH) },
+	       },
+	       .floating = {
+	           .offset = {
+	               (float)SpriteX(resources, kChatBackgroundBank, spriteIndex, logicalX),
+	               (float)SpriteY(resources, kChatBackgroundBank, spriteIndex, logicalY),
+	           },
+	           .attachTo = CLAY_ATTACH_TO_PARENT,
+	       },
+	       .custom = { .customData = AllocSpriteCustomData({
+	           kChatBackgroundBank,
+	           spriteIndex,
+	           0,
+	           0,
+	           static_cast<Sint16>(srcW),
+	           static_cast<Sint16>(srcH),
+	           0,
+	           128,
+	           0,
+	           0,
+	       }) } }) {}
+}
+
+void EmitChatBackground(const Resources& resources) {
+	int ordinal = 0;
+	EmitChatBackgroundSprite(resources, ordinal, 0, 0, 0);
+
+	int xOffset = SpriteWidth(resources, kChatBackgroundBank, 0);
+	while(xOffset < kChatW - SpriteWidth(resources, kChatBackgroundBank, 2)){
+		int tileW = kChatW - xOffset - kRightCapX;
+		const int maxTileW = SpriteWidth(resources, kChatBackgroundBank, 1);
+		if(maxTileW <= 0) break;
+		if(tileW > maxTileW) tileW = maxTileW;
+		if(tileW <= 0) break;
+		EmitChatBackgroundSprite(
+			resources,
+			ordinal,
+			1,
+			xOffset,
+			0,
+			tileW,
+			SpriteHeight(resources, kChatBackgroundBank, 1));
+		xOffset += tileW;
+	}
+	EmitChatBackgroundSprite(resources, ordinal, 2, kChatW - kRightCapX, 0);
+
+	xOffset = SpriteWidth(resources, kChatBackgroundBank, 6);
+	EmitChatBackgroundSprite(resources, ordinal, 6, 0, kChatBackgroundInteriorH);
+	while(xOffset < kChatW - SpriteWidth(resources, kChatBackgroundBank, 8)){
+		int tileW = kChatW - xOffset - kRightCapX;
+		const int maxTileW = SpriteWidth(resources, kChatBackgroundBank, 7);
+		if(maxTileW <= 0) break;
+		if(tileW > maxTileW) tileW = maxTileW;
+		if(tileW <= 0) break;
+		EmitChatBackgroundSprite(
+			resources,
+			ordinal,
+			7,
+			xOffset,
+			kChatBackgroundInteriorH,
+			tileW,
+			SpriteHeight(resources, kChatBackgroundBank, 7));
+		xOffset += tileW;
+	}
+	EmitChatBackgroundSprite(
+		resources, ordinal, 8, kChatW - kRightCapX, kChatBackgroundInteriorH);
+}
+
 }  // namespace
 
 void BuildChatOverlay(const HudView& view,
+                      const Resources& resources,
                       Surface* surface,
                       silencer::ui::UiInteractionRegistry& interactions) {
 	using namespace silencer::ui::primitives;
@@ -75,19 +163,7 @@ void BuildChatOverlay(const HudView& view,
 
 	(void)surface;
 	CLAY(HudFloatingElement("InGameChatPanel", kChatX, kChatY, kChatW, panelH)) {
-		CLAY({ .id = CLAY_ID("InGameChatBackground"),
-		       .layout = {
-		           .sizing = { CLAY_SIZING_FIXED((float)kChatW),
-		                       CLAY_SIZING_FIXED((float)kChatChromeH) },
-		       },
-		       .floating = {
-		           .offset = { 0, 0 },
-		           .attachTo = CLAY_ATTACH_TO_PARENT,
-		       },
-		       .custom = {
-		           .customData = AllocMessageBackgroundCustomData(
-		               { static_cast<Uint16>(kChatBackgroundInteriorH) }),
-		       } }) {}
+		EmitChatBackground(resources);
 
 		int yoffset = kTextStartY;
 		for(int i = 0; i < (int)lines.size(); i++) {

--- a/clients/silencer/src/client/ui/hud/hud_chat_overlay.h
+++ b/clients/silencer/src/client/ui/hud/hud_chat_overlay.h
@@ -1,6 +1,7 @@
 #pragma once
 
 class Surface;
+class Resources;
 
 namespace silencer {
 namespace ui {
@@ -13,6 +14,7 @@ struct HudView;
 // Bottom-right chat overlay: history + an in-progress chat input line when the
 // viewed player has chat focus.
 void BuildChatOverlay(const HudView& view,
+                      const Resources& resources,
                       Surface* surface,
                       silencer::ui::UiInteractionRegistry& interactions);
 

--- a/clients/silencer/src/render/clay_ui_compositor.cpp
+++ b/clients/silencer/src/render/clay_ui_compositor.cpp
@@ -558,28 +558,6 @@ Surface * ResolveSprite(::Resources & resources, Uint8 bank, Uint16 index) {
 	return src;
 }
 
-int SpriteWidth(::Resources & resources, Uint8 bank, Uint16 index) {
-	Surface * src = ResolveSprite(resources, bank, index);
-	return src ? src->w : 0;
-}
-
-int SpriteHeight(::Resources & resources, Uint8 bank, Uint16 index) {
-	Surface * src = ResolveSprite(resources, bank, index);
-	return src ? src->h : 0;
-}
-
-int SpriteOffsetX(::Resources & resources, Uint8 bank, Uint16 index) {
-	if(bank >= resources.spriteoffsetx.size()) return 0;
-	if(index >= resources.spriteoffsetx[bank].size()) return 0;
-	return resources.spriteoffsetx[bank][index];
-}
-
-int SpriteOffsetY(::Resources & resources, Uint8 bank, Uint16 index) {
-	if(bank >= resources.spriteoffsety.size()) return 0;
-	if(index >= resources.spriteoffsety[bank].size()) return 0;
-	return resources.spriteoffsety[bank][index];
-}
-
 bool BlitClipped(Surface * src,
                  Renderer::Rect srcRect,
                  Surface * dst,
@@ -694,65 +672,6 @@ void DispatchButtonNineSlice(::Resources & resources,
 	            dst, x + w - dstRight, y + h - dstBottom);
 
 	if(work != src) delete work;
-}
-
-void BlitMessageBackgroundSprite(::Resources & resources,
-                                 Surface * dst,
-                                 Uint16 index,
-                                 Renderer::Rect srcRect,
-                                 int logicalX,
-                                 int logicalY) {
-	Surface * src = ResolveSprite(resources, 188, index);
-	if(!src) return;
-	if(srcRect.w <= 0) srcRect.w = src->w;
-	if(srcRect.h <= 0) srcRect.h = src->h;
-	BlitClipped(src, srcRect, dst,
-	            logicalX - SpriteOffsetX(resources, 188, index),
-	            logicalY - SpriteOffsetY(resources, 188, index));
-}
-
-void DispatchMessageBackground(::Resources & resources,
-                               Surface * dst,
-                               const ::Clay_BoundingBox & bb,
-                               const MessageBackgroundPayload * payload) {
-	int x = static_cast<int>(bb.x);
-	int y = static_cast<int>(bb.y);
-	int w = static_cast<int>(bb.width);
-	int visibleH = static_cast<int>(bb.height);
-	int interiorH = payload ? static_cast<int>(payload->interiorHeight) : visibleH;
-	if(w <= 0 || visibleH <= 0 || interiorH <= 0) return;
-
-	Renderer::Rect srcRect{0, 0, 0, 0};
-	BlitMessageBackgroundSprite(resources, dst, 0, srcRect, x, y);
-
-	int xOffset = SpriteWidth(resources, 188, 0);
-	const int rightCapX = 36;
-	while(xOffset < w - SpriteWidth(resources, 188, 2)){
-		int tileW = w - xOffset - rightCapX;
-		int maxTileW = SpriteWidth(resources, 188, 1);
-		if(maxTileW <= 0) break;
-		if(tileW > maxTileW) tileW = maxTileW;
-		if(tileW <= 0) break;
-		Renderer::Rect tile{tileW, SpriteHeight(resources, 188, 1), 0, 0};
-		BlitMessageBackgroundSprite(resources, dst, 1, tile, x + xOffset, y);
-		xOffset += tileW;
-	}
-	BlitMessageBackgroundSprite(resources, dst, 2, srcRect, x + w - rightCapX, y);
-
-	xOffset = SpriteWidth(resources, 188, 6);
-	const int bottomY = y + interiorH;
-	BlitMessageBackgroundSprite(resources, dst, 6, srcRect, x, bottomY);
-	while(xOffset < w - SpriteWidth(resources, 188, 8)){
-		int tileW = w - xOffset - rightCapX;
-		int maxTileW = SpriteWidth(resources, 188, 7);
-		if(maxTileW <= 0) break;
-		if(tileW > maxTileW) tileW = maxTileW;
-		if(tileW <= 0) break;
-		Renderer::Rect tile{tileW, SpriteHeight(resources, 188, 7), 0, 0};
-		BlitMessageBackgroundSprite(resources, dst, 7, tile, x + xOffset, bottomY);
-		xOffset += tileW;
-	}
-	BlitMessageBackgroundSprite(resources, dst, 8, srcRect, x + w - rightCapX, bottomY);
 }
 
 void OutlineVisiblePixels(::Renderer & renderer,
@@ -999,12 +918,6 @@ void RenderInto(::Resources & resources, ::Renderer & renderer,
 							p->pixels, p->pixels + (static_cast<size_t>(p->width) * p->height));
 						Renderer::Rect dstrect{w, h, x, y};
 						Renderer::BlitSurface(&srcsurface, nullptr, dst, &dstrect);
-						break;
-					}
-					case CustomKind::MessageBackground: {
-						const auto * p =
-							reinterpret_cast<const MessageBackgroundPayload *>(ccd->payload);
-						DispatchMessageBackground(resources, dst, c->boundingBox, p);
 						break;
 					}
 					case CustomKind::ScrollBar: {

--- a/clients/silencer/src/render/clay_ui_payloads.h
+++ b/clients/silencer/src/render/clay_ui_payloads.h
@@ -57,16 +57,11 @@ enum class CustomKind : Uint8 {
 	Sprite,
 	TeamEmblem,
 	Surface,
-	MessageBackground,
 };
 
 struct ClayCustomData {
 	CustomKind kind;
 	void * payload;
-};
-
-struct MessageBackgroundPayload {
-	Uint16 interiorHeight;
 };
 
 struct ButtonSpritePayload {


### PR DESCRIPTION
Follow-up to #234 / #208.

## Summary
- Moves legacy bank-188 chat chrome composition out of the generic Clay compositor and into the HUD chat overlay.
- Emits the chat chrome as ordinary HUD `SpritePayload` elements, reusing existing sprite rendering instead of a chat-specific compositor custom kind.

## Screenshots
Secret gist: https://gist.github.com/hvent90/a81b822163a95c02dff48a4554b84ca2

Pre-Clay reference on the left, fixed runtime capture on the right:

![Pre-Clay vs fixed in-game chat overlay](https://gist.githubusercontent.com/hvent90/a81b822163a95c02dff48a4554b84ca2/raw/15d3c3a27d915cbd71e6dcf0fc9ee785089d5939/preclay-vs-fixed-side-by-side.svg)

Fixed runtime crop:

![Fixed runtime in-game chat overlay](https://gist.githubusercontent.com/hvent90/a81b822163a95c02dff48a4554b84ca2/raw/39e77c95ba364cf1a88e05cf4504e943317807be/fixed-runtime-chat.svg)

## Verification
- `git diff --check origin/main...HEAD`
- `clients/silencer/build.sh`
- `bash tests/cli-agent/e2e/51_ingame_ui_overlays.sh`
- Captured a fresh pre-Clay vs fixed runtime side-by-side after this refactor.