### PR TITLE
Fix lobby connect Login/Create button width

### DIFF
--- a/clients/silencer/src/client/ui/screens/lobby_connect/lobby_connect_screen.cpp
+++ b/clients/silencer/src/client/ui/screens/lobby_connect/lobby_connect_screen.cpp
@@ -12,6 +12,7 @@
 #include "world.h"
 
 #include "clay/clay.h"
+#include "clay_ui_payloads.h"
 #include "clay_ui_compositor.h"
 #include "runtime/UiInteractionRegistry.h"
 #include "primitives/text.h"
@@ -60,12 +61,14 @@ constexpr uint16_t kFormRowGap = 6;
 constexpr uint16_t kLabelW = 86;
 constexpr uint16_t kInputW = 183;
 constexpr uint16_t kInputInsetX = 7;
-constexpr uint16_t kLoginButtonW = 116;
-constexpr uint16_t kCancelButtonW = 68;
 constexpr uint16_t kButtonGap = 0;
-constexpr uint16_t kButtonRowX = (kPanelW - kLoginButtonW - kButtonGap - kCancelButtonW) / 2;
-constexpr uint16_t kButtonRowY = 246;
 constexpr uint16_t kButtonH = 21;
+constexpr uint16_t kButtonPatchX = 84;
+constexpr uint16_t kButtonPatchY = 246;
+constexpr uint16_t kButtonPatchW = 116;
+constexpr uint16_t kButtonPatchH = 24;
+constexpr uint16_t kButtonRowY = 249;
+constexpr uint16_t kButtonRowOffsetY = kButtonRowY - kButtonPatchY;
 constexpr int kButtonPaddingX = 10;
 constexpr int kMaxLogLines = 128;
 constexpr const char * kActionUsername = "lobby_connect.username";
@@ -73,6 +76,10 @@ constexpr const char * kActionPassword = "lobby_connect.password";
 constexpr const char * kActionLogin = "lobby_connect.login";
 constexpr const char * kActionCancel = "lobby_connect.cancel";
 ScrollTextBoxLine g_logSlab[kMaxLogLines];
+Uint8 g_buttonPatchPixels[kButtonPatchW * kButtonPatchH];
+silencer::clay_bridge::SurfacePayload g_buttonPatchPayload{};
+silencer::clay_bridge::ClayCustomData g_buttonPatchCustomData{};
+bool g_buttonPatchInitialized = false;
 
 Clay_String FromCStr(const char * s)
 {
@@ -141,6 +148,28 @@ int FillLogSlab(const std::vector<std::string> & lines)
 		count++;
 	}
 	return count;
+}
+
+void EnsureButtonPatch()
+{
+	if(g_buttonPatchInitialized) return;
+	// The original 52px login/cancel wells are baked into the panel sprite.
+	// Replace only that strip with the panel's stippled fill before drawing
+	// the measured-width buttons on top.
+	for(uint16_t y = 0; y < kButtonPatchH; ++y){
+		for(uint16_t x = 0; x < kButtonPatchW; ++x){
+			const uint16_t panelX = kButtonPatchX + x;
+			const uint16_t panelY = kButtonPatchY + y;
+			g_buttonPatchPixels[(y * kButtonPatchW) + x] =
+				((panelY & 1) == 0 || (panelX & 1) == 0) ? 210 : 146;
+		}
+	}
+	g_buttonPatchPayload.pixels = g_buttonPatchPixels;
+	g_buttonPatchPayload.width = kButtonPatchW;
+	g_buttonPatchPayload.height = kButtonPatchH;
+	g_buttonPatchCustomData.kind = silencer::clay_bridge::CustomKind::Surface;
+	g_buttonPatchCustomData.payload = &g_buttonPatchPayload;
+	g_buttonPatchInitialized = true;
 }
 } // namespace lobby_connect_screen_detail
 
@@ -305,6 +334,7 @@ void LobbyConnectScreen::BuildUi(ScreenContext & ctx, Surface & dst, float frame
 		scroll = static_cast<Uint16>(lineCount - visibleLines);
 	}
 	bool inactive = ctx.world.lobby.state == Lobby::AUTHSENT;
+	lobby_connect_screen_detail::EnsureButtonPatch();
 	const bool usernameFocused =
 		interactions.IsTextInputFocused(lobby_connect_screen_detail::LBY_INPUT_USERNAME);
 	const bool passwordFocused =
