### PR TITLE
Discord live-stats presence (player/game counts) in admin-api

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -94,6 +94,8 @@ services:
       GITHUB_TOKEN: "${GITHUB_TOKEN:-}"
       GITHUB_BACKUP_REPO: "${GITHUB_BACKUP_REPO:-Arsia-Mons/silencer-mongo-backup}"
       ASSETS_DIR: "/assets"
+      # Discord live-stats presence. Empty → presence disabled.
+      DISCORD_TOKEN: "${DISCORD_TOKEN:-}"
     volumes:
       - backup-data:/backups
       - ../shared/assets:/assets

--- a/infra/scripts/seed-ssm.sh
+++ b/infra/scripts/seed-ssm.sh
@@ -169,6 +169,16 @@ if ! aws ssm get-parameter --region "$REGION" \
   put_param /silencer/admin/github_backup_token SecureString "${token:-}"
 fi
 
+# Optional. Bot token for the admin-api Discord live-stats presence line.
+# Empty = presence disabled (admin-api still runs). Seed an empty string if
+# the operator declines so the IAM role can read it without a 404 at fetch.
+if ! aws ssm get-parameter --region "$REGION" \
+       --name /silencer/admin/discord_token >/dev/null 2>&1; then
+  printf '  Discord bot token (Developer Portal > Bot > Reset Token) — leave blank to disable: ' >&2
+  IFS= read -r dtoken
+  put_param /silencer/admin/discord_token SecureString "${dtoken:-}"
+fi
+
 echo
 echo "Done. Verify with:"
 echo "  aws ssm get-parameters-by-path --region $REGION --path /silencer --recursive --query 'Parameters[].Name'"

--- a/infra/terraform/CLAUDE.md
+++ b/infra/terraform/CLAUDE.md
@@ -156,6 +156,7 @@ teammates with IAM read access pull from the same source.
 | `/silencer/admin/jwt_secret`                   | SecureString | admin-api                                    | **Runtime fetch (IAM role)**    |
 | `/silencer/admin/cloudflare_tunnel_token`      | SecureString | `cloudflared service install` (one-shot)     | TF data → user_data             |
 | `/silencer/admin/github_backup_token`          | SecureString | admin-api (optional; empty = backups off)    | **Runtime fetch (IAM role)**    |
+| `/silencer/admin/discord_token`                | SecureString | admin-api (optional; empty = presence off)   | **Runtime fetch (IAM role)**    |
 
 **Two mechanisms because of two different needs**:
 *TF data* values get baked into resources at apply time and end up in

--- a/infra/terraform/cloud-init-admin.yaml.tftpl
+++ b/infra/terraform/cloud-init-admin.yaml.tftpl
@@ -66,6 +66,8 @@ write_files:
       JWT=$(get /silencer/admin/jwt_secret)
       GITHUB_TOKEN=$(get /silencer/admin/github_backup_token)
       GHCR_TOKEN=$(get /silencer/admin/ghcr_pull_token)
+      # Optional: empty (or unseeded) → Discord presence disabled.
+      DISCORD_TOKEN=$(get /silencer/admin/discord_token 2>/dev/null || echo "")
       umask 077
       mkdir -p /etc/silencer
       cat > /etc/silencer/admin-api.env <<EOF
@@ -81,6 +83,7 @@ write_files:
       GITHUB_TOKEN=$GITHUB_TOKEN
       GITHUB_BACKUP_REPO=${github_backup_repo}
       ASSETS_DIR=/assets
+      DISCORD_TOKEN=$DISCORD_TOKEN
       EOF
       chmod 0600 /etc/silencer/admin-api.env
       # docker login to ghcr.io so the silencer-admin-{api,web} units can

--- a/infra/terraform/iam.tf
+++ b/infra/terraform/iam.tf
@@ -34,6 +34,7 @@ locals {
     "${local.ssm_arn_prefix}/silencer/admin/jwt_secret",
     "${local.ssm_arn_prefix}/silencer/admin/github_backup_token",
     "${local.ssm_arn_prefix}/silencer/admin/ghcr_pull_token",
+    "${local.ssm_arn_prefix}/silencer/admin/discord_token",
   ]
 }
 

