### PR TITLE
Fix macOS auto-updater stage-2 signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,12 +57,14 @@ jobs:
           TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
           IDENTITY="Developer ID Application"
-          # Sign inside-out: dylibs first, then main binary, then bundle.
+          # Sign inside-out: dylibs and helper first, then main binary, then bundle.
           # --options runtime (Hardened Runtime) + --timestamp are required
           # by notarytool.
           find Silencer.app/Contents/Frameworks -name "*.dylib" -print0 \
             | xargs -0 -n1 codesign --force --timestamp --options runtime \
               --sign "$IDENTITY"
+          codesign --force --timestamp --options runtime \
+            --sign "$IDENTITY" Silencer.app/Contents/Helpers/updater-stage-2
           codesign --force --timestamp --options runtime \
             --sign "$IDENTITY" Silencer.app/Contents/MacOS/Silencer
           codesign --force --timestamp --options runtime \

--- a/clients/silencer/CMakeLists.txt
+++ b/clients/silencer/CMakeLists.txt
@@ -57,6 +57,25 @@ if(APPLE)
 		MACOSX_BUNDLE_ICON_FILE "icon.icns"
 		OUTPUT_NAME "Silencer"
 	)
+	add_executable(updater-stage-2
+		tools/updater-stage-2/main.cpp
+		src/updater/updaterstage2.cpp
+		src/updater/updaterzip.cpp
+	)
+	target_compile_features(updater-stage-2 PRIVATE cxx_std_20)
+	target_include_directories(updater-stage-2 PRIVATE
+		"${CMAKE_CURRENT_SOURCE_DIR}/src/updater")
+	set_target_properties(updater-stage-2 PROPERTIES OUTPUT_NAME "updater-stage-2")
+	set(updater_stage2_bundle_dir
+		"${CMAKE_CURRENT_BINARY_DIR}/Silencer.app/Contents/Helpers")
+	add_custom_command(TARGET updater-stage-2 POST_BUILD
+		COMMAND ${CMAKE_COMMAND} -E make_directory
+			"${updater_stage2_bundle_dir}"
+		COMMAND ${CMAKE_COMMAND} -E copy_if_different
+			"$<TARGET_FILE:updater-stage-2>"
+			"${updater_stage2_bundle_dir}/updater-stage-2"
+		COMMENT "Embedding macOS updater stage-2 helper")
+	add_dependencies(${SILENCER_TARGET} updater-stage-2)
 elseif(WIN32)
 	add_executable(${SILENCER_TARGET} WIN32 ${sources})
 	set_target_properties(${SILENCER_TARGET} PROPERTIES OUTPUT_NAME "Silencer")

--- a/clients/silencer/src/updater/CLAUDE.md
+++ b/clients/silencer/src/updater/CLAUDE.md
@@ -52,6 +52,8 @@ if (updater.IsStage2Spawned()) return false; // exits Game::Loop
 
 1. Normal client (`--self-update-stage2` absent): reaches STAGING, calls `UpdaterStage2::Launch(zippath)`, marks spawned, returns from game loop so `~Game()` tears down SDL cleanly.
 2. Stage-2 process (invoked with `--self-update-stage2`): `UpdaterStage2::Run` overwrites the binary, then `exec`-replaces itself with the new client.
+   - macOS launches the nested signed helper at `Silencer.app/Contents/Helpers/updater-stage-2`. Do not recreate a temporary `.app` bundle at runtime.
+   - Windows/Linux still copy the current executable to a temp path for the handoff.
 
 ## Rules
 

--- a/clients/silencer/src/updater/updaterstage2.cpp
+++ b/clients/silencer/src/updater/updaterstage2.cpp
@@ -530,69 +530,15 @@ bool Launch(const std::string &zippath) {
         }
     }
 #elif defined(__APPLE__)