@@ -450,36 +480,52 @@ void LobbyConnectScreen::BuildUi(ScreenContext & ctx, Surface & dst, float frame
 			       .layout = {
 			           .sizing = {
 			               CLAY_SIZING_GROW(0),
-			               CLAY_SIZING_FIXED(lobby_connect_screen_detail::kButtonRowY -
+			               CLAY_SIZING_FIXED(lobby_connect_screen_detail::kButtonPatchY -
 			                                  lobby_connect_screen_detail::kFormRowY -
 			                                  (lobby_connect_screen_detail::kFormRowH * 2) -
 			                                  lobby_connect_screen_detail::kFormRowGap) },
 			       } }) {
 			}
 
-			CLAY({ .id = CLAY_ID("LobbyConnectButtons"),
+			CLAY({ .id = CLAY_ID("LobbyConnectButtonArea"),
 			       .layout = {
 			           .sizing = { CLAY_SIZING_GROW(0),
-			                       CLAY_SIZING_FIXED(lobby_connect_screen_detail::kButtonH) },
-			           .padding = { lobby_connect_screen_detail::kButtonRowX, 0, 0, 0 },
-			           .childGap = lobby_connect_screen_detail::kButtonGap,
-			           .childAlignment = { CLAY_ALIGN_X_LEFT, CLAY_ALIGN_Y_CENTER },
+			                       CLAY_SIZING_FIXED(lobby_connect_screen_detail::kButtonPatchH) },
+			           .padding = { lobby_connect_screen_detail::kButtonPatchX, 0, 0, 0 },
 			           .layoutDirection = CLAY_LEFT_TO_RIGHT,
 			       } }) {
-				lobby_connect_screen_detail::Button(CLAY_STRING("LobbyConnectLoginButton"), CLAY_STRING("Login/Create"),
-					lobby_connect_screen_detail::ButtonOpts{ .variant = lobby_connect_screen_detail::ButtonVariant::Chrome,
-					                                         .size = lobby_connect_screen_detail::ButtonSize::Auto,
-					                                         .minWidth = lobby_connect_screen_detail::kLoginButtonW,
-					                                         .maxWidth = lobby_connect_screen_detail::kLoginButtonW,
-					                                         .paddingX = lobby_connect_screen_detail::kButtonPaddingX },
-					lobby_connect_screen_detail::ButtonHandle{ nullptr, lobby_connect_screen_detail::kActionLogin, &interactions });
-				lobby_connect_screen_detail::Button(CLAY_STRING("LobbyConnectCancelButton"), CLAY_STRING("Cancel"),
-					lobby_connect_screen_detail::ButtonOpts{ .variant = lobby_connect_screen_detail::ButtonVariant::Chrome,
-					                                         .size = lobby_connect_screen_detail::ButtonSize::Auto,
-					                                         .minWidth = lobby_connect_screen_detail::kCancelButtonW,
-					                                         .maxWidth = lobby_connect_screen_detail::kCancelButtonW,
-					                                         .paddingX = lobby_connect_screen_detail::kButtonPaddingX },
-					lobby_connect_screen_detail::ButtonHandle{ nullptr, lobby_connect_screen_detail::kActionCancel, &interactions });
+				CLAY({ .id = CLAY_ID("LobbyConnectButtonPatch"),
+				       .layout = {
+				           .sizing = { CLAY_SIZING_FIXED(lobby_connect_screen_detail::kButtonPatchW),
+				                       CLAY_SIZING_FIXED(lobby_connect_screen_detail::kButtonPatchH) },
+				       },
+				       .custom = { .customData = &lobby_connect_screen_detail::g_buttonPatchCustomData } }) {}
+				CLAY({ .id = CLAY_ID("LobbyConnectButtons"),
+				       .layout = {
+				           .sizing = { CLAY_SIZING_GROW(0),
+				                       CLAY_SIZING_FIXED(lobby_connect_screen_detail::kButtonH) },
+				           .childGap = lobby_connect_screen_detail::kButtonGap,
+				           .childAlignment = { CLAY_ALIGN_X_CENTER, CLAY_ALIGN_Y_CENTER },
+				           .layoutDirection = CLAY_LEFT_TO_RIGHT,
+				       },
+				       .floating = {
+				           .offset = { 0.0f, static_cast<float>(lobby_connect_screen_detail::kButtonRowOffsetY) },
+				           .zIndex = 1,
+				           .attachPoints = { .element = CLAY_ATTACH_POINT_LEFT_TOP,
+				                             .parent = CLAY_ATTACH_POINT_LEFT_TOP },
+				           .attachTo = CLAY_ATTACH_TO_PARENT,
+				       } }) {
+					lobby_connect_screen_detail::Button(CLAY_STRING("LobbyConnectLoginButton"), CLAY_STRING("Login/Create"),
+						lobby_connect_screen_detail::ButtonOpts{ .variant = lobby_connect_screen_detail::ButtonVariant::Chrome,
+						                                         .size = lobby_connect_screen_detail::ButtonSize::Auto,
+						                                         .paddingX = lobby_connect_screen_detail::kButtonPaddingX },
+						lobby_connect_screen_detail::ButtonHandle{ nullptr, lobby_connect_screen_detail::kActionLogin, &interactions });
+					lobby_connect_screen_detail::Button(CLAY_STRING("LobbyConnectCancelButton"), CLAY_STRING("Cancel"),
+						lobby_connect_screen_detail::ButtonOpts{ .variant = lobby_connect_screen_detail::ButtonVariant::Chrome,
+						                                         .size = lobby_connect_screen_detail::ButtonSize::Auto,
+						                                         .paddingX = lobby_connect_screen_detail::kButtonPaddingX },
+						lobby_connect_screen_detail::ButtonHandle{ nullptr, lobby_connect_screen_detail::kActionCancel, &interactions });
+				}
 			}
 		}
 	}

