### PR TITLE
Fix character naming and migrated renames

### DIFF
--- a/clients/lobby-sdk/cpp/include/silencer/lobby/client.h
+++ b/clients/lobby-sdk/cpp/include/silencer/lobby/client.h
@@ -77,6 +77,7 @@ public:
     void set_game(uint32_t game_id, GameStatus status);
     void create_character(const std::string& name, uint8_t agency_idx);
     void select_character(uint32_t character_id);
+    void rename_character(uint32_t character_id, const std::string& name);
     void register_stats(uint32_t game_id, uint8_t team_number, uint32_t account_id,
                         uint32_t character_id, uint8_t stats_agency, bool won, uint32_t xp,
                         const MatchStats& stats);

--- a/clients/lobby-sdk/cpp/include/silencer/lobby/codec.h
+++ b/clients/lobby-sdk/cpp/include/silencer/lobby/codec.h
@@ -91,6 +91,7 @@ std::vector<uint8_t> encode_upgrade_stat(uint32_t character_id, uint8_t agency_i
 std::vector<uint8_t> encode_set_game(uint32_t game_id, GameStatus status);
 std::vector<uint8_t> encode_create_character(const std::string& name, uint8_t agency_idx);
 std::vector<uint8_t> encode_select_character(uint32_t character_id);
+std::vector<uint8_t> encode_rename_character(uint32_t character_id, const std::string& name);
 std::vector<uint8_t> encode_register_stats(uint32_t game_id, uint8_t team_number,
                                            uint32_t account_id, uint32_t character_id,
                                            uint8_t stats_agency,

--- a/clients/lobby-sdk/cpp/include/silencer/lobby/types.h
+++ b/clients/lobby-sdk/cpp/include/silencer/lobby/types.h
@@ -28,6 +28,7 @@ enum Op : uint8_t {
     OpCharacters    = 14,
     OpCreateCharacter = 15,
     OpSelectCharacter = 16,
+    OpRenameCharacter = 17,
 };
 
 enum class Platform : uint8_t {
@@ -84,6 +85,7 @@ struct UserInfo {
 struct CharacterInfo {
     uint32_t    id         = 0;
     uint8_t     agency_idx = 0;
+    bool        rename_available = false;
     AgencyStats stats      = {};
     std::string name;
 };

--- a/clients/lobby-sdk/cpp/src/client.cpp
+++ b/clients/lobby-sdk/cpp/src/client.cpp
@@ -341,6 +341,10 @@ void Client::select_character(uint32_t character_id) {
     send_raw(encode_select_character(character_id));
 }
 
+void Client::rename_character(uint32_t character_id, const std::string& name) {
+    send_raw(encode_rename_character(character_id, name));
+}
+
 void Client::register_stats(uint32_t game_id, uint8_t team_number, uint32_t account_id,
                             uint32_t character_id, uint8_t stats_agency, bool won, uint32_t xp,
                             const MatchStats& stats) {

--- a/clients/lobby-sdk/cpp/src/codec.cpp
+++ b/clients/lobby-sdk/cpp/src/codec.cpp
@@ -234,6 +234,14 @@ std::vector<uint8_t> encode_select_character(uint32_t character_id) {
     return std::move(w).take();
 }
 
+std::vector<uint8_t> encode_rename_character(uint32_t character_id, const std::string& name) {
+    Writer w;
+    w.u8(OpRenameCharacter);
+    w.u32_le(character_id);
+    w.lenstr(name.size() > 16 ? name.substr(0, 16) : name);
+    return std::move(w).take();
+}
+
 std::vector<uint8_t> encode_register_stats(uint32_t game_id, uint8_t team_number,
                                            uint32_t account_id, uint32_t character_id,
                                            uint8_t stats_agency,
@@ -387,7 +395,9 @@ CharactersPayload decode_characters(Reader& r) {
     for(uint8_t i = 0; i < count; ++i){
         CharacterInfo ch;
         ch.id = r.u32_le();
-        ch.agency_idx = r.u8();
+        uint8_t agency_flags = r.u8();
+        ch.agency_idx = agency_flags & 0x7f;
+        ch.rename_available = (agency_flags & 0x80) != 0;
         ch.stats = decode_agency_stats(r);
         ch.name = r.lenstr();
         payload.characters.push_back(std::move(ch));
@@ -437,7 +447,7 @@ void encode_characters_body(Writer& w, const CharactersPayload& payload) {
     w.u32_le(payload.selected_char_id);
     for(const CharacterInfo& ch : payload.characters){
         w.u32_le(ch.id);
-        w.u8(ch.agency_idx);
+        w.u8((ch.agency_idx & 0x7f) | (ch.rename_available ? 0x80 : 0));
         encode_agency_stats(w, ch.stats);
         w.lenstr(ch.name);
     }

--- a/clients/lobby-sdk/cpp/tests/codec_test.cpp
+++ b/clients/lobby-sdk/cpp/tests/codec_test.cpp
@@ -349,10 +349,12 @@ static void test_characters_push(const std::string& hex) {
     CHECK_EQ(c.characters.size(), 2u);
     CHECK_EQ(c.characters[0].id, 300u);
     CHECK_EQ(c.characters[0].agency_idx, 1);
+    CHECK(c.characters[0].rename_available);
     CHECK_EQ(c.characters[0].name, std::string("Shade"));
     CHECK_EQ(c.characters[0].stats.level, 13);
     CHECK_EQ(c.characters[1].id, 301u);
     CHECK_EQ(c.characters[1].agency_idx, 3);
+    CHECK(!c.characters[1].rename_available);
     CHECK_EQ(c.characters[1].name, std::string("Vanta"));
 
     Writer w; w.u8(OpCharacters); encode_characters_body(w, c);
@@ -431,6 +433,11 @@ static void test_create_character_request(const std::string& hex) {
 
 static void test_select_character_request(const std::string& hex) {
     auto enc = frame(encode_select_character(300));
+    CHECK_EQ(to_hex(enc), hex);
+}
+
+static void test_rename_character_request(const std::string& hex) {
+    auto enc = frame(encode_rename_character(300, "Vesper"));
     CHECK_EQ(to_hex(enc), hex);
 }
 
@@ -565,6 +572,7 @@ int main() {
     run("setgame_request",                   test_setgame_request);
     run("create_character_request",          test_create_character_request);
     run("select_character_request",          test_select_character_request);
+    run("rename_character_request",          test_rename_character_request);
     run("register_stats_request",            test_register_stats_request);
 
     test_sha1();

--- a/clients/lobby-sdk/ts/src/client.ts
+++ b/clients/lobby-sdk/ts/src/client.ts
@@ -18,6 +18,7 @@ import {
   encodeNewGame,
   encodeCreateCharacter,
   encodePingAck,
+  encodeRenameCharacter,
   encodeRegisterStats,
   encodeSetGame,
   encodeSelectCharacter,
@@ -371,6 +372,11 @@ export class LobbyClient {
   selectCharacter(characterId: number): void {
     this.sendRaw(encodeSelectCharacter(characterId));
   }
+
+  renameCharacter(characterId: number, name: string): void {
+    this.sendRaw(encodeRenameCharacter(characterId, name));
+  }
+
   registerStats(args: {
     gameId: number;
     teamNumber: number;

--- a/clients/lobby-sdk/ts/src/codec.ts
+++ b/clients/lobby-sdk/ts/src/codec.ts
@@ -297,6 +297,14 @@ export function encodeSelectCharacter(characterId: number): Uint8Array {
   return w.bytes();
 }
 
+export function encodeRenameCharacter(characterId: number, name: string): Uint8Array {
+  const w = new Writer();
+  w.u8(Op.RenameCharacter);
+  w.u32Le(characterId);
+  w.lenstr(name.length > 16 ? name.slice(0, 16) : name);
+  return w.bytes();
+}
+
 export function encodeRegisterStats(
   gameId: number,
   teamNumber: number,
@@ -445,10 +453,12 @@ export function decodeCharacters(r: Reader): CharactersPayload {
   const characters: CharacterInfo[] = [];
   for (let i = 0; i < count; i++) {
     const id = r.u32Le();
-    const agencyIdx = r.u8();
+    const agencyFlags = r.u8();
+    const agencyIdx = agencyFlags & 0x7f;
+    const renameAvailable = (agencyFlags & 0x80) !== 0;
     const stats = decodeAgencyStats(r);
     const name = r.lenstr();
-    characters.push({ id, agencyIdx, stats, name });
+    characters.push({ id, agencyIdx, renameAvailable, stats, name });
   }
   return { selectedCharId, characters };
 }
@@ -525,7 +535,7 @@ export function encodeCharactersBody(w: Writer, payload: CharactersPayload): voi
   w.u32Le(payload.selectedCharId);
   for (const ch of payload.characters) {
     w.u32Le(ch.id);
-    w.u8(ch.agencyIdx);
+    w.u8((ch.agencyIdx & 0x7f) | (ch.renameAvailable ? 0x80 : 0));
     encodeAgencyStats(w, ch.stats);
     w.lenstr(ch.name);
   }

--- a/clients/lobby-sdk/ts/src/index.ts
+++ b/clients/lobby-sdk/ts/src/index.ts
@@ -20,6 +20,7 @@ export {
   encodeNewGame,
   encodePingAck,
   encodeRegisterStats,
+  encodeRenameCharacter,
   encodeSetGame,
   encodeCreateCharacter,
   encodeSelectCharacter,

--- a/clients/lobby-sdk/ts/src/types.ts
+++ b/clients/lobby-sdk/ts/src/types.ts
@@ -20,6 +20,7 @@ export const Op = {
   Characters: 14,
   CreateCharacter: 15,
   SelectCharacter: 16,
+  RenameCharacter: 17,
 } as const;
 export type Op = (typeof Op)[keyof typeof Op];
 
@@ -93,6 +94,7 @@ export interface UserInfo {
 export interface CharacterInfo {
   id: number;
   agencyIdx: number;
+  renameAvailable: boolean;
   stats: AgencyStats;
   name: string;
 }

--- a/clients/lobby-sdk/ts/tests/codec.test.ts
+++ b/clients/lobby-sdk/ts/tests/codec.test.ts
@@ -30,6 +30,7 @@ import {
   encodePingAck,
   encodePresence,
   encodeRegisterStats,
+  encodeRenameCharacter,
   encodeSetGame,
   encodeCreateCharacter,
   encodeSelectCharacter,
@@ -341,7 +342,9 @@ describe("golden vectors", () => {
     expect(payload.selectedCharId).toBe(300);
     expect(payload.characters).toHaveLength(2);
     expect(payload.characters[0]!.name).toBe("Shade");
+    expect(payload.characters[0]!.renameAvailable).toBe(true);
     expect(payload.characters[1]!.agencyIdx).toBe(3);
+    expect(payload.characters[1]!.renameAvailable).toBe(false);
 
     const w = new Writer();
     w.u8(Op.Characters);
@@ -416,6 +419,11 @@ describe("golden vectors", () => {
   test("select_character_request", () => {
     const v = need("select_character_request");
     expect(framedHex(encodeSelectCharacter(300))).toBe(v.hex);
+  });
+
+  test("rename_character_request", () => {
+    const v = need("rename_character_request");
+    expect(framedHex(encodeRenameCharacter(300, "Vesper"))).toBe(v.hex);
   });
 });
 

--- a/clients/silencer/CMakeLists.txt
+++ b/clients/silencer/CMakeLists.txt
@@ -220,7 +220,7 @@ endif()
 
 set(SILENCER_LOBBY_HOST "lobby.arsiamons.com" CACHE STRING "Lobby host the client connects to at startup")
 set(SILENCER_LOBBY_PORT "517" CACHE STRING "Lobby TCP port")
-set(SILENCER_VERSION "00055" CACHE STRING "Client version string sent to the lobby during MSG_VERSION; overridden by release.yml from git tag")
+set(SILENCER_VERSION "00056" CACHE STRING "Client version string sent to the lobby during MSG_VERSION; overridden by release.yml from git tag")
 set(SILENCER_MAP_API_URL "https://admin.arsiamons.com" CACHE STRING "Base URL for the community map HTTP API (used when fetching a missing map before falling back to P2P)")
 set(SILENCER_ADMIN_API_URL "https://admin.arsiamons.com" CACHE STRING "Base URL for the admin API (actordefs sync, etc.)")
 target_compile_definitions(${SILENCER_TARGET} PRIVATE

--- a/clients/silencer/src/actors/player/player.cpp
+++ b/clients/silencer/src/actors/player/player.cpp
@@ -306,7 +306,7 @@ void Player::Tick(World & world){
 					killedby = "a Player";
 					Peer * killedbypeer = player->GetPeer(world);
 					if(killedbypeer){
-						killedby = world.lobby.GetUserInfo(killedbypeer->accountid)->name;
+						killedby = world.lobby.GetUserInfo(killedbypeer->accountid)->DisplayName();
 						if(player->id == id){
 							killedself = true;
 						}else{
@@ -315,10 +315,10 @@ void Player::Tick(World & world){
 					}
 					char temp[256];
 					if(killedself){
-						sprintf(temp, "%s committed suicide", world.lobby.GetUserInfo(peer->accountid)->name);
+						sprintf(temp, "%s committed suicide", world.lobby.GetUserInfo(peer->accountid)->DisplayName());
 						peer->stats.suicides++;
 					}else{
-						sprintf(temp, "%s was killed by %s", world.lobby.GetUserInfo(peer->accountid)->name, killedby);
+						sprintf(temp, "%s was killed by %s", world.lobby.GetUserInfo(peer->accountid)->DisplayName(), killedby);
 						peer->stats.deaths++;
 					}
 					world.ShowStatus(temp, 160, true);
@@ -562,7 +562,7 @@ void Player::Tick(World & world){
 			if(peer && !world.intutorialmode){
 				User * user = world.lobby.GetUserInfo(peer->accountid);
 				char text[128];
-				sprintf(text, "Secret picked up by\n%s", user->name);
+				sprintf(text, "Secret picked up by\n%s", user->DisplayName());
 				world.ShowMessage(text, 128, 2, true);
 				peer->stats.secretspickedup++;
 			}
@@ -579,7 +579,7 @@ void Player::Tick(World & world){
 					}
 				}else{
 					char text[128];
-					sprintf(text, "%s dropped a secret", user->name);
+					sprintf(text, "%s dropped a secret", user->DisplayName());
 					if(!world.intutorialmode){
 						world.ShowMessage(text, 128, 3, true);
 					}
@@ -2731,7 +2731,7 @@ void Player::HandleHit(World & world, Uint8 x, Uint8 y, Object & projectile){
 						Player * player = static_cast<Player *>(owner);
 						Peer * killedbypeer = player->GetPeer(world);
 						if(killedbypeer){
-							killedby = world.lobby.GetUserInfo(killedbypeer->accountid)->name;
+							killedby = world.lobby.GetUserInfo(killedbypeer->accountid)->DisplayName();
 							if(player->id == id){
 								killedself = true;
 							}else{
@@ -2757,10 +2757,10 @@ void Player::HandleHit(World & world, Uint8 x, Uint8 y, Object & projectile){
 			}
 			char temp[256];
 			if(killedself){
-				sprintf(temp, "%s committed suicide", world.lobby.GetUserInfo(peer->accountid)->name);
+				sprintf(temp, "%s committed suicide", world.lobby.GetUserInfo(peer->accountid)->DisplayName());
 				peer->stats.suicides++;
 			}else{
-				sprintf(temp, "%s was killed by %s", world.lobby.GetUserInfo(peer->accountid)->name, killedby);
+				sprintf(temp, "%s was killed by %s", world.lobby.GetUserInfo(peer->accountid)->DisplayName(), killedby);
 				peer->stats.deaths++;
 			}
 			world.ShowStatus(temp, 160, true);
@@ -2851,7 +2851,7 @@ void Player::HandleDisconnect(World & world, Uint8 peerid){
 			User * user = world.lobby.GetUserInfo(peer->accountid);
 			if(user){
 				char temp[256];
-				sprintf(temp, "%s has left the game", user->name);
+				sprintf(temp, "%s has left the game", user->DisplayName());
 				world.ShowStatus(temp, 176, true);
 				Team * team = GetTeam(world);
 				if(team){
@@ -4413,7 +4413,7 @@ bool Player::PickUpItem(World & world, PickUp & pickup){
 					Peer * peer = GetPeer(world);
 					if(peer){
 						User * user = world.lobby.GetUserInfo(peer->accountid);
-						username = user->name;
+						username = user->DisplayName();
 					}
 					sprintf(text, "NEUTRON BOMB\nACTIVATION IN\n15 SECONDS\n\nACTIVATED BY\n%s", username);
 					world.ShowMessage(text, 128, 4, true);

--- a/clients/silencer/src/client/ui/screens/character_create/character_create_layout.cpp
+++ b/clients/silencer/src/client/ui/screens/character_create/character_create_layout.cpp
@@ -76,6 +76,8 @@ constexpr int kAgentIconW = 32;
 constexpr int kAgentIconH = 30;
 constexpr int kAgentStatsTopGap = 14;
 constexpr int kAgentStatsLineGap = 1;
+constexpr int kAgentRenameTopGap = 8;
+constexpr int kAgentRenameButtonW = 112;
 constexpr int kAgentAdvantagesTopGap = 17;
 constexpr int kAgentAdvantagesLineGap = 1;
 constexpr int kAdvantageListIndent = 20;
@@ -100,6 +102,7 @@ constexpr int kMaxRows = 32;
 
 constexpr const char * kActionAgentPrefix = "character_create.agent";
 constexpr const char * kActionAgencyPrefix = "character_create.agency";
+constexpr const char * kActionRenamePrefix = "character_create.rename";
 constexpr const char * kActionCreate = "character_create.create";
 constexpr const char * kActionAlias = "character_create.alias";
 
@@ -523,6 +526,14 @@ std::string AgencyActionId(int index)
 	return out;
 }
 
+std::string RenameActionId(int index)
+{
+	std::string out = kActionRenamePrefix;
+	out += ".";
+	out += std::to_string(index);
+	return out;
+}
+
 const AgencyDef& AgencyByIndex(int index)
 {
 	if(index < 0 || index >= 5) return kAgencies[0];
@@ -687,6 +698,17 @@ void CharacterCreateScreen::BuildSelectAgent(ScreenContext & ctx,
 				statLines.push_back(std::string("Successful Missions:") + std::to_string(ch.stats.wins));
 				AgentStatsBlock(CLAY_STRING("CharacterCreateAgentStats"),
 				                statLines);
+				if(interactive && ch.renameAvailable){
+					Spacer(CLAY_STRING("CharacterCreateAgentRenameTopGap"),
+					       kAgentRenameTopGap);
+					const std::string action = RenameActionId(detailAgentIndex);
+					Button(CLAY_STRING("CharacterCreateAgentRenameButton"),
+					       CLAY_STRING("Rename Once"),
+					       ButtonOpts{ .variant = ButtonVariant::Chrome,
+					                   .size = ButtonSize::Auto,
+					                   .minWidth = kAgentRenameButtonW },
+					       ButtonHandle{ nullptr, action.c_str(), &interactions });
+				}
 				Spacer(CLAY_STRING("CharacterCreateAgentAdvantagesTopGap"),
 				       kAgentAdvantagesTopGap);
 				CLAY({ .id = CLAY_ID("CharacterCreateAgentAdvantages"),
@@ -745,7 +767,7 @@ void CharacterCreateScreen::BuildEnterAlias(ScreenContext & ctx,
 		           .pointerCaptureMode = CLAY_POINTER_CAPTURE_MODE_CAPTURE,
 		           .attachTo = CLAY_ATTACH_TO_PARENT,
 		       } }) {
-			Text(CLAY_STRING("SILENCER ALIAS"),
+			Text(FromCStr(IsRenaming() ? "ONE-TIME RENAME" : "SILENCER ALIAS"),
 			     { .size = TextSize::Title,
 			       .effect = TextEffect::LegacyPalette(0) });
 		}

--- a/clients/silencer/src/client/ui/screens/character_create/character_create_screen.cpp
+++ b/clients/silencer/src/client/ui/screens/character_create/character_create_screen.cpp
@@ -17,6 +17,7 @@ namespace {
 constexpr int kMaxRows = 32;
 constexpr const char * kActionAgentPrefix = "character_create.agent";
 constexpr const char * kActionAgencyPrefix = "character_create.agency";
+constexpr const char * kActionRenamePrefix = "character_create.rename";
 constexpr const char * kActionCreate = "character_create.create";
 constexpr const char * kActionAlias = "character_create.alias";
 
@@ -67,6 +68,8 @@ void CharacterCreateScreen::Build(ScreenContext & ctx)
 	previewAgencyIndex = -1;
 	characterCountOnEntry = ctx.lobby.characters.size();
 	waitingForCreate = false;
+	waitingForRename = false;
+	renameCharacterId = 0;
 	focusAliasRequested = false;
 	alias[0] = '\0';
 	RebuildAgentRows(ctx);
@@ -89,6 +92,38 @@ void CharacterCreateScreen::Tick(ScreenContext & ctx)
 			ctx.ShowMessage("Could not create character");
 		}
 	}
+	if(waitingForRename){
+		bool received = false;
+		bool renamed = false;
+		int renamedIndex = -1;
+		ctx.lobby.LockMutex();
+		received = ctx.lobby.charactersreceived;
+		for(size_t i = 0; i < ctx.lobby.characters.size(); ++i){
+			const Lobby::Character& ch = ctx.lobby.characters[i];
+			if(ch.id == renameCharacterId){
+				renamed = !ch.renameAvailable;
+				renamedIndex = static_cast<int>(i);
+				break;
+			}
+		}
+		ctx.lobby.UnlockMutex();
+		if(renamed){
+			waitingForRename = false;
+			renameCharacterId = 0;
+			alias[0] = '\0';
+			step = Step::SelectAgent;
+			if(renamedIndex >= 0){
+				selectedAgentIndex = renamedIndex;
+				previewAgentIndex = renamedIndex;
+			}
+			return;
+		}
+		if(received){
+			waitingForRename = false;
+			ctx.ShowMessage("Could not rename character");
+			focusAliasRequested = true;
+		}
+	}
 }
 
 void CharacterCreateScreen::Destroy(ScreenContext & ctx)
@@ -105,6 +140,13 @@ bool CharacterCreateScreen::HandleBack(ScreenContext & ctx)
 		return true;
 	}
 	if(step == Step::EnterAlias){
+		if(waitingForRename){
+			return true;
+		}
+		if(IsRenaming()){
+			renameCharacterId = 0;
+			alias[0] = '\0';
+		}
 		step = Step::SelectAgent;
 		previewAgentIndex = -1;
 		return true;
@@ -166,7 +208,11 @@ bool CharacterCreateScreen::HandleUiIntent(ScreenContext & ctx,
 	if(action.kind == silencer::ui::UiActionKind::SubmitText &&
 	   step == Step::EnterAlias && action.id == kActionAlias){
 		CopyAlias(action.value);
-		AdvanceAliasStep(ctx);
+		if(IsRenaming()){
+			RenameCurrentAgent(ctx);
+		}else{
+			AdvanceAliasStep(ctx);
+		}
 		return true;
 	}
 	if(action.kind != silencer::ui::UiActionKind::Activate){
@@ -177,6 +223,11 @@ bool CharacterCreateScreen::HandleUiIntent(ScreenContext & ctx,
 		selectedAgentIndex = agentIndex;
 		previewAgentIndex = agentIndex;
 		SelectCurrentAgent(ctx);
+		return true;
+	}
+	int renameIndex = SuffixInt(action.id, kActionRenamePrefix);
+	if(step == Step::SelectAgent && renameIndex >= 0){
+		StartRenameAgent(ctx, renameIndex);
 		return true;
 	}
 	int agencyIndex = SuffixInt(action.id, kActionAgencyPrefix);
@@ -204,6 +255,7 @@ void CharacterCreateScreen::SelectCurrentAgent(ScreenContext & ctx)
 	const int createIndex = CreateRowIndex(ctx.lobby.characters.size());
 	if(selectedAgentIndex == createIndex ||
 	   selectedAgentIndex >= static_cast<int>(ctx.lobby.characters.size())){
+		renameCharacterId = 0;
 		step = Step::EnterAlias;
 		focusAliasRequested = true;
 		return;
@@ -244,6 +296,53 @@ void CharacterCreateScreen::CreateCurrentAgent(ScreenContext & ctx)
 	ctx.lobby.CreateCharacter(alias, selectedAgency);
 	ctx.lobby.UnlockMutex();
 	waitingForCreate = true;
+}
+
+void CharacterCreateScreen::StartRenameAgent(ScreenContext & ctx, int agentIndex)
+{
+	if(waitingForRename){
+		return;
+	}
+	Uint32 charID = 0;
+	char currentName[17] = {};
+	ctx.lobby.LockMutex();
+	if(agentIndex >= 0 && agentIndex < static_cast<int>(ctx.lobby.characters.size())){
+		const Lobby::Character& ch = ctx.lobby.characters[static_cast<size_t>(agentIndex)];
+		if(ch.renameAvailable){
+			charID = ch.id;
+			std::strncpy(currentName, ch.name, sizeof(currentName) - 1);
+			selectedAgentIndex = agentIndex;
+			previewAgentIndex = agentIndex;
+		}
+	}
+	ctx.lobby.UnlockMutex();
+	if(charID == 0){
+		return;
+	}
+	renameCharacterId = charID;
+	CopyAlias(currentName);
+	step = Step::EnterAlias;
+	focusAliasRequested = true;
+}
+
+void CharacterCreateScreen::RenameCurrentAgent(ScreenContext & ctx)
+{
+	if(waitingForRename){
+		return;
+	}
+	if(alias[0] == '\0'){
+		ctx.ShowMessage("Enter an alias");
+		focusAliasRequested = true;
+		return;
+	}
+	if(renameCharacterId == 0){
+		return;
+	}
+	ctx.lobby.LockMutex();
+	ctx.lobby.charactersreceived = false;
+	ctx.lobby.RenameCharacter(renameCharacterId, alias);
+	ctx.lobby.UnlockMutex();
+	waitingForRename = true;
 }
 
 void CharacterCreateScreen::RebuildAgentRows(ScreenContext & ctx)

--- a/clients/silencer/src/client/ui/screens/character_create/character_create_screen.h
+++ b/clients/silencer/src/client/ui/screens/character_create/character_create_screen.h
@@ -37,9 +37,12 @@ private:
 	void BuildSelectAgency(ScreenContext & ctx, silencer::ui::UiInteractionRegistry& interactions);
 	void SelectCurrentAgent(ScreenContext & ctx);
 	void CreateCurrentAgent(ScreenContext & ctx);
+	void StartRenameAgent(ScreenContext & ctx, int agentIndex);
+	void RenameCurrentAgent(ScreenContext & ctx);
 	void RebuildAgentRows(ScreenContext & ctx);
 	void CopyAlias(const std::string& value);
 	void AdvanceAliasStep(ScreenContext & ctx);
+	bool IsRenaming() const { return renameCharacterId != 0; }
 
 	Step step = Step::SelectAgent;
 	int selectedAgentIndex = 0;
@@ -50,6 +53,8 @@ private:
 	int previewAgencyIndex = -1;
 	size_t characterCountOnEntry = 0;
 	bool waitingForCreate = false;
+	bool waitingForRename = false;
+	Uint32 renameCharacterId = 0;
 	bool focusAliasRequested = false;
 	char alias[17] = {};
 	std::vector<std::string> agentRows;

--- a/clients/silencer/src/client/ui/screens/lobby/character_panel.cpp
+++ b/clients/silencer/src/client/ui/screens/lobby/character_panel.cpp
@@ -231,20 +231,19 @@ namespace silencer::client_ui::lobby {
             }
         }
 
-        void XpBadge(const std::string &Xp, int width) {
-            CLAY({ .id = CLAY_ID("CharacterPanelLevelBadge"),
+        void XpLine(const std::string &xp) {
+            CLAY({ .id = CLAY_ID("CharacterPanelXpLine"),
                  .layout = {
-                 .sizing = { CLAY_SIZING_FIXED(static_cast<float>(width)),
+                 .sizing = { CLAY_SIZING_GROW(0),
                  CLAY_SIZING_FIXED(static_cast<float>(
                      TextLineHeight(TextSize::Body))) },
-                 .childAlignment = { .x = CLAY_ALIGN_X_CENTER,
+                 .childAlignment = { .x = CLAY_ALIGN_X_LEFT,
                  .y = CLAY_ALIGN_Y_CENTER },
                  },
                  .clip = { .horizontal = true } }) {
-                Text(FromStd(Xp),
+                Text(FromStd(xp),
                      TextOpts{
                          .size = TextSize::Body,
-                         .align = TextAlign::Center,
                          .wrap = TextWrap::None
                      });
             }
@@ -419,9 +418,6 @@ namespace silencer::client_ui::lobby {
                 character_panel_detail::LevelBadge(
                     character_panel_detail::g_stats.level,
                     emblemBoxW);
-                character_panel_detail::XpBadge(
-                    "XP " + character_panel_detail::g_stats.xp,
-                    emblemBoxW);
             }
 
             CLAY({ .id = CLAY_ID("CharacterPanelInfoArea"),
@@ -481,6 +477,9 @@ namespace silencer::client_ui::lobby {
                             character_panel_detail::StatRow(1, "LOSSES", character_panel_detail::g_stats.losses,
                                                             labelColumnWidth);
                         }
+
+                        character_panel_detail::XpLine(
+                            "XP " + character_panel_detail::g_stats.xp);
 
                         CLAY({ .id = CLAY_ID("CharacterPanelActionsRow"),
                              .layout = {

--- a/clients/silencer/src/client/ui/screens/lobby/game_join_panel.cpp
+++ b/clients/silencer/src/client/ui/screens/lobby/game_join_panel.cpp
@@ -102,7 +102,7 @@ void GameJoinPanelTick(GameJoinPanelState & state,
 				Peer * peer = world.GetPeer(team->peers[i]);
 				if(!peer || peer->observer || peer->disconnected) continue;
 				User * user = world.lobby.GetUserInfo(peer->accountid);
-				if(!user || user->retrieving || !user->name[0]) continue;
+				if(!user || user->retrieving || !user->DisplayName()[0]) continue;
 
 				GameJoinRosterRow row;
 				row.ready = peer->isready;
@@ -110,8 +110,8 @@ void GameJoinPanelTick(GameJoinPanelState & state,
 				row.teamNumber = team->number;
 				row.peerSlot = static_cast<Uint8>(i);
 				row.drawEmblem = !drewEmblem;
-				row.name = peer->isbot ? std::string(user->name) + " [BOT]"
-				                       : std::string(user->name);
+				row.name = peer->isbot ? std::string(user->DisplayName()) + " [BOT]"
+				                       : std::string(user->DisplayName());
 				row.level = "L:" + std::to_string(user->agency[team->agency].level);
 				state.rosterRows.push_back(row);
 				drewEmblem = true;

--- a/clients/silencer/src/client/ui/screens/lobby/game_tech_panel.cpp
+++ b/clients/silencer/src/client/ui/screens/lobby/game_tech_panel.cpp
@@ -124,7 +124,7 @@ void GameTechPanelTick(GameTechPanelState & state,
 			if(i >= team->numpeers){ peerindex++; continue; }
 			Peer * peer = owner.TechPanelPeer(world, team->peers[i]);
 			User * user = peer ? world.lobby.GetUserInfo(peer->accountid) : nullptr;
-			state.peerNameStrs[peerindex] = user ? std::string(user->name) : std::string();
+			state.peerNameStrs[peerindex] = user ? std::string(user->DisplayName()) : std::string();
 			peerindex++;
 		}
 	}

--- a/clients/silencer/src/client/ui/views/HudView.cpp
+++ b/clients/silencer/src/client/ui/views/HudView.cpp
@@ -125,9 +125,9 @@ void PopulateTeams(HudView& out, ::World& world) {
 			if(user){
 				char displayname[120];
 				if(p->isbot){
-					std::snprintf(displayname, sizeof(displayname), "%s [BOT]", user->name);
+					std::snprintf(displayname, sizeof(displayname), "%s [BOT]", user->DisplayName());
 				}else{
-					std::snprintf(displayname, sizeof(displayname), "%s", user->name);
+					std::snprintf(displayname, sizeof(displayname), "%s", user->DisplayName());
 				}
 				pv.displayName = displayname;
 				pv.agencyLevel = user->agency[team->agency].level;
@@ -173,7 +173,7 @@ void PopulateBuyTech(HudView& out, ::World& world, ::Player* player) {
 			::Peer* targetPeer = world.GetPeer(buyTechTeam->peers[peerIndex]);
 			if(targetPeer){
 				::User* user = world.lobby.GetUserInfo(targetPeer->accountid);
-				if(user) name += user->name;
+				if(user) name += user->DisplayName();
 			}
 		}
 		return name;

--- a/clients/silencer/src/game/actor/user.cpp
+++ b/clients/silencer/src/game/actor/user.cpp
@@ -49,6 +49,10 @@ User::User(){
 	teamnumber = 0;
 }
 
+const char * User::DisplayName() const{
+	return charname[0] ? charname : name;
+}
+
 // Wire format (MSG_USERINFO, matches server encodeUser):
 //   [u32 accountID][u32 charID][u8 agencyIdx]
 //   [u16 wins][u16 losses][u16 xp][u8 level]

--- a/clients/silencer/src/game/actor/user.h
+++ b/clients/silencer/src/game/actor/user.h
@@ -10,6 +10,7 @@ class User
 public:
 	User();
 	void Serialize(bool write, Serializer & data);
+	const char * DisplayName() const;
 	int TotalUpgradePointsPossible(Uint8 agency);
 	bool retrieving;
 	Uint32 accountid;

--- a/clients/silencer/src/game/init/game_init.cpp
+++ b/clients/silencer/src/game/init/game_init.cpp
@@ -17,7 +17,7 @@ using namespace GameState;
 #define SILENCER_LOBBY_PORT 517
 #endif
 #ifndef SILENCER_VERSION
-#define SILENCER_VERSION "00055"
+#define SILENCER_VERSION "00056"
 #endif
 #ifndef SILENCER_MAP_API_URL
 #define SILENCER_MAP_API_URL "http://127.0.0.1:8080"

--- a/clients/silencer/src/game/modes/data_retrieval_mode.cpp
+++ b/clients/silencer/src/game/modes/data_retrieval_mode.cpp
@@ -92,7 +92,7 @@ void DataRetrievalMode::OnSecretDelivered(World& world, Team& team) {
 			int remaining = GASLoader::Get().player.secretsNeededToWin - team.secrets;
 			char text[128];
 			sprintf(text, "%s returned a %s\n( %d remaining )\n\nTeam awarded %d credits",
-			        user->name, stolen ? "stolen secret" : "secret", remaining,
+			        user->DisplayName(), stolen ? "stolen secret" : "secret", remaining,
 			        GASLoader::Get().player.secretDeliveryCredits);
 			if(!world.intutorialmode){
 				world.ShowMessage(text, 128, 0, true);
@@ -150,11 +150,10 @@ void DataRetrievalMode::OnSecretDelivered(World& world, Team& team) {
 			Peer* tp = world.peers.peerlist[team.peers[j]];
 			if(tp){
 				User* user = world.lobby.GetUserInfo(tp->accountid);
-				strcat(message, user->name);
+				strcat(message, user->DisplayName());
 				strcat(message, "\n");
 			}
 		}
 		world.ShowMessage(message, 255, type, true, peer);
 	}
 }
-

--- a/clients/silencer/src/net/lobby.cpp
+++ b/clients/silencer/src/net/lobby.cpp
@@ -474,7 +474,10 @@ void Lobby::DoNetwork(void){
 										Character ch;
 										memset(&ch, 0, sizeof(ch));
 										data.Get(ch.id);
-										data.Get(ch.agencyIdx);
+										Uint8 agencyByte;
+										data.Get(agencyByte);
+										ch.renameAvailable = (agencyByte & 0x80) != 0;
+										ch.agencyIdx = agencyByte & 0x7f;
 										data.Get(ch.stats.wins);
 										data.Get(ch.stats.losses);
 										data.Get(ch.stats.xp);
@@ -784,6 +787,20 @@ void Lobby::SelectCharacter(Uint32 charID){
 	Uint8 code = MSG_SELECTCHARACTER;
 	data.Put(code);
 	data.Put(charID);
+	SendMessage(data.data, data.BitsToBytes(data.offset));
+}
+
+void Lobby::RenameCharacter(Uint32 charID, const char * name){
+	Serializer data;
+	Uint8 code = MSG_RENAMECHARACTER;
+	data.Put(code);
+	data.Put(charID);
+	Uint8 namelen = (Uint8)strnlen(name, 16);
+	data.Put(namelen);
+	for(int i = 0; i < namelen; i++){
+		char c = name[i];
+		data.Put(c);
+	}
 	SendMessage(data.data, data.BitsToBytes(data.offset));
 }
 

--- a/clients/silencer/src/net/lobby.h
+++ b/clients/silencer/src/net/lobby.h
@@ -35,7 +35,7 @@ public:
 		Uint32 accountid;
 		Uint32 gameid; // 0 = main lobby
 		Uint8 status;  // 0 = lobby, 1 = pregame, 2 = playing
-		char name[17]; // matches server-side max username (16) + null
+		char name[17]; // selected character display name (16) + null
 	};
 	struct Character {
 		Uint32 id;

--- a/clients/silencer/src/net/lobby.h
+++ b/clients/silencer/src/net/lobby.h
@@ -22,7 +22,7 @@ public:
 	void LockMutex(void);
 	void UnlockMutex(void);
 	enum {IDLE, WAITING, CONNECTING, RESOLVING, WAITINGFORRESOLVER, RESOLVED, RESOLVEFAILED, CONNECTIONFAILED, CONNECTED, CHECKINGVERSION, AUTHENTICATING, AUTHSENT, AUTHENTICATED, AUTHFAILED, DISCONNECTED} state;
-	enum {MSG_AUTH, MSG_MOTD, MSG_CHAT, MSG_NEWGAME, MSG_DELGAME, MSG_CHANNEL, MSG_CONNECT, MSG_VERSION, MSG_USERINFO, MSG_PING, MSG_UPGRADESTAT, MSG_REGISTERSTATS, MSG_PRESENCE, MSG_SETGAME, MSG_CHARACTERS, MSG_CREATECHARACTER, MSG_SELECTCHARACTER};
+	enum {MSG_AUTH, MSG_MOTD, MSG_CHAT, MSG_NEWGAME, MSG_DELGAME, MSG_CHANNEL, MSG_CONNECT, MSG_VERSION, MSG_USERINFO, MSG_PING, MSG_UPGRADESTAT, MSG_REGISTERSTATS, MSG_PRESENCE, MSG_SETGAME, MSG_CHARACTERS, MSG_CREATECHARACTER, MSG_SELECTCHARACTER, MSG_RENAMECHARACTER};
 	enum StatID {
 		STAT_ENDURANCE = 1,
 		STAT_SHIELD = 2,
@@ -41,6 +41,7 @@ public:
 		Uint32 id;
 		char name[17];
 		Uint8 agencyIdx;
+		bool renameAvailable;
 		struct {
 			Uint16 wins, losses, xp;
 			Uint8 level, endurance, shield, jetpack, techslots, hacking, contacts;
@@ -62,6 +63,7 @@ public:
 	void SendSetGame(Uint32 gameid, Uint8 status);
 	void CreateCharacter(const char * name, Uint8 agencyIdx);
 	void SelectCharacter(Uint32 charID);
+	void RenameCharacter(Uint32 charID, const char * name);
 	const Character * GetSelectedCharacter() const;
 	Uint8 GetSelectedAgencyOrDefault(Uint8 fallback) const;
 	char failmessage[256];

--- a/clients/silencer/src/render/renderer.cpp
+++ b/clients/silencer/src/render/renderer.cpp
@@ -823,7 +823,7 @@ void Renderer::DrawWorld(Surface * surface, Camera & camera, bool drawminimap, b
 									User * user = world.lobby.GetUserInfo(peer->accountid);
 									if(user && !user->retrieving){
 										char username[64];
-										strcpy(username, user->name);
+										strcpy(username, user->DisplayName());
 										DrawText(surface, player->x + camera.GetXOffset() - ((strlen(username) * 6) / 2), player->y + camera.GetYOffset() - 80, username, 133, 6);
 									}
 								}

--- a/clients/silencer/src/world/messaging/world_messaging.cpp
+++ b/clients/silencer/src/world/messaging/world_messaging.cpp
@@ -32,7 +32,7 @@ WorldMessaging::WorldMessaging(World & world) : world(world){
 }
 
 void WorldMessaging::DisplayChatMessage(Uint32 accountid, const char * msg){
-	std::string chatmsg(world.lobby.GetUserInfo(accountid)->name);
+	std::string chatmsg(world.lobby.GetUserInfo(accountid)->DisplayName());
 	std::replace(chatmsg.begin(), chatmsg.end(), ' ', '\xA0');
 	// replace spaces with nbsp so usernames dont wordwrap
 	chatmsg.append(":\xA0");
@@ -183,4 +183,3 @@ void WorldMessaging::PushStatusString(char * statusstring){
 	}
 	statusmessages.push_front(statusstring);
 }
-

--- a/clients/silencer/src/world/network/world_network.cpp
+++ b/clients/silencer/src/world/network/world_network.cpp
@@ -641,10 +641,13 @@ void WorldNetwork::DoNetwork_Replica(void){
 						if(team){
 							User * user = world.lobby.GetUserInfo(localpeer->accountid);
 							char namecopy[64];
+							char charnamecopy[17];
 							strcpy(namecopy, user->name);
+							strcpy(charnamecopy, user->charname);
 							world.lobby.ForgetUserInfo(localpeer->accountid);
 							user = world.lobby.GetUserInfo(localpeer->accountid);
 							strcpy(user->name, namecopy);
+							strcpy(user->charname, charnamecopy);
 							user->statscopy = localpeer->stats;
 							user->selectedcharid = localpeer->selectedcharid;
 							user->statsagency = team->agency;

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -55,7 +55,7 @@ services:
       - "-public-addr"
       - "${PUBLIC_ADDR:-127.0.0.1}"
       - "-version"
-      - "00055"
+      - "00056"
       - "-db"
       - "/data/lobby.json"
       - "-game-binary"

--- a/infra/scripts/build-mac-local.sh
+++ b/infra/scripts/build-mac-local.sh
@@ -5,7 +5,7 @@
 #   ./infra/scripts/build-mac-local.sh               # lobby at 127.0.0.1:15170
 #   LOBBY_HOST=1.2.3.4 ./infra/scripts/build-mac-local.sh
 #   LOBBY_PORT=517      ./infra/scripts/build-mac-local.sh
-#   VERSION=00055       ./infra/scripts/build-mac-local.sh  # must match lobby -version flag
+#   VERSION=00056       ./infra/scripts/build-mac-local.sh  # must match lobby -version flag
 #
 # The lobby host, port, and version are baked into the binary at compile time.
 # Run `docker compose -f infra/docker-compose.yml up -d` first so the lobby is ready before launching.
@@ -15,7 +15,7 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 LOBBY_HOST="${LOBBY_HOST:-127.0.0.1}"
 LOBBY_PORT="${LOBBY_PORT:-15170}"
-VERSION="${VERSION:-00055}"
+VERSION="${VERSION:-00056}"
 BUILD_DIR="$REPO_ROOT/build"
 
 echo "==> Installing/updating dependencies via Homebrew"

--- a/services/lobby/Dockerfile
+++ b/services/lobby/Dockerfile
@@ -54,7 +54,7 @@ RUN apt-get -o Acquire::Check-Valid-Until=false \
         ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-ARG SILENCER_VERSION=00055
+ARG SILENCER_VERSION=00056
 
 WORKDIR /src
 COPY clients/silencer/CMakeLists.txt clients/silencer/

--- a/services/lobby/characters_test.go
+++ b/services/lobby/characters_test.go
@@ -61,6 +61,29 @@ func TestCreateCharacterRejectsDuplicateAlias(t *testing.T) {
 	}
 }
 
+func TestClientDisplayNamePrefersSelectedCharacter(t *testing.T) {
+	c := &Client{}
+	c.setUser(&User{
+		Name:           "alice",
+		SelectedCharID: 7,
+		Characters: []Character{
+			{ID: 3, Name: "Old", AgencyIdx: 0},
+			{ID: 7, Name: "Shade", AgencyIdx: 1},
+		},
+	})
+	if got := c.displayName(); got != "Shade" {
+		t.Fatalf("displayName: got %q want %q", got, "Shade")
+	}
+}
+
+func TestClientDisplayNameFallsBackToAccountName(t *testing.T) {
+	c := &Client{}
+	c.setUser(&User{Name: "alice"})
+	if got := c.displayName(); got != "alice" {
+		t.Fatalf("displayName fallback: got %q want %q", got, "alice")
+	}
+}
+
 func TestLegacyAgencyMigrationKeepsAnyProgressField(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "lobby.json")
 	before := &Store{

--- a/services/lobby/characters_test.go
+++ b/services/lobby/characters_test.go
@@ -126,11 +126,146 @@ func TestLegacyAgencyMigrationKeepsAnyProgressField(t *testing.T) {
 	if user.Characters[1].AgencyIdx != 2 || user.Characters[1].Stats.TechSlots != 4 {
 		t.Fatalf("upgrade-only agency was not preserved: %#v", user.Characters[1])
 	}
+	if !user.Characters[0].RenameAvailable || !user.Characters[1].RenameAvailable {
+		t.Fatalf("migrated characters did not receive rename grants: %#v", user.Characters)
+	}
 	if user.SelectedCharID != user.Characters[0].ID {
 		t.Fatalf("selected char: got %d want %d", user.SelectedCharID, user.Characters[0].ID)
 	}
 	if user.LegacyAgency != [5]Agency{} {
 		t.Fatalf("legacy agencies were not cleared: %#v", user.LegacyAgency)
+	}
+}
+
+func TestExistingAgencyNamedCharactersGetOneTimeRenameSweep(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "lobby.json")
+	before := &Store{
+		NextID:     2,
+		NextCharID: 12,
+		ByName: map[string]*User{
+			"alice": {
+				AccountID: 1,
+				Name:      "alice",
+				PassHash:  "pw",
+				Characters: []Character{
+					{ID: 10, Name: "Noxis", AgencyIdx: 0},
+					{ID: 11, Name: "Shade", AgencyIdx: 1},
+				},
+				SelectedCharID: 10,
+			},
+		},
+	}
+	data, err := json.Marshal(before)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	store, err := NewStore(path)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	user := store.ByName["alice"]
+	if !user.Characters[0].RenameAvailable {
+		t.Fatalf("agency-named character was not marked: %#v", user.Characters[0])
+	}
+	if user.Characters[1].RenameAvailable {
+		t.Fatalf("custom-named character was marked: %#v", user.Characters[1])
+	}
+	if !store.LegacyRenameSweepDone {
+		t.Fatalf("rename sweep marker was not persisted")
+	}
+
+	user.Characters[1].Name = "Lazarus"
+	user.Characters[1].RenameAvailable = false
+	if err := store.save(); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	store, err = NewStore(path)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if store.ByName["alice"].Characters[1].RenameAvailable {
+		t.Fatalf("rename sweep ran again after marker was persisted")
+	}
+}
+
+func TestRenameCharacterClearsGrantAndRejectsSecondRename(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "lobby.json")
+	store, err := NewStore(path)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	user, ok, banned := store.Login("alice", hashPassword("secret"))
+	if !ok || banned {
+		t.Fatalf("Login: ok=%v banned=%v", ok, banned)
+	}
+	user, ok = store.CreateCharacter(user.AccountID, "Noxis", 0)
+	if !ok {
+		t.Fatalf("CreateCharacter rejected")
+	}
+	store.ByName["alice"].Characters[0].RenameAvailable = true
+	charID := user.SelectedCharID
+
+	user, ok = store.RenameCharacter(user.AccountID, charID, "Shade")
+	if !ok {
+		t.Fatalf("RenameCharacter rejected")
+	}
+	ch := characterByID(user, charID)
+	if ch == nil || ch.Name != "Shade" || ch.RenameAvailable {
+		t.Fatalf("rename did not update character and clear grant: %#v", ch)
+	}
+	if _, ok = store.RenameCharacter(user.AccountID, charID, "Vanta"); ok {
+		t.Fatalf("RenameCharacter accepted second rename")
+	}
+}
+
+func TestRenameCharacterRejectsCharactersWithoutGrant(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "lobby.json")
+	store, err := NewStore(path)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	user, ok, banned := store.Login("alice", hashPassword("secret"))
+	if !ok || banned {
+		t.Fatalf("Login: ok=%v banned=%v", ok, banned)
+	}
+	user, ok = store.CreateCharacter(user.AccountID, "Shade", 1)
+	if !ok {
+		t.Fatalf("CreateCharacter rejected")
+	}
+	if _, ok = store.RenameCharacter(user.AccountID, user.SelectedCharID, "Vanta"); ok {
+		t.Fatalf("RenameCharacter accepted character without grant")
+	}
+}
+
+func TestRenameCharacterRejectsDuplicateAlias(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "lobby.json")
+	store, err := NewStore(path)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	user, ok, banned := store.Login("alice", hashPassword("secret"))
+	if !ok || banned {
+		t.Fatalf("Login: ok=%v banned=%v", ok, banned)
+	}
+	user, ok = store.CreateCharacter(user.AccountID, "Noxis", 0)
+	if !ok {
+		t.Fatalf("CreateCharacter Noxis rejected")
+	}
+	firstID := user.SelectedCharID
+	user, ok = store.CreateCharacter(user.AccountID, "Shade", 1)
+	if !ok {
+		t.Fatalf("CreateCharacter Shade rejected")
+	}
+	store.ByName["alice"].Characters[0].RenameAvailable = true
+	if _, ok = store.RenameCharacter(user.AccountID, firstID, " shade "); ok {
+		t.Fatalf("RenameCharacter accepted duplicate alias")
+	}
+	user = store.ByName["alice"]
+	if user.Characters[0].Name != "Noxis" || !user.Characters[0].RenameAvailable {
+		t.Fatalf("failed duplicate rename mutated character: %#v", user.Characters[0])
 	}
 }
 

--- a/services/lobby/client.go
+++ b/services/lobby/client.go
@@ -16,6 +16,7 @@ type Client struct {
 	hub  *Hub
 
 	mu        sync.Mutex
+	userMu    sync.RWMutex
 	accountID uint32
 	user      *User
 	channel   string
@@ -28,10 +29,28 @@ type Client struct {
 }
 
 func (c *Client) displayName() string {
-	if c.user != nil && c.user.Name != "" {
-		return c.user.Name
+	user := c.currentUser()
+	if user != nil {
+		if ch := selectedChar(user); ch != nil && ch.Name != "" {
+			return ch.Name
+		}
+		if user.Name != "" {
+			return user.Name
+		}
 	}
 	return "Player"
+}
+
+func (c *Client) setUser(u *User) {
+	c.userMu.Lock()
+	c.user = u
+	c.userMu.Unlock()
+}
+
+func (c *Client) currentUser() *User {
+	c.userMu.RLock()
+	defer c.userMu.RUnlock()
+	return c.user
 }
 
 func serveClient(conn net.Conn, hub *Hub, version string, manifest *UpdateManifest) {
@@ -184,8 +203,8 @@ func (c *Client) handleAuth(r *reader) error {
 		c.send(w.b)
 		return nil
 	}
+	c.setUser(u)
 	c.mu.Lock()
-	c.user = u
 	c.accountID = u.AccountID
 	c.mu.Unlock()
 
@@ -393,7 +412,9 @@ func (c *Client) handleCreateCharacter(r *reader) error {
 		}
 		return nil
 	}
+	c.setUser(u)
 	c.send(encodeCharacters(u))
+	c.hub.BroadcastClientPresence(c)
 	return nil
 }
 
@@ -409,7 +430,9 @@ func (c *Client) handleSelectCharacter(r *reader) error {
 	if !ok {
 		return nil
 	}
+	c.setUser(u)
 	c.send(encodeCharacters(u))
+	c.hub.BroadcastClientPresence(c)
 	return nil
 }
 

--- a/services/lobby/client.go
+++ b/services/lobby/client.go
@@ -145,6 +145,8 @@ func (c *Client) handleFrame(frame []byte, expectedVersion string, manifest *Upd
 		return c.handleCreateCharacter(r)
 	case opSelectCharacter:
 		return c.handleSelectCharacter(r)
+	case opRenameCharacter:
+		return c.handleRenameCharacter(r)
 	default:
 		log.Printf("[op] %s unknown opcode %d", c.conn.RemoteAddr(), op)
 	}
@@ -428,6 +430,31 @@ func (c *Client) handleSelectCharacter(r *reader) error {
 	}
 	u, ok := c.hub.store.SelectCharacter(c.accountID, charID)
 	if !ok {
+		return nil
+	}
+	c.setUser(u)
+	c.send(encodeCharacters(u))
+	c.hub.BroadcastClientPresence(c)
+	return nil
+}
+
+func (c *Client) handleRenameCharacter(r *reader) error {
+	if c.accountID == 0 {
+		return nil
+	}
+	charID, err := r.u32()
+	if err != nil {
+		return err
+	}
+	name, err := r.lenBytes()
+	if err != nil {
+		return err
+	}
+	u, ok := c.hub.store.RenameCharacter(c.accountID, charID, name)
+	if !ok {
+		if user := c.hub.store.ByAccountID(c.accountID); user != nil {
+			c.send(encodeCharacters(user))
+		}
 		return nil
 	}
 	c.setUser(u)

--- a/services/lobby/hub.go
+++ b/services/lobby/hub.go
@@ -93,8 +93,8 @@ func (h *Hub) Join(c *Client) {
 	if h.events != nil && c.accountID != 0 {
 		ip, _, _ := net.SplitHostPort(c.conn.RemoteAddr().String())
 		var agencies [5]AgencyEvent
-		if c.user != nil {
-			for i, ch := range c.user.Characters {
+		if user := c.currentUser(); user != nil {
+			for i, ch := range user.Characters {
 				if i >= 5 {
 					break
 				}
@@ -195,7 +195,6 @@ func (h *Hub) GameExited(gameID uint32) {
 	}
 }
 
-
 // status: 0 = main lobby, 1 = pregame (game-specific lobby), 2 = playing.
 // gameID=0 requires status=0. Unknown non-zero IDs are rejected.
 func (h *Hub) SetClientGame(c *Client, gameID uint32, status uint8) {
@@ -221,6 +220,36 @@ func (h *Hub) SetClientGame(c *Client, gameID uint32, status uint8) {
 	c.gameID = gameID
 	c.gameStatus = status
 	acct := c.accountID
+	name := c.displayName()
+	peers := make([]*Client, 0, len(h.clients))
+	for other := range h.clients {
+		peers = append(peers, other)
+	}
+	h.mu.Unlock()
+
+	for _, p := range peers {
+		p.sendPresence(0, acct, gameID, status, name)
+	}
+
+	if h.events != nil {
+		h.events.Publish("player.presence", playerPresenceEvent{
+			AccountID: acct, Name: name, GameID: gameID, GameStatus: status,
+			Online: true, Timestamp: time.Now().UnixMilli(),
+		})
+	}
+}
+
+// BroadcastClientPresence re-sends a client's current lobby presence when
+// display-only state changes, such as selecting a different character.
+func (h *Hub) BroadcastClientPresence(c *Client) {
+	h.mu.Lock()
+	if c.accountID == 0 {
+		h.mu.Unlock()
+		return
+	}
+	acct := c.accountID
+	gameID := c.gameID
+	status := c.gameStatus
 	name := c.displayName()
 	peers := make([]*Client, 0, len(h.clients))
 	for other := range h.clients {

--- a/services/lobby/mongosync.go
+++ b/services/lobby/mongosync.go
@@ -112,6 +112,7 @@ func charactersToBSON(chars []Character) []bson.M {
 		doc["id"] = ch.ID
 		doc["name"] = ch.Name
 		doc["agencyIdx"] = ch.AgencyIdx
+		doc["renameAvailable"] = ch.RenameAvailable
 		out[i] = doc
 	}
 	return out

--- a/services/lobby/protocol.go
+++ b/services/lobby/protocol.go
@@ -24,6 +24,7 @@ const (
 	opCharacters      = 14 // server→client: full character list for the authed player
 	opCreateCharacter = 15 // client→server: create a new character
 	opSelectCharacter = 16 // client→server: select an existing character
+	opRenameCharacter = 17 // client→server: one-time rename for migrated characters
 )
 
 const (
@@ -41,6 +42,8 @@ const maxCharacterNameBytes = 16
 const characterListHeaderBytes = 1 + 1 + 4 // op + count + selectedCharID
 const characterFixedBytes = 4 + 1 + 2 + 2 + 2 + 1 + 1 + 1 + 1 + 1 + 1 + 1
 const maxCharactersPerUser = (maxFrame - characterListHeaderBytes) / (characterFixedBytes + 1 + maxCharacterNameBytes)
+const characterAgencyMask = 0x7f
+const characterRenameFlag = 0x80
 
 func readFrame(r io.Reader) ([]byte, error) {
 	var sz [1]byte
@@ -356,9 +359,11 @@ func encodeUser(w *writer, u *User) {
 
 // encodeCharacters builds an opCharacters frame.
 // Layout: [u8 count][u32 selectedCharID][count × char]
-// Each char: [u32 id][u8 agencyIdx][u16 wins][u16 losses][u16 xp][u8 level]
+// Each char: [u32 id][u8 agencyFlags][u16 wins][u16 losses][u16 xp][u8 level]
 //
 //	[u8 endurance][u8 shield][u8 jetpack][u8 techslots][u8 hacking][u8 contacts][lenStr name]
+//
+// agencyFlags stores agencyIdx in bits 0..6 and rename availability in bit 7.
 func encodeCharacters(u *User) []byte {
 	var w writer
 	w.u8(opCharacters)
@@ -385,7 +390,11 @@ func encodeCharacters(u *User) []byte {
 		ch := &u.Characters[i]
 		a := &ch.Stats
 		w.u32(ch.ID)
-		w.u8(ch.AgencyIdx)
+		agencyByte := ch.AgencyIdx & characterAgencyMask
+		if ch.RenameAvailable {
+			agencyByte |= characterRenameFlag
+		}
+		w.u8(agencyByte)
 		w.u16(a.Wins)
 		w.u16(a.Losses)
 		w.u16(a.XPToNextLevel)

--- a/services/lobby/protocol_version_test.go
+++ b/services/lobby/protocol_version_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 )
 
-const currentProtocolVersion = "00055"
-const currentWireFingerprint = "6ed03e899380959a143ffde183e59cf211d11a03d851e2d75872abd92a4c2486"
+const currentProtocolVersion = "00056"
+const currentWireFingerprint = "c16c0106632b187bff8887ecf00fdef413aa9a46434b90a7caaf8d96d8da80eb"
 
 var wireFingerprintPaths = []string{
 	"shared/lobby-protocol/protocol.md",

--- a/services/lobby/protocol_version_test.go
+++ b/services/lobby/protocol_version_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 const currentProtocolVersion = "00055"
-const currentWireFingerprint = "5ee766b2ad0c165228cc932d483d73460431b187fc8918d88672ea10731d7a79"
+const currentWireFingerprint = "6ed03e899380959a143ffde183e59cf211d11a03d851e2d75872abd92a4c2486"
 
 var wireFingerprintPaths = []string{
 	"shared/lobby-protocol/protocol.md",

--- a/services/lobby/store.go
+++ b/services/lobby/store.go
@@ -27,10 +27,11 @@ type Agency struct {
 
 // Character is a named playable character locked to one agency.
 type Character struct {
-	ID        uint32 `json:"id"`
-	Name      string `json:"name"`
-	AgencyIdx uint8  `json:"agency"` // 0=Noxis 1=Lazarus 2=Caliber 3=Static 4=BlackRose
-	Stats     Agency `json:"stats"`
+	ID              uint32 `json:"id"`
+	Name            string `json:"name"`
+	AgencyIdx       uint8  `json:"agency"` // 0=Noxis 1=Lazarus 2=Caliber 3=Static 4=BlackRose
+	RenameAvailable bool   `json:"rename,omitempty"`
+	Stats           Agency `json:"stats"`
 }
 
 type User struct {
@@ -45,14 +46,15 @@ type User struct {
 }
 
 type Store struct {
-	path       string
-	mu         sync.Mutex
-	NextID     uint32           `json:"next"`
-	NextCharID uint32           `json:"nextchar"`
-	ByName     map[string]*User `json:"users"`
-	dirty      bool
-	saveErr    error
-	mongo      *MongoSync
+	path                  string
+	mu                    sync.Mutex
+	NextID                uint32           `json:"next"`
+	NextCharID            uint32           `json:"nextchar"`
+	ByName                map[string]*User `json:"users"`
+	LegacyRenameSweepDone bool             `json:"legacyRenameSweepDone,omitempty"`
+	dirty                 bool
+	saveErr               error
+	mongo                 *MongoSync
 }
 
 func NewStore(path string) (*Store, error) {
@@ -64,6 +66,7 @@ func NewStore(path string) (*Store, error) {
 	}
 	data, err := os.ReadFile(path)
 	if errors.Is(err, os.ErrNotExist) {
+		s.LegacyRenameSweepDone = true
 		return s, s.save()
 	}
 	if err != nil {
@@ -111,6 +114,12 @@ func NewStore(path string) (*Store, error) {
 			// Clear legacy field so it doesn't accumulate in JSON.
 			u.LegacyAgency = [5]Agency{}
 		}
+	}
+	if !s.LegacyRenameSweepDone {
+		for _, u := range s.ByName {
+			markLegacyRenameCandidates(u)
+		}
+		s.LegacyRenameSweepDone = true
 	}
 	return s, s.save()
 }
@@ -217,6 +226,38 @@ func (s *Store) CreateCharacter(accountID uint32, name string, agencyIdx uint8) 
 		s.NextCharID++
 		u.Characters = append(u.Characters, ch)
 		u.SelectedCharID = ch.ID
+		_ = s.save()
+		s.mongo.SyncPlayer(u)
+		return cloneUser(u), true
+	}
+	return nil, false
+}
+
+// RenameCharacter renames a migrated agency-name character once.
+// Returns the updated User and true on success; false if the character does not
+// belong to the account, has no rename grant, or the alias is invalid/duplicate.
+func (s *Store) RenameCharacter(accountID uint32, charID uint32, name string) (*User, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	name = strings.TrimSpace(name)
+	if name == "" || len(name) > 16 {
+		return nil, false
+	}
+	for _, u := range s.ByName {
+		if u.AccountID != accountID {
+			continue
+		}
+		ch := characterByID(u, charID)
+		if ch == nil || !ch.RenameAvailable || strings.EqualFold(ch.Name, name) {
+			return nil, false
+		}
+		for _, existing := range u.Characters {
+			if existing.ID != charID && strings.EqualFold(existing.Name, name) {
+				return nil, false
+			}
+		}
+		ch.Name = name
+		ch.RenameAvailable = false
 		_ = s.save()
 		s.mongo.SyncPlayer(u)
 		return cloneUser(u), true
@@ -404,22 +445,36 @@ func defaultAgency() Agency {
 	return Agency{TechSlots: 3}
 }
 
+var agencyCharacterNames = [5]string{"Noxis", "Lazarus", "Caliber", "Static", "BlackRose"}
+
 func migrateLegacyAgencies(u *User, nextCharID *uint32) {
-	agencyNames := [5]string{"Noxis", "Lazarus", "Caliber", "Static", "BlackRose"}
 	for i, a := range u.LegacyAgency {
 		if !hasLegacyAgencyProgress(a) {
 			continue
 		}
 		u.Characters = append(u.Characters, Character{
-			ID:        *nextCharID,
-			Name:      agencyNames[i],
-			AgencyIdx: uint8(i),
-			Stats:     a,
+			ID:              *nextCharID,
+			Name:            agencyCharacterNames[i],
+			AgencyIdx:       uint8(i),
+			RenameAvailable: true,
+			Stats:           a,
 		})
 		if u.SelectedCharID == 0 {
 			u.SelectedCharID = *nextCharID
 		}
 		*nextCharID++
+	}
+}
+
+func markLegacyRenameCandidates(u *User) {
+	for i := range u.Characters {
+		ch := &u.Characters[i]
+		if ch.AgencyIdx >= uint8(len(agencyCharacterNames)) {
+			continue
+		}
+		if ch.Name == agencyCharacterNames[ch.AgencyIdx] {
+			ch.RenameAvailable = true
+		}
 	}
 }
 

--- a/services/lobby/vectors_test.go
+++ b/services/lobby/vectors_test.go
@@ -251,6 +251,26 @@ func TestVector_SelectCharacterRequest_Decode(t *testing.T) {
 	}
 }
 
+func TestVector_RenameCharacterRequest_Decode(t *testing.T) {
+	v := mustGet(t, loadVectors(t), "rename_character_request")
+	op, body := unframe(t, unhex(t, v.Hex))
+	if op != opRenameCharacter {
+		t.Fatalf("op: got %d want %d", op, opRenameCharacter)
+	}
+	r := newReader(body)
+	id, err := r.u32()
+	if err != nil {
+		t.Fatalf("character id: %v", err)
+	}
+	name, err := r.lenBytes()
+	if err != nil {
+		t.Fatalf("name: %v", err)
+	}
+	if id != 300 || name != "Vesper" {
+		t.Errorf("request: id=%d name=%q", id, name)
+	}
+}
+
 func TestVector_RegisterStatsRequest_Decode(t *testing.T) {
 	v := mustGet(t, loadVectors(t), "register_stats_request")
 	op, body := unframe(t, unhex(t, v.Hex))
@@ -534,10 +554,11 @@ func TestVector_CharactersPush_Encode(t *testing.T) {
 		SelectedCharID: 300,
 		Characters: []Character{
 			{
-				ID:        300,
-				Name:      "Shade",
-				AgencyIdx: 1,
-				Stats:     Agency{Wins: 10, Losses: 11, XPToNextLevel: 12, Level: 13, Endurance: 14, Shield: 15, Jetpack: 16, TechSlots: 17, Hacking: 18, Contacts: 19},
+				ID:              300,
+				Name:            "Shade",
+				AgencyIdx:       1,
+				RenameAvailable: true,
+				Stats:           Agency{Wins: 10, Losses: 11, XPToNextLevel: 12, Level: 13, Endurance: 14, Shield: 15, Jetpack: 16, TechSlots: 17, Hacking: 18, Contacts: 19},
 			},
 			{
 				ID:        301,

--- a/shared/lobby-protocol/protocol.md
+++ b/shared/lobby-protocol/protocol.md
@@ -68,6 +68,7 @@ opSetGame       = 13
 opCharacters    = 14
 opCreateCharacter = 15
 opSelectCharacter = 16
+opRenameCharacter = 17
 ```
 
 ## Connection lifecycle
@@ -335,13 +336,14 @@ No reply.
 
 ### `opCharacters` (14)
 
-**Push** (`S → C`), sent after auth and after create/select changes:
+**Push** (`S → C`), sent after auth and after create/select/rename changes:
 ```
 u8     count                          (number of characters in this frame)
 u32    selected_char_id               (0 if no character is selected)
 struct[count] character:
   u32   id
-  u8    agency_idx
+  u8    agency_flags                  (bits 0..6 = agency_idx, bit 7 =
+                                      one-time rename available)
   struct AgencyStats:
     u16 wins
     u16 losses
@@ -355,6 +357,9 @@ struct[count] character:
     u8  contacts
   lenstr name
 ```
+Clients MUST mask `agency_idx = agency_flags & 0x7f` before indexing
+agency data. If `(agency_flags & 0x80) != 0`, the character may be
+renamed once with `opRenameCharacter`.
 
 ### `opCreateCharacter` (15)
 
@@ -376,6 +381,21 @@ u32    character_id
 ```
 The server selects the existing character and replies with
 `opCharacters`.
+
+### `opRenameCharacter` (17)
+
+**Request** (`C → S`):
+```
+u32    character_id
+lenstr name
+```
+The server applies the one-time rename only if the character belongs
+to the authenticated account and has the rename-available bit. The
+alias is trimmed, must be non-empty, must be ≤16 bytes, must differ
+from the current character name, and must not case-insensitively
+duplicate another character on the same account. Success clears the
+rename bit and replies with `opCharacters`; rejection replies with
+the unchanged `opCharacters` state.
 
 ## `LobbyGame` wire layout
 

--- a/shared/lobby-protocol/vectors.json
+++ b/shared/lobby-protocol/vectors.json
@@ -192,13 +192,14 @@
     {
       "name": "characters_push",
       "kind": "Characters",
-      "hex": "360e022c0100002c010000010a000b000c000d0e0f101112130553686164652d010000030100020003000405060708090a0556616e7461",
+      "hex": "360e022c0100002c010000810a000b000c000d0e0f101112130553686164652d010000030100020003000405060708090a0556616e7461",
       "value": {
         "selected_char_id": 300,
         "characters": [
           {
             "id": 300,
             "agency_idx": 1,
+            "rename_available": true,
             "stats": {
               "wins": 10,
               "losses": 11,
@@ -216,6 +217,7 @@
           {
             "id": 301,
             "agency_idx": 3,
+            "rename_available": false,
             "stats": {
               "wins": 1,
               "losses": 2,
@@ -309,6 +311,15 @@
       "hex": "05102c010000",
       "value": {
         "character_id": 300
+      }
+    },
+    {
+      "name": "rename_character_request",
+      "kind": "RenameCharacterRequest",
+      "hex": "0c112c01000006566573706572",
+      "value": {
+        "character_id": 300,
+        "name": "Vesper"
       }
     },
     {


### PR DESCRIPTION
Closes #242

## Summary
- Move lobby XP text into the action column above Agents
- Use selected character names for lobby/game display names
- Add a one-time rename grant for migrated agency-named characters, including protocol/version/SDK updates

## Verification
- go test ./... (services/lobby)
- bun test (clients/lobby-sdk/ts)
- bun run typecheck (clients/lobby-sdk/ts)
- bun run fmt:check (clients/lobby-sdk/ts)
- cmake -B build -S . && cmake --build build && ctest --test-dir build (clients/lobby-sdk/cpp)
- clients/silencer/build.sh win-ninja
- git diff --check