### PR TITLE
Release v00058

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to Silencer are documented here.
 
 ## [Unreleased]
 
+## [v00058] — 2026-05-31
+
+### Game client
+
+#### Lobby connect and UI (#264)
+
+- The lobby connect primary action now reads `Login/Create`, with auto-width chrome buttons and a patched legacy backdrop so the wider label no longer clips or overlaps `Cancel`.
+
+#### Physics materials and footsteps (#229)
+
+- Added data-driven physics materials for platforms, including friction/speed multipliers and material-driven footstep cue resolution.
+- Player and NPC footsteps now use frame-event tags with per-material actor overrides, and map data can persist platform material assignments.
+
+### Admin web and API
+
+- Added the Physics Materials editor and API route for editing per-material movement and sound cue data (#229).
+- Actor footstep override controls now use searchable cue pickers, and expired admin sessions redirect back to login instead of leaving pages in a broken offline state (#229).
+- Admin API can drive a Discord live-stats presence from live player/game counts when `DISCORD_TOKEN` is configured (#262).
+
+### Lobby and compatibility
+
+- Added the WON.net replacement DLL client plus lobby compatibility endpoints for legacy login, account creation, and profile requests (#260).
+- Fixed the WON DLL Windows socket include path so its x86 Windows build uses the expected Winsock declarations.
+
+### Docs
+
+- Added extracted original beta reference files and game-reference docs for the WON compatibility work (#260).
+
 ## [v00057] — 2026-05-25
 
 ### Game client

--- a/clients/silencer/CMakeLists.txt
+++ b/clients/silencer/CMakeLists.txt
@@ -220,7 +220,7 @@ endif()
 
 set(SILENCER_LOBBY_HOST "lobby.arsiamons.com" CACHE STRING "Lobby host the client connects to at startup")
 set(SILENCER_LOBBY_PORT "517" CACHE STRING "Lobby TCP port")
-set(SILENCER_VERSION "00057" CACHE STRING "Client version string sent to the lobby during MSG_VERSION; overridden by release.yml from git tag")
+set(SILENCER_VERSION "00058" CACHE STRING "Client version string sent to the lobby during MSG_VERSION; overridden by release.yml from git tag")
 set(SILENCER_MAP_API_URL "https://admin.arsiamons.com" CACHE STRING "Base URL for the community map HTTP API (used when fetching a missing map before falling back to P2P)")
 set(SILENCER_ADMIN_API_URL "https://admin.arsiamons.com" CACHE STRING "Base URL for the admin API (actordefs sync, etc.)")
 target_compile_definitions(${SILENCER_TARGET} PRIVATE

--- a/clients/silencer/src/game/init/game_init.cpp
+++ b/clients/silencer/src/game/init/game_init.cpp
@@ -17,7 +17,7 @@ using namespace GameState;
 #define SILENCER_LOBBY_PORT 517
 #endif
 #ifndef SILENCER_VERSION
-#define SILENCER_VERSION "00057"
+#define SILENCER_VERSION "00058"
 #endif
 #ifndef SILENCER_MAP_API_URL
 #define SILENCER_MAP_API_URL "http://127.0.0.1:8080"

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -55,7 +55,7 @@ services:
       - "-public-addr"
       - "${PUBLIC_ADDR:-127.0.0.1}"
       - "-version"
-      - "00057"
+      - "00058"
       - "-db"
       - "/data/lobby.json"
       - "-game-binary"

--- a/infra/scripts/build-mac-local.sh
+++ b/infra/scripts/build-mac-local.sh
@@ -5,7 +5,7 @@
 #   ./infra/scripts/build-mac-local.sh               # lobby at 127.0.0.1:15170
 #   LOBBY_HOST=1.2.3.4 ./infra/scripts/build-mac-local.sh
 #   LOBBY_PORT=517      ./infra/scripts/build-mac-local.sh
-#   VERSION=00057       ./infra/scripts/build-mac-local.sh  # must match lobby -version flag
+#   VERSION=00058       ./infra/scripts/build-mac-local.sh  # must match lobby -version flag
 #
 # The lobby host, port, and version are baked into the binary at compile time.
 # Run `docker compose -f infra/docker-compose.yml up -d` first so the lobby is ready before launching.
@@ -15,7 +15,7 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 LOBBY_HOST="${LOBBY_HOST:-127.0.0.1}"
 LOBBY_PORT="${LOBBY_PORT:-15170}"
-VERSION="${VERSION:-00057}"
+VERSION="${VERSION:-00058}"
 BUILD_DIR="$REPO_ROOT/build"
 
 echo "==> Installing/updating dependencies via Homebrew"

--- a/services/lobby/Dockerfile
+++ b/services/lobby/Dockerfile
@@ -54,7 +54,7 @@ RUN apt-get -o Acquire::Check-Valid-Until=false \
         ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-ARG SILENCER_VERSION=00057
+ARG SILENCER_VERSION=00058
 
 WORKDIR /src
 COPY clients/silencer/CMakeLists.txt clients/silencer/

--- a/services/lobby/protocol_version_test.go
+++ b/services/lobby/protocol_version_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 )
 
-const currentProtocolVersion = "00057"
+const currentProtocolVersion = "00058"
 const currentWireFingerprint = "c16c0106632b187bff8887ecf00fdef413aa9a46434b90a7caaf8d96d8da80eb"
 
 var wireFingerprintPaths = []string{


### PR DESCRIPTION
Closes #265

## Summary
- add the v00058 changelog entry for changes since v00057
- bump Silencer client/lobby default version values to 00058
- update local mac build and protocol-version guard defaults

## Verification
- go test ./...
- clients/silencer/build.sh