--- a/clients/silencer/src/client/ui/screens/lobby_connect/lobby_connect_screen.cpp
+++ b/clients/silencer/src/client/ui/screens/lobby_connect/lobby_connect_screen.cpp
@@ -60,10 +60,13 @@ constexpr uint16_t kFormRowGap = 6;
 constexpr uint16_t kLabelW = 86;
 constexpr uint16_t kInputW = 183;
 constexpr uint16_t kInputInsetX = 7;
-constexpr uint16_t kButtonRowX = 86;
+constexpr uint16_t kLoginButtonW = 116;
+constexpr uint16_t kCancelButtonW = 68;
+constexpr uint16_t kButtonGap = 0;
+constexpr uint16_t kButtonRowX = (kPanelW - kLoginButtonW - kButtonGap - kCancelButtonW) / 2;
 constexpr uint16_t kButtonRowY = 246;
-constexpr uint16_t kButtonGap = 5;
 constexpr uint16_t kButtonH = 21;
+constexpr int kButtonPaddingX = 10;
 constexpr int kMaxLogLines = 128;
 constexpr const char * kActionUsername = "lobby_connect.username";
 constexpr const char * kActionPassword = "lobby_connect.password";
@@ -463,13 +466,19 @@ void LobbyConnectScreen::BuildUi(ScreenContext & ctx, Surface & dst, float frame
 			           .childAlignment = { CLAY_ALIGN_X_LEFT, CLAY_ALIGN_Y_CENTER },
 			           .layoutDirection = CLAY_LEFT_TO_RIGHT,
 			       } }) {
-				lobby_connect_screen_detail::Button(CLAY_STRING("LobbyConnectLoginButton"), CLAY_STRING("Login"),
-					lobby_connect_screen_detail::ButtonOpts{ .variant = lobby_connect_screen_detail::ButtonVariant::Text,
-					                                         .size = lobby_connect_screen_detail::ButtonSize::Compact },
+				lobby_connect_screen_detail::Button(CLAY_STRING("LobbyConnectLoginButton"), CLAY_STRING("Login/Create"),
+					lobby_connect_screen_detail::ButtonOpts{ .variant = lobby_connect_screen_detail::ButtonVariant::Chrome,
+					                                         .size = lobby_connect_screen_detail::ButtonSize::Auto,
+					                                         .minWidth = lobby_connect_screen_detail::kLoginButtonW,
+					                                         .maxWidth = lobby_connect_screen_detail::kLoginButtonW,
+					                                         .paddingX = lobby_connect_screen_detail::kButtonPaddingX },
 					lobby_connect_screen_detail::ButtonHandle{ nullptr, lobby_connect_screen_detail::kActionLogin, &interactions });
 				lobby_connect_screen_detail::Button(CLAY_STRING("LobbyConnectCancelButton"), CLAY_STRING("Cancel"),
-					lobby_connect_screen_detail::ButtonOpts{ .variant = lobby_connect_screen_detail::ButtonVariant::Text,
-					                                         .size = lobby_connect_screen_detail::ButtonSize::Compact },
+					lobby_connect_screen_detail::ButtonOpts{ .variant = lobby_connect_screen_detail::ButtonVariant::Chrome,
+					                                         .size = lobby_connect_screen_detail::ButtonSize::Auto,
+					                                         .minWidth = lobby_connect_screen_detail::kCancelButtonW,
+					                                         .maxWidth = lobby_connect_screen_detail::kCancelButtonW,
+					                                         .paddingX = lobby_connect_screen_detail::kButtonPaddingX },
 					lobby_connect_screen_detail::ButtonHandle{ nullptr, lobby_connect_screen_detail::kActionCancel, &interactions });
 			}
 		}

