### PR TITLE
Clean up macOS updater old app bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Silencer are documented here.
 
 ## [Unreleased]
 
+### Game client
+
+- macOS startup now removes a stale `Silencer.app.old` sibling left by a successful auto-update once the new app has relaunched (#253).
+
 ## [v00056] — 2026-05-25
 
 ### Game client

--- a/clients/silencer/src/main.cpp
+++ b/clients/silencer/src/main.cpp
@@ -182,11 +182,60 @@ static void SweepSidelinedFiles(const std::string &dir) {
 }
 #endif
 
+#ifdef __APPLE__
+static void RemoveDirRecursive(const std::string &path) {
+	DIR *d = opendir(path.c_str());
+	if (!d) return;
+	struct dirent *e;
+	while ((e = readdir(d)) != NULL) {
+		std::string n = e->d_name;
+		if (n == "." || n == "..") continue;
+		std::string child = path + "/" + n;
+		struct stat st;
+		if (lstat(child.c_str(), &st) != 0) continue;
+		if (S_ISDIR(st.st_mode)) {
+			RemoveDirRecursive(child);
+		} else if (unlink(child.c_str()) != 0) {
+			fprintf(stderr, "[updater] cleanup unlink failed: %s (%s)\n",
+				child.c_str(), strerror(errno));
+		}
+	}
+	closedir(d);
+	if (rmdir(path.c_str()) != 0) {
+		fprintf(stderr, "[updater] cleanup rmdir failed: %s (%s)\n",
+			path.c_str(), strerror(errno));
+	}
+}
+
+static std::string CurrentMacAppBundlePath(void) {
+	char buf[PATH_MAX];
+	uint32_t n = sizeof(buf);
+	if (_NSGetExecutablePath(buf, &n) != 0) return "";
+	std::string exe = buf;
+	size_t slash = exe.find_last_of("/");
+	if (slash == std::string::npos) return "";
+	std::string parent = exe.substr(0, slash);
+	const std::string bundle_suffix = "/Contents/MacOS";
+	if (parent.size() < bundle_suffix.size() ||
+		parent.compare(parent.size() - bundle_suffix.size(),
+			bundle_suffix.size(), bundle_suffix) != 0) {
+		return "";
+	}
+	return parent.substr(0, parent.size() - bundle_suffix.size());
+}
+#endif
+
 static void CleanupPreviousUpdate(void) {
 #ifdef __APPLE__
-	// .app install: sibling foo.app.old. We don't know our exact install dir
-	// here without mach-o/dyld logic; skip cleanup on macOS and rely on the
-	// user trashing .app.old manually.
+	std::string install_dir = CurrentMacAppBundlePath();
+	if (install_dir.empty()) return;
+	std::string old_dir = install_dir + ".old";
+	struct stat st;
+	if (lstat(old_dir.c_str(), &st) == 0 && S_ISDIR(st.st_mode)) {
+		fprintf(stderr, "[updater] cleaning up prior install: %s\n",
+			old_dir.c_str());
+		RemoveDirRecursive(old_dir);
+	}
 #else
 	char buf[1024];
 	int n = 0;

--- a/clients/silencer/src/main.cpp
+++ b/clients/silencer/src/main.cpp
@@ -163,116 +163,7 @@ static void SyncInstalledVersionRegistry(void) {
 	RegCloseKey(key);
 }
 
-static void SweepSidelinedFiles(const std::string &dir) {
-	WIN32_FIND_DATAA fd;
-	std::string pattern = dir + "\\*";
-	HANDLE h = FindFirstFileA(pattern.c_str(), &fd);
-	if (h == INVALID_HANDLE_VALUE) return;
-	do {
-		std::string n = fd.cFileName;
-		if (n == "." || n == "..") continue;
-		std::string child = dir + "\\" + n;
-		if (fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
-			SweepSidelinedFiles(child);
-		} else if (n.find(".old-") != std::string::npos) {
-			DeleteFileA(child.c_str());
-		}
-	} while (FindNextFileA(h, &fd));
-	FindClose(h);
-}
 #endif
-
-#ifdef __APPLE__
-static void RemoveDirRecursive(const std::string &path) {
-	DIR *d = opendir(path.c_str());
-	if (!d) return;
-	struct dirent *e;
-	while ((e = readdir(d)) != NULL) {
-		std::string n = e->d_name;
-		if (n == "." || n == "..") continue;
-		std::string child = path + "/" + n;
-		struct stat st;
-		if (lstat(child.c_str(), &st) != 0) continue;
-		if (S_ISDIR(st.st_mode)) {
-			RemoveDirRecursive(child);
-		} else if (unlink(child.c_str()) != 0) {
-			fprintf(stderr, "[updater] cleanup unlink failed: %s (%s)\n",
-				child.c_str(), strerror(errno));
-		}
-	}
-	closedir(d);
-	if (rmdir(path.c_str()) != 0) {
-		fprintf(stderr, "[updater] cleanup rmdir failed: %s (%s)\n",
-			path.c_str(), strerror(errno));
-	}
-}
-
-static std::string CurrentMacAppBundlePath(void) {
-	char buf[PATH_MAX];
-	uint32_t n = sizeof(buf);
-	if (_NSGetExecutablePath(buf, &n) != 0) return "";
-	std::string exe = buf;
-	size_t slash = exe.find_last_of("/");
-	if (slash == std::string::npos) return "";
-	std::string parent = exe.substr(0, slash);
-	const std::string bundle_suffix = "/Contents/MacOS";
-	if (parent.size() < bundle_suffix.size() ||
-		parent.compare(parent.size() - bundle_suffix.size(),
-			bundle_suffix.size(), bundle_suffix) != 0) {
-		return "";
-	}
-	return parent.substr(0, parent.size() - bundle_suffix.size());
-}
-#endif
-
-static void CleanupPreviousUpdate(void) {
-#ifdef __APPLE__
-	std::string install_dir = CurrentMacAppBundlePath();
-	if (install_dir.empty()) return;
-	std::string old_dir = install_dir + ".old";
-	struct stat st;
-	if (lstat(old_dir.c_str(), &st) == 0 && S_ISDIR(st.st_mode)) {
-		fprintf(stderr, "[updater] cleaning up prior install: %s\n",
-			old_dir.c_str());
-		RemoveDirRecursive(old_dir);
-	}
-#else
-	char buf[1024];
-	int n = 0;
-#ifdef _WIN32
-	GetModuleFileNameA(NULL, buf, sizeof(buf));
-	n = (int)strlen(buf);
-#else
-	n = (int)readlink("/proc/self/exe", buf, sizeof(buf) - 1);
-#endif
-	if (n <= 0) return;
-	buf[n] = 0;
-	std::string exe = buf;
-	size_t slash = exe.find_last_of("/\\");
-	if (slash == std::string::npos) return;
-	std::string install_dir = exe.substr(0, slash);
-
-	// Pre-per-file-replace builds left a `<install>.old` sibling; sweep until
-	// they age out.
-	std::string old_dir = install_dir + ".old";
-	struct stat st;
-	if (stat(old_dir.c_str(), &st) == 0) {
-		fprintf(stderr, "[updater] cleaning up prior install: %s\n", old_dir.c_str());
-#ifdef _WIN32
-		std::string cmd = "rd /s /q \"" + old_dir + "\"";
-#else
-		std::string cmd = "rm -rf '" + old_dir + "'";
-#endif
-		system(cmd.c_str());
-	}
-
-#ifdef _WIN32
-	// ReplaceFileAtomic sidelines locked targets as `<file>.old-<ticks>`;
-	// they're usually unlocked by next launch.
-	SweepSidelinedFiles(install_dir);
-#endif
-#endif
-}
 
 #ifdef POSIX
 int main(int argc, char * argv[]){
@@ -321,7 +212,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 	}
 #endif
 
-	CleanupPreviousUpdate();
+	UpdaterStage2::CleanupPreviousUpdate();
 #ifdef _WIN32
 	SyncInstalledVersionRegistry();
 #endif

--- a/clients/silencer/src/updater/updaterstage2.cpp
+++ b/clients/silencer/src/updater/updaterstage2.cpp
@@ -144,6 +144,17 @@ bool RenameDir(const std::string &src, const std::string &dst) {
 #endif
 }
 
+bool IsDirectory(const std::string &path) {
+#ifdef _WIN32
+    DWORD attrs = GetFileAttributesA(path.c_str());
+    return attrs != INVALID_FILE_ATTRIBUTES &&
+        (attrs & FILE_ATTRIBUTE_DIRECTORY) != 0;
+#else
+    struct stat st;
+    return stat(path.c_str(), &st) == 0 && S_ISDIR(st.st_mode);
+#endif
+}
+
 // Best-effort recursive delete. Used to strip `__MACOSX/` siblings that
 // ditto --sequesterRsrc bakes alongside the real bundle — leaving them
 // in place would break FindSingleTopDir (sees 2 entries) and pollute the
@@ -314,6 +325,24 @@ bool ReplaceFileAtomic(const std::string &src, const std::string &dst) {
     return true;
 }
 
+void SweepSidelinedFiles(const std::string &dir) {
+    WIN32_FIND_DATAA fd;
+    std::string pattern = dir + "\\*";
+    HANDLE h = FindFirstFileA(pattern.c_str(), &fd);
+    if (h == INVALID_HANDLE_VALUE) return;
+    do {
+        std::string n = fd.cFileName;
+        if (n == "." || n == "..") continue;
+        std::string child = dir + "\\" + n;
+        if (fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
+            SweepSidelinedFiles(child);
+        } else if (n.find(".old-") != std::string::npos) {
+            DeleteFileA(child.c_str());
+        }
+    } while (FindNextFileA(h, &fd));
+    FindClose(h);
+}
+
 // Files in install_root that aren't in new_root are left in place — no
 // manifest of removed files yet.
 bool MergeTreeWindows(const std::string &new_root, const std::string &install_root) {
@@ -349,6 +378,26 @@ bool MergeTreeWindows(const std::string &new_root, const std::string &install_ro
 } // namespace
 
 namespace UpdaterStage2 {
+
+void CleanupPreviousUpdate() {
+    std::string self = MySelfPath();
+    if (self.empty()) return;
+    std::string install_dir = ResolveInstallDir(self);
+
+    // POSIX stage-2 swaps by renaming `<install>` to `<install>.old`; older
+    // Windows builds used the same shape before the per-file replace path.
+    std::string old_dir = install_dir + ".old";
+    if (IsDirectory(old_dir)) {
+        Logf("cleaning up prior install: %s", old_dir.c_str());
+        RemoveDirRecursive(old_dir);
+    }
+
+#ifdef _WIN32
+    // ReplaceFileAtomic sidelines locked targets as `<file>.old-<ticks>`;
+    // they're usually unlocked by next launch.
+    SweepSidelinedFiles(install_dir);
+#endif
+}
 
 int Run(int argc, char **argv) {
     std::string zip, install_dir, exe_to_relaunch;

--- a/clients/silencer/src/updater/updaterstage2.h
+++ b/clients/silencer/src/updater/updaterstage2.h
@@ -10,6 +10,10 @@ namespace UpdaterStage2 {
 // success path (exec replaces us).
 int Run(int argc, char **argv);
 
+// Called by the normal client on startup. Removes stale updater leftovers
+// from a prior successful or partially successful self-update.
+void CleanupPreviousUpdate();
+
 // Called by the normal client when Updater reaches STAGING.
 // Spawns stage-2. macOS launches the nested signed helper at
 // Contents/Helpers/updater-stage-2; Windows/Linux keep the copied-binary


### PR DESCRIPTION
Closes #253

## Summary
- Resolve the running macOS app bundle path during startup.
- Remove a stale sibling `Silencer.app.old` once the new app has relaunched successfully.
- Add an Unreleased changelog note for the release cut after merge.

## Verification
- `clients/silencer/build.sh`
- Created a synthetic `clients/silencer/build/Silencer.app.old`, launched `Silencer.app/Contents/MacOS/Silencer --headless`, and confirmed startup cleanup removed the stale bundle.
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check`