--- a/services/admin-api/CLAUDE.md
+++ b/services/admin-api/CLAUDE.md
@@ -61,6 +61,17 @@ unit + env file + Mongo/LavinMQ co-location are described in
   `socket.handshake.auth.token`. `liveState` +
   `onlinePlayers` / `activeGames` `Map`s are the in-memory
   snapshot fanned via `snapshot` / per-event broadcasts.
+  `setLiveStateListener(fn)` registers one observer, called
+  with `(players, games)` on the count-changing events — the
+  Discord presence updater hooks in here.
+- `src/discord/presence.js` — Discord **live-stats bot**: shows
+  "Watching N players · M games" as the bot's presence line.
+  Raw gateway WebSocket (Bun native), **no discord.js** — presence
+  is a gateway-only op, so it adds zero deps. Driven entirely by
+  `ws/index.js`'s existing live counts (no extra consumer/poll).
+  Needs `DISCORD_TOKEN`; empty = presence disabled (counts logged
+  on change, nothing connects). Presence sends are throttled to
+  one per 5 s (Discord allows ~5 / 20 s).
 - `src/amqp/consumer.js` — single durable topic queue
   `admin-dashboard` bound to `silencer.events` with `#`.
   Each message: `persistEvent` (Mongo write) **then**

--- a/services/admin-api/src/config.js
+++ b/services/admin-api/src/config.js
@@ -3,6 +3,9 @@ export const MONGO_URL = process.env.MONGO_URL || 'mongodb://localhost:28017/sil
 export const AMQP_URL = process.env.AMQP_URL || 'amqp://silencer:silencer@localhost:25672/';
 export const JWT_SECRET = process.env.JWT_SECRET || 'changeme-in-production';
 export const JWT_EXPIRES_IN = '8h';
+// Discord bot token for the live-stats presence line. Empty = presence
+// disabled (counts are logged on change but nothing connects to Discord).
+export const DISCORD_TOKEN = process.env.DISCORD_TOKEN || '';
 export const LOBBY_PLAYER_AUTH_URL = process.env.LOBBY_PLAYER_AUTH_URL || 'http://localhost:15171';
 export const LOBBY_MAP_API_URL = process.env.LOBBY_MAP_API_URL || 'http://localhost:15172';
 // Path to shared/assets directory (game binary assets).  Set via ASSETS_DIR env var in production.