--- a/clients/silencer/src/net/controldispatch.cpp
+++ b/clients/silencer/src/net/controldispatch.cpp
@@ -457,7 +457,7 @@ void HandleImmediate(Game& game, ControlCommand& cmd) {
 		r["ui_height"] = game.CurrentUiInput().height;
 		r["ui_scale"] = game.CurrentUiInput().uiScale;
 		// Expose the lobby connection sub-state so test scripts can wait for
-		// AUTHENTICATING before dispatching a Login click — the LobbyConnect
+		// AUTHENTICATING before dispatching a Login/Create click — the LobbyConnect
 		// state machine progresses asynchronously through Connect/version
 		// check, and a click before AUTHENTICATING is silently consumed.
 		static const char * lobbyStateNames[] = {

--- a/clients/silencer/src/render/clay_ui_tests/button_test.cpp
+++ b/clients/silencer/src/render/clay_ui_tests/button_test.cpp
@@ -388,49 +388,78 @@ bool RunButtonCheck(::Game & game, ButtonCheckResult & out) {
 	            out.chromeAutoWidth,
 	            out.chromeAutoHeight);
 
-	int textCompactTextRows = 0;
-	bool textCompactTextOffsetMatches = false;
-	::Clay_SetPointerState(::Clay_Vector2{-1.0f, -1.0f}, false);
-	::Clay_UpdateScrollContainers(false, ::Clay_Vector2{0, 0}, 0.0f);
-	interactions.BeginFrame();
-	silencer::ui::primitives::TextBeginFrame();
-	silencer::ui::primitives::ButtonBeginFrame();
-	::Clay_BeginLayout();
-	CLAY({ .id = CLAY_ID("ButtonTextCompactProbeRoot"),
-	       .layout = {
-	           .sizing = { CLAY_SIZING_FIXED(W), CLAY_SIZING_FIXED(H) },
-	           .padding = { 40, 0, 40, 0 },
-	       } }) {
-		Button(CLAY_STRING("test.button.text_compact"),
-		       CLAY_STRING("Login"),
-		       ButtonOpts{ .variant = ButtonVariant::Text,
-		                   .size = ButtonSize::Compact },
-		       ButtonHandle{ nullptr, "test.button.text_compact", &interactions });
-	}
-	::Clay_RenderCommandArray textCompactCmds = ::Clay_EndLayout();
-	interactions.ResolveClayBoundsFromClay();
-	const auto * textCompactWidget = FindButton(interactions, "test.button.text_compact");
-	if(textCompactWidget){
-		out.textCompactWidth = textCompactWidget->w;
-		out.textCompactHeight = textCompactWidget->h;
-		for(int i = 0; i < textCompactCmds.length; i++){
-			::Clay_RenderCommand * c = &textCompactCmds.internalArray[i];
-			if(c->commandType != CLAY_RENDER_COMMAND_TYPE_TEXT) continue;
-			textCompactTextRows++;
-			out.textCompactTextXOffset =
-				static_cast<int>(c->boundingBox.x) - textCompactWidget->x;
-			out.textCompactTextWidth = static_cast<int>(c->boundingBox.width);
-			out.textCompactTextYOffset =
-				static_cast<int>(c->boundingBox.y) - textCompactWidget->y;
+	auto probeTextCompactButton = [&](const char * id,
+	                                  Clay_String label,
+	                                  int& buttonW,
+	                                  int& buttonH,
+	                                  int& textXOffset,
+	                                  int& textWidth,
+	                                  int& textYOffset,
+	                                  bool& textOffsetMatches) {
+		int textRows = 0;
+		::Clay_SetPointerState(::Clay_Vector2{-1.0f, -1.0f}, false);
+		::Clay_UpdateScrollContainers(false, ::Clay_Vector2{0, 0}, 0.0f);
+		interactions.BeginFrame();
+		silencer::ui::primitives::TextBeginFrame();
+		silencer::ui::primitives::ButtonBeginFrame();
+		::Clay_BeginLayout();
+		CLAY({ .id = CLAY_ID("ButtonTextCompactProbeRoot"),
+		       .layout = {
+		           .sizing = { CLAY_SIZING_FIXED(W), CLAY_SIZING_FIXED(H) },
+		           .padding = { 40, 0, 40, 0 },
+		       } }) {
+			Button(Clay_String{ false, static_cast<int32_t>(std::strlen(id)), id },
+			       label,
+			       ButtonOpts{ .variant = ButtonVariant::Text,
+			                   .size = ButtonSize::Compact },
+			       ButtonHandle{ nullptr, id, &interactions });
 		}
-		const int textRightGap = textCompactWidget->w -
-		                         out.textCompactTextXOffset -
-		                         out.textCompactTextWidth;
-		textCompactTextOffsetMatches =
-			textCompactTextRows == 1 &&
-			std::abs(out.textCompactTextXOffset - textRightGap) <= 1 &&
-			out.textCompactTextYOffset == 8;
-	}
+		::Clay_RenderCommandArray cmds = ::Clay_EndLayout();
+		interactions.ResolveClayBoundsFromClay();
+		const auto * widget = FindButton(interactions, id);
+		if(widget){
+			buttonW = widget->w;
+			buttonH = widget->h;
+			for(int i = 0; i < cmds.length; i++){
+				::Clay_RenderCommand * c = &cmds.internalArray[i];
+				if(c->commandType != CLAY_RENDER_COMMAND_TYPE_TEXT) continue;
+				textRows++;
+				textXOffset = static_cast<int>(c->boundingBox.x) - widget->x;
+				textWidth = static_cast<int>(c->boundingBox.width);
+				textYOffset = static_cast<int>(c->boundingBox.y) - widget->y;
+			}
+			const int textRightGap = widget->w - textXOffset - textWidth;
+			textOffsetMatches =
+				textRows == 1 &&
+				std::abs(textXOffset - textRightGap) <= 1 &&
+				textYOffset == 8;
+		}
+	};
+
+	bool textCompactTextOffsetMatches = false;
+	probeTextCompactButton("test.button.text_compact",
+	                       CLAY_STRING("Login"),
+	                       out.textCompactWidth,
+	                       out.textCompactHeight,
+	                       out.textCompactTextXOffset,
+	                       out.textCompactTextWidth,
+	                       out.textCompactTextYOffset,
+	                       textCompactTextOffsetMatches);
+
+	int textCompactLongWidth = 0;
+	int textCompactLongHeight = 0;
+	int textCompactLongXOffset = 0;
+	int textCompactLongTextWidth = 0;
+	int textCompactLongYOffset = 0;
+	bool textCompactLongTextOffsetMatches = false;
+	probeTextCompactButton("test.button.text_compact_long",
+	                       CLAY_STRING("Login/Create"),
+	                       textCompactLongWidth,
+	                       textCompactLongHeight,
+	                       textCompactLongXOffset,
+	                       textCompactLongTextWidth,
+	                       textCompactLongYOffset,
+	                       textCompactLongTextOffsetMatches);
 
 	int ovalMdLongWidth = 0;
 	int ovalMdLongHeight = 0;
@@ -520,7 +549,10 @@ bool RunButtonCheck(::Game & game, ButtonCheckResult & out) {
 	}
 	if(out.textCompactWidth != 52 ||
 	   out.textCompactHeight != 21 ||
-	   !textCompactTextOffsetMatches){
+	   textCompactLongWidth != 84 ||
+	   textCompactLongHeight != 21 ||
+	   !textCompactTextOffsetMatches ||
+	   !textCompactLongTextOffsetMatches){
 		return false;
 	}
 	return true;

--- a/clients/silencer/src/ui/primitives/button.cpp
+++ b/clients/silencer/src/ui/primitives/button.cpp
@@ -66,6 +66,7 @@ struct ResolvedButton {
 	Uint16 spriteIndex = 0;
 	int fixedWidth = 0;
 	int fixedHeight = 0;
+	int minWidth = 0;
 	int minHeight = 0;
 	TextSize textSize = TextSize::BodySm;
 	TextMetrics textMetrics = ResolveTextMetrics(TextSize::BodySm);
@@ -175,8 +176,8 @@ ResolvedButton ResolveButton(const ButtonOpts& opts) {
 			out.defaultPaddingY = 0;
 			out.measureTextInk = true;
 			if(opts.size == ButtonSize::Compact){
-				out.fixedWidth = 52;
 				out.fixedHeight = 21;
+				out.minWidth = 52;
 				// B52x21 text-only buttons draw at y + 8 in the legacy
 				// renderer. Clay centers the measured 11px bank-133 line box,
 				// so bias the content area until the emitted text bbox lands
@@ -407,9 +408,10 @@ AllocCustomData(silencer::clay_bridge::CustomKind kind, void * payload) {
 	return c;
 }
 
-int ClampAutoWidth(int width, const ButtonOpts& opts) {
+int ClampAutoWidth(int width, const ButtonOpts& opts, int defaultMinWidth) {
 	if(opts.maxWidth > 0 && width > opts.maxWidth) width = opts.maxWidth;
-	if(opts.minWidth > 0 && width < opts.minWidth) width = opts.minWidth;
+	int minWidth = std::max(defaultMinWidth, opts.minWidth);
+	if(minWidth > 0 && width < minWidth) width = minWidth;
 	return width < 1 ? 1 : width;
 }
 
@@ -491,7 +493,7 @@ void Button(Clay_String id,
 	                                    : contentWidth + paddingX * 2;
 	int height = resolved.fixedHeight > 0 ? resolved.fixedHeight
 	                                      : contentHeight + paddingY * 2;
-	if(resolved.fixedWidth == 0) width = ClampAutoWidth(width, opts);
+	if(resolved.fixedWidth == 0) width = ClampAutoWidth(width, opts, resolved.minWidth);
 	if(resolved.minHeight > 0 && height < resolved.minHeight) height = resolved.minHeight;
 	if(height < 1) height = 1;
 

--- a/tests/cli-agent/e2e/17_character_create_focus.sh
+++ b/tests/cli-agent/e2e/17_character_create_focus.sh
@@ -95,12 +95,12 @@ cli --port "$CTRL_PORT" wait_for_state --state MAINMENU --timeout-ms 15000 >/dev
 wait_for_widget "Connect To Lobby"
 cli --port "$CTRL_PORT" click --label "Connect To Lobby" >/dev/null
 cli --port "$CTRL_PORT" wait_for_state --state LOBBYCONNECT --timeout-ms 5000 >/dev/null
-wait_for_widget "Login"
+wait_for_widget "Login/Create"
 for ch in a l i c e; do cli --port "$CTRL_PORT" key --key "$ch" >/dev/null; done
 cli --port "$CTRL_PORT" key --key tab >/dev/null
 for ch in s e c r e t; do cli --port "$CTRL_PORT" key --key "$ch" >/dev/null; done
 wait_for_lobby_state AUTHENTICATING
-cli --port "$CTRL_PORT" click --label "Login" >/dev/null
+cli --port "$CTRL_PORT" click --label "Login/Create" >/dev/null
 
 # Walk the create flow up to the SELECT AGENCY stage (5 oval agency rows).
 cli --port "$CTRL_PORT" wait_for_state --state CREATECHARACTER --timeout-ms 15000 >/dev/null

--- a/tests/cli-agent/e2e/30_lobby_login.sh
+++ b/tests/cli-agent/e2e/30_lobby_login.sh
@@ -99,7 +99,7 @@ cli --port "$CTRL_PORT" wait_for_state --state MAINMENU --timeout-ms 15000
 wait_for_widget "Connect To Lobby"
 cli --port "$CTRL_PORT" click --label "Connect To Lobby" >/dev/null
 cli --port "$CTRL_PORT" wait_for_state --state LOBBYCONNECT --timeout-ms 5000
-wait_for_widget "Login"
+wait_for_widget "Login/Create"
 
 # Type the credentials through the same key path real text input uses
 # (auto-creates the account on first login).
@@ -111,7 +111,7 @@ for ch in s e c r e t; do
   cli --port "$CTRL_PORT" key --key "$ch" >/dev/null
 done
 
-# The Login button only dispatches credentials when the lobby state machine
+# The Login/Create button only dispatches credentials when the lobby state machine
 # has advanced through Connect → version-check → AUTHENTICATING; a click
 # before that is silently consumed. The `state` op exposes lobby_state for
 # exactly this kind of synchronization.
@@ -128,7 +128,7 @@ wait_for_lobby_state() {
 }
 wait_for_lobby_state AUTHENTICATING
 
-cli --port "$CTRL_PORT" click --label "Login" >/dev/null
+cli --port "$CTRL_PORT" click --label "Login/Create" >/dev/null
 
 # Auth + lobby state pump can take a couple of seconds in CI. Fresh
 # accounts now land in character creation before the lobby.

--- a/tests/cli-agent/e2e/40_lobby_basic.sh
+++ b/tests/cli-agent/e2e/40_lobby_basic.sh
@@ -106,12 +106,12 @@ cli --port "$CTRL_PORT" wait_for_state --state MAINMENU --timeout-ms 15000
 wait_for_widget "Connect To Lobby"
 cli --port "$CTRL_PORT" click --label "Connect To Lobby" >/dev/null
 cli --port "$CTRL_PORT" wait_for_state --state LOBBYCONNECT --timeout-ms 5000
-wait_for_widget "Login"
+wait_for_widget "Login/Create"
 
 cli --port "$CTRL_PORT" set_text --uid 1 --text "claybob" >/dev/null
 cli --port "$CTRL_PORT" set_text --uid 2 --text "secret" >/dev/null
 wait_for_lobby_state AUTHENTICATING
-cli --port "$CTRL_PORT" click --label "Login" >/dev/null
+cli --port "$CTRL_PORT" click --label "Login/Create" >/dev/null
 create_initial_character "ClayBob"
 wait_for_widget "Create Game"
 

--- a/tests/cli-agent/e2e/53_lobby_create_options_scroll.sh
+++ b/tests/cli-agent/e2e/53_lobby_create_options_scroll.sh
@@ -104,11 +104,11 @@ cli --port "$CTRL_PORT" wait_for_state --state MAINMENU --timeout-ms 15000 >/dev
 wait_for_widget "Connect To Lobby"
 cli --port "$CTRL_PORT" click --label "Connect To Lobby" >/dev/null
 cli --port "$CTRL_PORT" wait_for_state --state LOBBYCONNECT --timeout-ms 5000 >/dev/null
-wait_for_widget "Login"
+wait_for_widget "Login/Create"
 cli --port "$CTRL_PORT" set_text --uid 1 --text "scrolltest" >/dev/null
 cli --port "$CTRL_PORT" set_text --uid 2 --text "secret" >/dev/null
 wait_for_lobby_state AUTHENTICATING
-cli --port "$CTRL_PORT" click --label "Login" >/dev/null
+cli --port "$CTRL_PORT" click --label "Login/Create" >/dev/null
 create_initial_character "Scrolltest"
 wait_for_widget "Create Game"
 cli --port "$CTRL_PORT" click --label "Create Game" >/dev/null


### PR DESCRIPTION
Closes #263\n\n## Summary\n- rename the lobby connect action to "Login/Create"\n- draw real auto-width chrome buttons on the connect screen instead of relying on the baked 52px wells\n- let compact text buttons grow to measured label width while preserving the 52px minimum\n- update CLI E2E selectors for the new label\n\n## Verification\n- clients/silencer/build.sh\n- clay_button_check via silencer control API\n- rendered LOBBYCONNECT screenshot: Login/Create bounds 116x21, Cancel bounds 68x21\n- SILENCER_BIN=clients/silencer/build/Silencer.app/Contents/MacOS/Silencer tests/cli-agent/e2e/30_lobby_login.sh