-    // The shipped binary is signed with hardened runtime + library
-    // validation and references its dylibs via @rpath, with LC_RPATH set
-    // to @executable_path/../Frameworks. A flat copy at /tmp/silencer-stage2
-    // resolves @executable_path to /tmp, so dyld looks in /Frameworks/ and
-    // bails before main() runs — silently, because hardened runtime
-    // suppresses dyld errors when no TTY is attached. Mirror just enough
-    // bundle structure under /tmp that Frameworks/ sits next to the binary.
-    std::string stage2_bundle = tempdir + "/silencer-stage2.app";
-    std::string stage2_contents = stage2_bundle + "/Contents";
-    std::string stage2_macos = stage2_contents + "/MacOS";
-    std::string stage2_fw = stage2_contents + "/Frameworks";
-    RemoveDirRecursive(stage2_bundle);
-    mkdir(stage2_bundle.c_str(), 0755);
-    mkdir(stage2_contents.c_str(), 0755);
-    mkdir(stage2_macos.c_str(), 0755);
-    mkdir(stage2_fw.c_str(), 0755);
-
-    std::string temp = stage2_macos + "/silencer-stage2";
-    if (!CopyFile_(self, temp)) {
-        Logf("copy self → %s failed", temp.c_str());
+    // Do not synthesize a temporary .app bundle. Gatekeeper assesses that
+    // as new downloaded code and can reject it before stage-2 reaches main().
+    // The helper is nested signed code shipped inside the notarized app.
+    std::string temp = install + "/Contents/Helpers/updater-stage-2";
+    struct stat stage2_st;
+    if (stat(temp.c_str(), &stage2_st) != 0 || !S_ISREG(stage2_st.st_mode) ||
+        access(temp.c_str(), X_OK) != 0) {
+        Logf("missing executable macOS stage-2 helper: %s", temp.c_str());
         return false;
-    }
-
-    // Production-signed binaries have their embedded LC_CODE_SIGNATURE
-    // bound to the bundle's Info.plist (the "Info.plist entries=N" line
-    // in `codesign -dvvv`). Without it, AMFI rejects the binary at
-    // execve() with "The code contains a Team ID, but validating its
-    // signature failed" and SIGKILLs stage-2 before main() — silent,
-    // since the parent's TTY is gone. Mirror Info.plist so the seal
-    // validates. Best-effort: ad-hoc-signed dev builds don't bind it.
-    if (!CopyFile_(install + "/Contents/Info.plist",
-                   stage2_contents + "/Info.plist")) {
-        Logf("copy Info.plist failed (ok for ad-hoc-signed dev builds)");
-    }
-
-    // Mirror Frameworks/ from the source bundle so @rpath dylib refs
-    // (libSDL3, libSDL3_mixer, libminizip, …) resolve. Local dev builds
-    // link against absolute /opt/homebrew paths and have an empty (or
-    // missing) Frameworks/ — that's fine, the absolute paths resolve
-    // straight from /tmp without help.
-    std::string src_fw = install + "/Contents/Frameworks";
-    DIR *fwd = opendir(src_fw.c_str());
-    if (fwd) {
-        struct dirent *e;
-        while ((e = readdir(fwd)) != NULL) {
-            std::string n = e->d_name;
-            if (n == "." || n == "..") continue;
-            std::string from = src_fw + "/" + n;
-            struct stat st;
-            if (lstat(from.c_str(), &st) != 0) continue;
-            if (S_ISDIR(st.st_mode)) {
-                Logf("skipping framework dir %s (flat-dylib layout expected)", n.c_str());
-                continue;
-            }
-            std::string to = stage2_fw + "/" + n;
-            if (!CopyFile_(from, to)) {
-                Logf("copy framework %s -> %s failed", from.c_str(), to.c_str());
-            }
-        }
-        closedir(fwd);
-    } else {
-        Logf("no Frameworks/ at %s; assuming dev build with absolute dylib paths",
-            src_fw.c_str());
     }
 #else
     std::string temp = tempdir + "/silencer-stage2";
@@ -643,6 +589,12 @@ bool Launch(const std::string &zippath) {
         return false;
     }
     if (f == 0) {
+#ifdef __APPLE__
+        if (chdir(tempdir.c_str()) != 0) {
+            Logf("chdir(%s) before stage2 failed: %s",
+                 tempdir.c_str(), strerror(errno));
+        }
+#endif
         execl(temp.c_str(), temp.c_str(), "--self-update-stage2",
               ziparg, instarg, pidarg, relarg, (char*)nullptr);
         _exit(99);

--- a/clients/silencer/src/updater/updaterstage2.h
+++ b/clients/silencer/src/updater/updaterstage2.h
@@ -11,8 +11,9 @@ namespace UpdaterStage2 {
 int Run(int argc, char **argv);
 
 // Called by the normal client when Updater reaches STAGING.
-// Spawns stage-2 (the same binary, copied to a temp path, reinvoked
-// with --self-update-stage2). Returns true on a successful spawn — the
+// Spawns stage-2. macOS launches the nested signed helper at
+// Contents/Helpers/updater-stage-2; Windows/Linux keep the copied-binary
+// handoff. Returns true on a successful spawn — the
 // caller is then responsible for exiting cleanly via main-return so
 // ~Game() runs (otherwise the audio device is left open, producing a
 // pop when the new process re-opens it). Returns false if the spawn

--- a/clients/silencer/tools/updater-stage-2/main.cpp
+++ b/clients/silencer/tools/updater-stage-2/main.cpp
@@ -1,0 +1,5 @@
+#include "updaterstage2.h"
+
+int main(int argc, char **argv) {
+    return UpdaterStage2::Run(argc, argv);
+}

--- a/docs/plans/2026-05-25-macos-auto-updater-stage2.md
+++ b/docs/plans/2026-05-25-macos-auto-updater-stage2.md
@@ -1,0 +1,189 @@
+# macOS Auto-Updater Stage-2
+
+**Status:** Proposed  
+**Date:** 2026-05-25  
+**Issue:** #243
+
+## Goal
+
+Fix the macOS auto-updater failure where Gatekeeper reports
+`updater-stage-2` as damaged and prompts the user to move it to Trash.
+
+The correct macOS shape is not to create an updater app bundle at
+runtime. The updater executable must be shipped as nested signed code
+inside `Silencer.app`, notarized as part of the release artifact, and
+launched from that trusted bundle.
+
+## Decision
+
+Keep the existing cross-platform lobby-driven updater, but make macOS
+stage-2 a real helper executable:
+
+- Build a dedicated `updater-stage-2` command-line helper target on
+  macOS.
+- Embed it at `Silencer.app/Contents/Helpers/updater-stage-2`.
+- Sign the helper first, then sign `Silencer.app`, then notarize and
+  staple the app and DMG.
+- Launch the embedded helper directly from `Contents/Helpers`; do not
+  copy the main game executable to `/tmp`, and do not synthesize a
+  `silencer-stage2.app`.
+
+Sparkle 2 is the macOS-native long-term option and should be preferred
+if we want to replace the custom updater entirely. For this issue, a
+signed helper is the narrow fix because the lobby protocol, update
+manifest, SHA-256 verification, Windows updater, and release zip format
+already exist.
+
+## Why the Current Design Fails
+
+The current macOS launcher builds a temporary bundle under
+`/tmp/silencer-stage2.app`, copies the main executable into it as
+`silencer-stage2`, copies `Info.plist`, and mirrors `Frameworks/`.
+That tries to recreate enough of a signed app after distribution.
+
+That is fragile on macOS:
+
+- The app's outer resource envelope is signed. Runtime-created bundle
+  contents are not the notarized artifact Apple assessed.
+- The copied executable no longer lives in the bundle path and resource
+  layout it was signed with.
+- A helper named differently from the bundle's `CFBundleExecutable`
+  makes the temporary bundle look malformed.
+- If quarantine is present, Gatekeeper assesses this temporary helper
+  as user-downloaded code and can reject it before our logging code runs.
+
+Apple's signing model expects nested code to live in standard bundle
+locations and be signed before the outer app is signed. `Contents/Helpers`
+is a standard location for helper tools.
+
+## Implementation Plan
+
+1. Extract the stage-2 implementation from the game executable.
+
+   Move the code behind `UpdaterStage2::Run` into a small reusable module
+   that can be linked by both the game and a helper target. Keep the
+   game-facing `UpdaterStage2::Launch(zippath)` API so the UI and state
+   machine do not change. Add a tiny helper-only `main` that calls the
+   shared runner when `--self-update-stage2` is present.
+
+   Keep the boundary explicit: the helper runner owns argument parsing
+   and replacement work, while the game-side launcher owns only locating
+   and spawning the helper. Do not move more updater orchestration into
+   `main.cpp`.
+
+2. Add a macOS-only helper target.
+
+   In `clients/silencer/CMakeLists.txt`, add an executable target named
+   `updater-stage-2` for Apple builds. It should link only the stage-2
+   runner and minimal updater zip/extraction code. Avoid SDL, rendering,
+   audio, networking, UI, and game systems. The helper should depend only
+   on system libraries on macOS, because extraction uses `/usr/bin/ditto`.
+
+   Install/copy the built helper into:
+
+   ```text
+   Silencer.app/Contents/Helpers/updater-stage-2
+   ```
+
+3. Change macOS launch behavior.
+
+   On Apple builds, `UpdaterStage2::Launch` should resolve the installed
+   app bundle from the running game path, then spawn:
+
+   ```text
+   <Silencer.app>/Contents/Helpers/updater-stage-2
+   ```
+
+   Pass the existing arguments:
+
+   ```text
+   --self-update-stage2
+   --zip=<downloaded zip>
+   --install-dir=<Silencer.app>
+   --pid=<parent pid>
+   --relaunch=<Silencer.app/Contents/MacOS/Silencer>
+   ```
+
+   The helper may live inside the bundle it later renames to `.old`.
+   POSIX permits an already-running executable to continue after its
+   containing directory is renamed. Keep the helper's current working
+   directory outside the app bundle.
+
+4. Remove the macOS temporary bundle path.
+
+   Delete the macOS code that creates `/tmp/silencer-stage2.app`, copies
+   `Info.plist`, copies `Frameworks/`, and renames the main executable to
+   a helper name. Keep the Windows and Linux paths unchanged.
+
+5. Sign inside-out in release CI.
+
+   Update `.github/workflows/release.yml` so macOS release signing signs
+   in this order:
+
+   ```text
+   Silencer.app/Contents/Frameworks/*.dylib
+   Silencer.app/Contents/Helpers/updater-stage-2
+   Silencer.app/Contents/MacOS/Silencer
+   Silencer.app
+   ```
+
+   Use the same Developer ID Application identity, hardened runtime, and
+   timestamp options already used for the main app.
+
+6. Strengthen bundle checks.
+
+   Extend `tests/e2e/check-bundle-macos.sh` to verify:
+
+   - `Contents/Helpers/updater-stage-2` exists and is executable.
+   - The helper has no unbundled non-system dylib references. Prefer no
+     non-system dylib references at all.
+   - `codesign --verify --deep --strict` covers the final app in release
+     CI after helper signing.
+
+7. Update the local updater harness.
+
+   Update `infra/scripts/test-updater.sh` so the macOS path exercises the
+   embedded helper. The local unsigned/ad-hoc build can validate process
+   flow, extraction, rename, rollback, and relaunch. Gatekeeper behavior
+   still requires a Developer ID signed, notarized release artifact.
+
+8. Add release-only verification for Gatekeeper.
+
+   After notarization and stapling in release CI, verify the app and DMG:
+
+   ```bash
+   codesign --verify --deep --strict --verbose=2 Silencer.app
+   xcrun stapler validate Silencer.app
+   spctl -a -vv -t execute Silencer.app
+   spctl -a -vv -t open --context context:primary-signature silencer-macos-arm64.dmg
+   ```
+
+   Add a manual release checklist item to install an older notarized DMG,
+   connect to the lobby, accept the update, and confirm the helper runs
+   without the damaged-app prompt.
+
+## Out of Scope
+
+- Replacing the custom updater with Sparkle 2.
+- Changing the lobby update protocol.
+- Changing the release artifact shape consumed by the updater
+  (`silencer-macos-arm64.zip` remains a `ditto --keepParent` archive of
+  `Silencer.app`).
+- Changing Windows updater behavior.
+- Adding privileged installation into locations the user cannot write.
+
+## Rollout Note
+
+This cannot retroactively fix already-shipped macOS builds that do not
+contain the nested helper. Those users may need one manual DMG install to
+get onto the helper-bearing version. Once installed, future auto-updates
+use the signed helper path.
+
+## References
+
+- Apple Code Signing Guide: nested code must be signed before the outer
+  app, and `Contents/Helpers` is a standard helper location.
+- Apple notarization guidance: distributed Developer ID software should
+  be signed, notarized, and stapled before distribution.
+- Sparkle 2: the standard macOS updater framework if we later decide to
+  replace the custom updater.

--- a/infra/scripts/test-updater.sh
+++ b/infra/scripts/test-updater.sh
@@ -53,6 +53,10 @@ cmake -B build-old -S clients/silencer \
     -DSILENCER_LOBBY_PORT=15170
 cmake --build build-old -j
 
+if [ "$(uname)" = "Darwin" ]; then
+    test -x build-old/Silencer.app/Contents/Helpers/updater-stage-2
+fi
+
 cat > update.json <<EOF
 {
   "version":        "$NEW_VER",

--- a/tests/e2e/check-bundle-macos.sh
+++ b/tests/e2e/check-bundle-macos.sh
@@ -9,21 +9,34 @@ set -euo pipefail
 APP="${1:?usage: $0 <path-to-Silencer.app>}"
 BINARY="$APP/Contents/MacOS/Silencer"
 FRAMEWORKS="$APP/Contents/Frameworks"
+HELPER="$APP/Contents/Helpers/updater-stage-2"
 
 [ -x "$BINARY" ] || { echo "no executable at $BINARY" >&2; exit 1; }
+[ -x "$HELPER" ] || { echo "no executable at $HELPER" >&2; exit 1; }
 
 errors=0
 
 check_file() {
 	local file="$1"
+	local allow_bundled_deps="${2:-1}"
 	local refs
 	refs=$(otool -L "$file" | tail -n +2 | awk '{print $1}')
 	while IFS= read -r ref; do
 		case "$ref" in
 			"") ;;
 			/System/*|/usr/lib/*) ;;
-			@executable_path/*|@loader_path/*) ;;
+			@executable_path/*|@loader_path/*)
+				if [ "$allow_bundled_deps" != "1" ]; then
+					echo "UNEXPECTED helper dependency: $ref (in $file)"
+					errors=$((errors + 1))
+				fi
+				;;
 			@rpath/*)
+				if [ "$allow_bundled_deps" != "1" ]; then
+					echo "UNEXPECTED helper dependency: $ref (in $file)"
+					errors=$((errors + 1))
+					continue
+				fi
 				local lib="${ref#@rpath/}"
 				if [ ! -f "$FRAMEWORKS/$lib" ]; then
 					echo "MISSING in Frameworks/: $lib (referenced from $file)"
@@ -43,6 +56,7 @@ check_file() {
 }
 
 check_file "$BINARY"
+check_file "$HELPER" 0
 
 if [ -d "$FRAMEWORKS" ]; then
 	while IFS= read -r dylib; do


### PR DESCRIPTION
Closes #243

## Summary
- add a dedicated macOS updater-stage-2 helper embedded at Silencer.app/Contents/Helpers/updater-stage-2
- launch the nested helper instead of synthesizing /tmp/silencer-stage2.app
- sign the helper inside-out in release CI before the main app and outer bundle
- strengthen macOS bundle verification so the helper must exist and stay system-library-only
- document the correct updater architecture and rollout caveat

## Verification
- clients/silencer/build.sh win-ninja --clean
- local CI-style dylibbundler step for clients/silencer/build/Silencer.app
- tests/e2e/check-bundle-macos.sh clients/silencer/build/Silencer.app
- local inside-out ad-hoc codesign of Frameworks/*.dylib, Contents/Helpers/updater-stage-2, Contents/MacOS/Silencer, and Silencer.app
- codesign --verify --deep --strict --verbose=2 clients/silencer/build/Silencer.app
- otool -L clients/silencer/build/Silencer.app/Contents/Helpers/updater-stage-2
- git diff --check

## Review
- thermo-nuclear review pass 1 raised stale helper-copy and helper-dependency-boundary issues; both fixed
- thermo-nuclear review pass 2 reported no blocking structural findings

## Release note
Existing macOS installs that do not already contain the nested helper may need one manual DMG install to get onto this helper-bearing version. Future auto-updates then use the signed helper path.