### PR TITLE
Release v00055

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to Silencer are documented here.
 
 ## [Unreleased]
 
+## [v00055] — 2026-05-25
+
+### Game client
+
+#### macOS updater (#247)
+
+- macOS release builds now package `updater-stage-2` as a nested, signed helper at `Silencer.app/Contents/Helpers/updater-stage-2`, so Gatekeeper validates it as part of the app bundle instead of rejecting a copied runtime executable as damaged.
+- The updater no longer stages a temporary `.app` around `updater-stage-2`; it resolves and launches the helper from the installed bundle, then keeps the actual app replacement flow in the signed helper.
+- Release signing now signs and verifies the helper inside-out, and the macOS bundle verifier enforces that the helper exists and only links against system libraries.
+
+#### Release note
+
+- Existing macOS installs that already lost or quarantined their stage-2 helper may need one manual DMG install. After that, future auto-updates use the signed nested helper.
+
 ### Infrastructure
 
 - Removed the disposable AWS smoke-test environment: automatic staging deploys, staging SSM seed entries, the retired plan documentation, and the staging Terraform module are gone after the approved destroy and cleanup (#235, #240).

--- a/clients/silencer/CMakeLists.txt
+++ b/clients/silencer/CMakeLists.txt
@@ -220,7 +220,7 @@ endif()
 
 set(SILENCER_LOBBY_HOST "lobby.arsiamons.com" CACHE STRING "Lobby host the client connects to at startup")
 set(SILENCER_LOBBY_PORT "517" CACHE STRING "Lobby TCP port")
-set(SILENCER_VERSION "00054" CACHE STRING "Client version string sent to the lobby during MSG_VERSION; overridden by release.yml from git tag")
+set(SILENCER_VERSION "00055" CACHE STRING "Client version string sent to the lobby during MSG_VERSION; overridden by release.yml from git tag")
 set(SILENCER_MAP_API_URL "https://admin.arsiamons.com" CACHE STRING "Base URL for the community map HTTP API (used when fetching a missing map before falling back to P2P)")
 set(SILENCER_ADMIN_API_URL "https://admin.arsiamons.com" CACHE STRING "Base URL for the admin API (actordefs sync, etc.)")
 target_compile_definitions(${SILENCER_TARGET} PRIVATE

--- a/clients/silencer/src/game/init/game_init.cpp
+++ b/clients/silencer/src/game/init/game_init.cpp
@@ -17,7 +17,7 @@ using namespace GameState;
 #define SILENCER_LOBBY_PORT 517
 #endif
 #ifndef SILENCER_VERSION
-#define SILENCER_VERSION "00054"
+#define SILENCER_VERSION "00055"
 #endif
 #ifndef SILENCER_MAP_API_URL
 #define SILENCER_MAP_API_URL "http://127.0.0.1:8080"
@@ -291,4 +291,3 @@ bool Game::Load(char * cmdline){
 	}
 	return true;
 }
-

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -55,7 +55,7 @@ services:
       - "-public-addr"
       - "${PUBLIC_ADDR:-127.0.0.1}"
       - "-version"
-      - "00054"
+      - "00055"
       - "-db"
       - "/data/lobby.json"
       - "-game-binary"

--- a/infra/scripts/build-mac-local.sh
+++ b/infra/scripts/build-mac-local.sh
@@ -5,7 +5,7 @@
 #   ./infra/scripts/build-mac-local.sh               # lobby at 127.0.0.1:15170
 #   LOBBY_HOST=1.2.3.4 ./infra/scripts/build-mac-local.sh
 #   LOBBY_PORT=517      ./infra/scripts/build-mac-local.sh
-#   VERSION=00054       ./infra/scripts/build-mac-local.sh  # must match lobby -version flag
+#   VERSION=00055       ./infra/scripts/build-mac-local.sh  # must match lobby -version flag
 #
 # The lobby host, port, and version are baked into the binary at compile time.
 # Run `docker compose -f infra/docker-compose.yml up -d` first so the lobby is ready before launching.
@@ -15,7 +15,7 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 LOBBY_HOST="${LOBBY_HOST:-127.0.0.1}"
 LOBBY_PORT="${LOBBY_PORT:-15170}"
-VERSION="${VERSION:-00054}"
+VERSION="${VERSION:-00055}"
 BUILD_DIR="$REPO_ROOT/build"
 
 echo "==> Installing/updating dependencies via Homebrew"

--- a/services/lobby/Dockerfile
+++ b/services/lobby/Dockerfile
@@ -54,7 +54,7 @@ RUN apt-get -o Acquire::Check-Valid-Until=false \
         ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-ARG SILENCER_VERSION=00054
+ARG SILENCER_VERSION=00055
 
 WORKDIR /src
 COPY clients/silencer/CMakeLists.txt clients/silencer/

--- a/services/lobby/protocol_version_test.go
+++ b/services/lobby/protocol_version_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 )
 
-const currentProtocolVersion = "00054"
+const currentProtocolVersion = "00055"
 const currentWireFingerprint = "5ee766b2ad0c165228cc932d483d73460431b187fc8918d88672ea10731d7a79"
 
 var wireFingerprintPaths = []string{


### PR DESCRIPTION
Closes #248

## Summary
- Move the current unreleased notes into v00055.
- Document the macOS signed nested updater-stage-2 helper release note.
- Bump checked-in default Silencer version pins from 00054 to 00055.

## Verification
- git diff --check
- go test ./... (services/lobby)