--- a/services/admin-api/src/discord/presence.js
+++ b/services/admin-api/src/discord/presence.js
@@ -1,0 +1,233 @@
+// Minimal Discord gateway client: just enough to hold a connection and keep
+// the bot's presence ("Watching N players · M games") current. No discord.js —
+// presence is a gateway-only op, so a raw WebSocket is the entire requirement
+// and adds no dependency (Bun ships a native WebSocket).
+//
+// This lives inside admin-api because admin-api already consumes silencer.events
+// and computes the live counts (ws/index.js getLiveState). The presence updater
+// just formats those counts and pushes them to Discord on change — no extra
+// process, queue, or poll.
+
+const GATEWAY_URL = 'wss://gateway.discord.gg/?v=10&encoding=json';
+const ACTIVITY_WATCHING = 3;
+const PRESENCE_MIN_INTERVAL_MS = 5000; // Discord limits presence updates to ~5 / 20s.
+const MAX_BACKOFF_MS = 30000;
+
+// Gateway opcodes (https://discord.com/developers/docs/topics/gateway).
+const OP_DISPATCH = 0;
+const OP_HEARTBEAT = 1;
+const OP_IDENTIFY = 2;
+const OP_PRESENCE_UPDATE = 3;
+const OP_RECONNECT = 7;
+const OP_INVALID_SESSION = 9;
+const OP_HELLO = 10;
+const OP_HEARTBEAT_ACK = 11;
+
+export function formatPresence(players, games) {
+  const p = `${players} player${players === 1 ? '' : 's'}`;
+  const g = `${games} game${games === 1 ? '' : 's'}`;
+  return `${p} · ${g}`;
+}
+
+export class DiscordPresence {
+  constructor(token) {
+    this.token = token || '';
+    this.ws = null;
+    this.heartbeatTimer = null;
+    this.heartbeatStart = null;
+    this.lastSeq = null;
+    this.acked = true;
+    this.ready = false;
+    this.stopped = false;
+    this.backoffMs = 1000;
+
+    this.desiredName = null;
+    this.sentName = null;
+    this.lastSentAt = 0;
+    this.flushTimer = null;
+  }
+
+  start() {
+    if (!this.token) {
+      console.warn(
+        '[discord] no DISCORD_TOKEN — presence disabled (counts logged on change, not sent)',
+      );
+      return;
+    }
+    this.connect();
+  }
+
+  // Update presence from live counts. Coalesced + throttled before the gateway.
+  update(players, games) {
+    this.setActivity(formatPresence(players, games));
+  }
+
+  setActivity(name) {
+    this.desiredName = name;
+    if (!this.token) {
+      if (name !== this.sentName) {
+        console.log(`[discord] (disabled) presence → Watching ${name}`);
+        this.sentName = name;
+      }
+      return;
+    }
+    this.scheduleFlush();
+  }
+
+  stop() {
+    this.stopped = true;
+    this.clearTimers();
+    if (this.ws) this.ws.close(1000, 'shutdown');
+    this.ws = null;
+  }
+
+  connect() {
+    // Clear any stale timers up front: a fast RECONNECT/INVALID_SESSION can
+    // schedule connect() before onClose() fires, and a leftover heartbeat
+    // timer would otherwise beat on the fresh socket before HELLO arrives.
+    this.clearTimers();
+    this.ready = false;
+    this.acked = true;
+    const ws = new WebSocket(GATEWAY_URL);
+    this.ws = ws;
+    ws.addEventListener('message', (ev) => this.onMessage(String(ev.data)));
+    ws.addEventListener('close', (ev) => this.onClose(ev.code));
+    ws.addEventListener('error', () => console.error('[discord] websocket error'));
+  }
+
+  onMessage(raw) {
+    let msg;
+    try {
+      msg = JSON.parse(raw);
+    } catch {
+      return;
+    }
+    if (msg.s !== null && msg.s !== undefined) this.lastSeq = msg.s;
+
+    switch (msg.op) {
+      case OP_HELLO:
+        this.startHeartbeat(msg.d.heartbeat_interval);
+        this.identify();
+        break;
+      case OP_HEARTBEAT:
+        this.sendHeartbeat();
+        break;
+      case OP_HEARTBEAT_ACK:
+        this.acked = true;
+        break;
+      case OP_DISPATCH:
+        if (msg.t === 'READY') {
+          this.ready = true;
+          this.backoffMs = 1000;
+          console.log('[discord] gateway ready');
+          this.flush(true);
+        }
+        break;
+      case OP_RECONNECT:
+      case OP_INVALID_SESSION:
+        console.warn('[discord] gateway requested reconnect');
+        if (this.ws) this.ws.close(4000, 'reconnect');
+        break;
+    }
+  }
+
+  startHeartbeat(intervalMs) {
+    this.clearHeartbeat();
+    // Jitter the first beat per the gateway spec, then beat on a fixed interval.
+    this.heartbeatStart = setTimeout(() => {
+      this.sendHeartbeat();
+      this.heartbeatTimer = setInterval(() => {
+        if (!this.acked) {
+          // No ACK since the last beat → zombie connection. Drop and reconnect.
+          console.warn('[discord] heartbeat not acked — reconnecting');
+          if (this.ws) this.ws.close(4000, 'zombie');
+          return;
+        }
+        this.sendHeartbeat();
+      }, intervalMs);
+    }, intervalMs * Math.random());
+  }
+
+  sendHeartbeat() {
+    this.acked = false;
+    this.send({ op: OP_HEARTBEAT, d: this.lastSeq });
+  }
+
+  identify() {
+    this.send({
+      op: OP_IDENTIFY,
+      d: {
+        token: this.token,
+        intents: 0, // We subscribe to no events; we only push presence.
+        properties: { os: 'linux', browser: 'silencer-admin-api', device: 'silencer-admin-api' },
+        presence: this.presencePayload(this.desiredName),
+      },
+    });
+  }
+
+  scheduleFlush() {
+    if (this.flushTimer) return;
+    const wait = Math.max(0, PRESENCE_MIN_INTERVAL_MS - (Date.now() - this.lastSentAt));
+    this.flushTimer = setTimeout(() => {
+      this.flushTimer = null;
+      this.flush(false);
+    }, wait);
+  }
+
+  flush(force) {
+    if (!this.ready || !this.ws || this.ws.readyState !== WebSocket.OPEN) return;
+    if (this.desiredName === null) return;
+    if (!force && this.desiredName === this.sentName) return;
+    if (!force && Date.now() - this.lastSentAt < PRESENCE_MIN_INTERVAL_MS) {
+      this.scheduleFlush();
+      return;
+    }
+    this.send({ op: OP_PRESENCE_UPDATE, d: this.presencePayload(this.desiredName) });
+    this.sentName = this.desiredName;
+    this.lastSentAt = Date.now();
+  }
+
+  presencePayload(name) {
+    return {
+      since: null,
+      activities: name ? [{ name, type: ACTIVITY_WATCHING }] : [],
+      status: 'online',
+      afk: false,
+    };
+  }
+
+  send(payload) {
+    if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+      this.ws.send(JSON.stringify(payload));
+    }
+  }
+
+  onClose(code) {
+    this.clearTimers();
+    this.ws = null;
+    this.ready = false;
+    if (this.stopped) return;
+    console.warn(`[discord] disconnected (code ${code}) — reconnecting in ${this.backoffMs}ms`);
+    setTimeout(() => this.connect(), this.backoffMs);
+    this.backoffMs = Math.min(this.backoffMs * 2, MAX_BACKOFF_MS);
+  }
+
+  clearHeartbeat() {
+    if (this.heartbeatStart) {
+      clearTimeout(this.heartbeatStart);
+      this.heartbeatStart = null;
+    }
+    if (this.heartbeatTimer) {
+      clearInterval(this.heartbeatTimer);
+      this.heartbeatTimer = null;
+    }
+  }
+
+  clearTimers() {
+    this.clearHeartbeat();
+    if (this.flushTimer) {
+      clearTimeout(this.flushTimer);
+      this.flushTimer = null;
+    }
+  }
+}

