### PR TITLE
Release v00057

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Silencer are documented here.
 
 ## [Unreleased]
 
+## [v00057] — 2026-05-25
+
 ### Game client
 
 - macOS startup now removes a stale `Silencer.app.old` sibling left by a successful auto-update once the new app has relaunched (#253).

--- a/clients/silencer/CMakeLists.txt
+++ b/clients/silencer/CMakeLists.txt
@@ -220,7 +220,7 @@ endif()
 
 set(SILENCER_LOBBY_HOST "lobby.arsiamons.com" CACHE STRING "Lobby host the client connects to at startup")
 set(SILENCER_LOBBY_PORT "517" CACHE STRING "Lobby TCP port")
-set(SILENCER_VERSION "00056" CACHE STRING "Client version string sent to the lobby during MSG_VERSION; overridden by release.yml from git tag")
+set(SILENCER_VERSION "00057" CACHE STRING "Client version string sent to the lobby during MSG_VERSION; overridden by release.yml from git tag")
 set(SILENCER_MAP_API_URL "https://admin.arsiamons.com" CACHE STRING "Base URL for the community map HTTP API (used when fetching a missing map before falling back to P2P)")
 set(SILENCER_ADMIN_API_URL "https://admin.arsiamons.com" CACHE STRING "Base URL for the admin API (actordefs sync, etc.)")
 target_compile_definitions(${SILENCER_TARGET} PRIVATE

--- a/clients/silencer/src/game/init/game_init.cpp
+++ b/clients/silencer/src/game/init/game_init.cpp
@@ -17,7 +17,7 @@ using namespace GameState;
 #define SILENCER_LOBBY_PORT 517
 #endif
 #ifndef SILENCER_VERSION
-#define SILENCER_VERSION "00056"
+#define SILENCER_VERSION "00057"
 #endif
 #ifndef SILENCER_MAP_API_URL
 #define SILENCER_MAP_API_URL "http://127.0.0.1:8080"

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -55,7 +55,7 @@ services:
       - "-public-addr"
       - "${PUBLIC_ADDR:-127.0.0.1}"
       - "-version"
-      - "00056"
+      - "00057"
       - "-db"
       - "/data/lobby.json"
       - "-game-binary"

--- a/infra/scripts/build-mac-local.sh
+++ b/infra/scripts/build-mac-local.sh
@@ -5,7 +5,7 @@
 #   ./infra/scripts/build-mac-local.sh               # lobby at 127.0.0.1:15170
 #   LOBBY_HOST=1.2.3.4 ./infra/scripts/build-mac-local.sh
 #   LOBBY_PORT=517      ./infra/scripts/build-mac-local.sh
-#   VERSION=00056       ./infra/scripts/build-mac-local.sh  # must match lobby -version flag
+#   VERSION=00057       ./infra/scripts/build-mac-local.sh  # must match lobby -version flag
 #
 # The lobby host, port, and version are baked into the binary at compile time.
 # Run `docker compose -f infra/docker-compose.yml up -d` first so the lobby is ready before launching.
@@ -15,7 +15,7 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 LOBBY_HOST="${LOBBY_HOST:-127.0.0.1}"
 LOBBY_PORT="${LOBBY_PORT:-15170}"
-VERSION="${VERSION:-00056}"
+VERSION="${VERSION:-00057}"
 BUILD_DIR="$REPO_ROOT/build"
 
 echo "==> Installing/updating dependencies via Homebrew"

--- a/services/lobby/Dockerfile
+++ b/services/lobby/Dockerfile
@@ -54,7 +54,7 @@ RUN apt-get -o Acquire::Check-Valid-Until=false \
         ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-ARG SILENCER_VERSION=00056
+ARG SILENCER_VERSION=00057
 
 WORKDIR /src
 COPY clients/silencer/CMakeLists.txt clients/silencer/

--- a/services/lobby/protocol_version_test.go
+++ b/services/lobby/protocol_version_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 )
 
-const currentProtocolVersion = "00056"
+const currentProtocolVersion = "00057"
 const currentWireFingerprint = "c16c0106632b187bff8887ecf00fdef413aa9a46434b90a7caaf8d96d8da80eb"
 
 var wireFingerprintPaths = []string{


### PR DESCRIPTION
Closes #255

## Summary
- Move the macOS updater cleanup note from Unreleased into a v00057 changelog section.
- Bump checked-in default client/lobby version strings from 00056 to 00057.

## Verification
- `go test ./...` in `services/lobby`
- `clients/silencer/build.sh`
- `git diff --check`