--- a/services/admin-api/src/index.js
+++ b/services/admin-api/src/index.js
@@ -1,10 +1,11 @@
 import http from 'http';
 import express from 'express';
 import cors from 'cors';
-import { PORT } from './config.js';
+import { PORT, DISCORD_TOKEN } from './config.js';
 import { connectDB } from './db/connection.js';
-import { initWS } from './ws/index.js';
+import { initWS, setLiveStateListener, getLiveState } from './ws/index.js';
 import { startConsumer } from './amqp/consumer.js';
+import { DiscordPresence } from './discord/presence.js';
 import authRoutes    from './routes/auth.js';
 import playerRoutes  from './routes/players.js';
 import sessionRoutes from './routes/sessions.js';
@@ -64,6 +65,15 @@ async function start() {
   await seed();
   startBackupScheduler();
   initWS(server);
+
+  // Discord live-stats presence: reuse the AMQP-fed live counts (no extra
+  // consumer/process) and push them to the bot's presence line on change.
+  const presence = new DiscordPresence(DISCORD_TOKEN);
+  setLiveStateListener((players, games) => presence.update(players, games));
+  presence.start();
+  const live = getLiveState();
+  presence.update(live.onlinePlayers, live.activeGames);
+
   await startConsumer();
   server.listen(PORT, () => console.log(`[api] Silencer admin API on :${PORT}`));
 }

--- a/services/admin-api/src/ws/index.js
+++ b/services/admin-api/src/ws/index.js
@@ -6,6 +6,11 @@ let liveState = { onlinePlayers: 0, activeGames: 0, rabbitmqConnected: false };
 const onlinePlayers = new Map(); // accountId → { name, gameId, gameStatus }
 const activeGames    = new Map(); // gameId   → { name, mapName, hostname, port, state }
 
+// Optional observer notified whenever the player/game counts change — the
+// Discord presence updater hooks in here so it needs no consumer of its own.
+let liveStateListener = null;
+export function setLiveStateListener(fn) { liveStateListener = fn; }
+
 export function initWS(httpServer) {
   io = new Server(httpServer, {
     cors: { origin: '*', methods: ['GET', 'POST'] },
@@ -92,6 +97,17 @@ export function handleLobbyEvent(type, data) {
       liveState.activeGames = activeGames.size;
       broadcast('game.ended', data);
       break;
+  }
+
+  // Notify the presence updater on the events that move the counts.
+  if (
+    liveStateListener &&
+    (type === 'player.login' ||
+      type === 'player.logout' ||
+      type === 'game.created' ||
+      type === 'game.ended')
+  ) {
+    liveStateListener(liveState.onlinePlayers, liveState.activeGames);
   }
 }
 


### PR DESCRIPTION
Closes #261

Surfaces real-time in-game stats in the Silencer Discord as a bot **presence line** — `Watching N players · M games`. Presence only: no channels, embeds, or slash commands.

## Why it lives in admin-api
admin-api already consumes `silencer.events` and computes the live counts (`getLiveState()`). Rather than add a separate service/container (footprint matters on the small admin box), the Discord piece folds in as a ~230-line module — **no new process, container, AMQP queue, poll, or JWT.**

## What's here
- **`src/discord/presence.js`** — minimal raw Discord gateway WebSocket client. **No `discord.js`** (presence is a gateway-only op, so a bare WebSocket is the whole dependency surface — Bun ships a native one). Handles IDENTIFY/heartbeat + zombie detection, reconnect with backoff, and presence throttling (~1 update / 5s per Discord's limit).
- **`src/ws/index.js`** — `setLiveStateListener` hook, fired on the count-changing events (`player.login/logout`, `game.created/ended`).
- **`src/index.js` / `src/config.js`** — starts presence on boot from `DISCORD_TOKEN`. **Empty token ⇒ disabled** (counts logged on change, nothing connects) — so this is a no-op until the secret is set.
- **Deploy wiring** — optional `/silencer/admin/discord_token` SSM param (`iam.tf` read + `cloud-init` runtime fetch + `seed-ssm.sh`), `DISCORD_TOKEN` passthrough in `docker-compose.yml`. Runtime-fetched secret like `jwt_secret`; **no GitHub secret needed.**

## Footprint
Zero new containers/processes. One extra outbound WebSocket from the existing admin-api process.

## Test plan
- [x] Unit logic + count/format verified.
- [x] End-to-end against real admin-api + RabbitMQ: published synthetic `player.login` ×3 / `game.created` ×2 / `player.logout` / `game.ended` → presence settled at `Watching 2 players · 1 game`, matching `/api/stats`.
- [x] Live Discord gateway connection confirmed (`gateway ready`, presence visible in the server).
- [x] Adversarial review pass; fixed a reconnect timer race in `presence.js` and a `seed-ssm.sh` consistency nit.

## Deploy steps (post-merge)
1. `infra/scripts/seed-ssm.sh` (or `aws ssm put-parameter --name /silencer/admin/discord_token --type SecureString`) with a **freshly-reset** bot token.
2. `terraform apply` (adds the IAM read) or just `silencer-fetch-secrets` + `systemctl restart silencer-admin-api` to pick up the token.
3. Invite the bot: `https://discord.com/oauth2/authorize?client_id=<APP_ID>&scope=bot&permissions=0`