### PR TITLE
feat(silencer): Black Rose poison for guards and civilians

### DIFF
--- a/clients/silencer/src/actors/npc/civilian.cpp
+++ b/clients/silencer/src/actors/npc/civilian.cpp
@@ -15,6 +15,12 @@ Civilian::Civilian() : Object(ObjectTypes::CIVILIAN){
 	state_i = 0;
 	const EnemyDef* c = GASLoader::Get().GetEnemyDef("civilian");
 	speed = c ? c->speed : 4;
+	// Health pool only matters for poison DoT — direct hits kill via the state machine.
+	maxhealth = c ? c->health : 10;
+	health = maxhealth;
+	poisonedby = 0;
+	poisonedamount = 0;
+	poisoned_i = 0;
 	res_bank = 121;
 	res_index = 0;
 	suitcolor = defaultsuitcolor;
@@ -118,11 +124,15 @@ void Civilian::Serialize(bool write, Serializer & data, Serializer * old){
 	data.Serialize(write, state, old);
 	data.Serialize(write, state_i, old);
 	data.Serialize(write, tractteamid, old);
+	data.Serialize(write, poisonedby, old);
+	data.Serialize(write, poisonedamount, old);
+	data.Serialize(write, poisoned_i, old);
 }
 
 void Civilian::Tick(World & world){
 	Hittable::Tick(*this, world);
 	Bipedal::Tick(*this, world);
+	TickPoison(world);
 	switch(state){
 		case NEW:{
 			if(FindCurrentPlatform(*this, world)){
@@ -305,6 +315,10 @@ void Civilian::Tick(World & world){
 				state = WALKING;
 				state_warp = _cd ? _cd->warpTeleportTick : GASLoader::Get().player.warpTeleportTick;
 				state_i = -1;
+				health = maxhealth;
+				poisonedby = 0;
+				poisonedamount = 0;
+				poisoned_i = 0;
 				break;
 			  }
 			}
@@ -345,6 +359,67 @@ void Civilian::HandleHit(World & world, Uint8 x, Uint8 y, Object & projectile){
 		}
 	}
 	state_i = 0;
+}
+
+bool Civilian::Poison(World & world, Uint16 playerid, Uint8 amount){
+	if(state == DYINGFORWARD || state == DYINGBACKWARD || state == DYINGEXPLODE || state == DEAD){
+		return false;
+	}
+	int maxpois = GASLoader::Get().player.maxPoisoned;
+	if(poisonedamount >= maxpois){
+		return false;
+	}
+	poisonedby = playerid;
+	poisonedamount += amount;
+	if(poisonedamount > maxpois){
+		poisonedamount = maxpois;
+	}
+	state_hit = 1 + (3 * 32);
+	hitx = 50;
+	hity = 50;
+	return true;
+}
+
+void Civilian::TickPoison(World & world){
+	if(!poisonedby || state == DYINGFORWARD || state == DYINGBACKWARD || state == DYINGEXPLODE || state == DEAD){
+		return;
+	}
+	const EnemyDef* cd = GASLoader::Get().GetEnemyDef("civilian");
+	int cycle = cd ? cd->poisonTickCycle : 24;
+	int damage = cd ? cd->poisonDamagePerTick : 1;
+	if(poisoned_i % (cycle / poisonedamount) == 0){
+		health = health > damage ? health - damage : 0;
+		if(destructible && world.IsAuthority()){
+			GameEvent ev;
+			ev.actor_id = id;
+			if(health == 0){
+				ev.type = EventType::ACTOR_KILLED;
+			}else{
+				ev.type = EventType::ACTOR_DAMAGED;
+				ev.value = damage;
+			}
+			world.triggerGraph.Bus().Emit(ev);
+		}
+		if(health == 0){
+			// Silent collapse in place — no knockback, no threat reaction.
+			state = DYINGFORWARD;
+			state_i = 0;
+			xv = 0;
+			Object * owner = world.GetObjectFromId(poisonedby);
+			if(owner && owner->type == ObjectTypes::PLAYER){
+				Peer * peer = static_cast<Player *>(owner)->GetPeer(world);
+				if(peer){
+					peer->stats.civilianskilled++;
+				}
+			}
+			poisonedby = 0;
+			poisonedamount = 0;
+		}
+	}
+	poisoned_i++;
+	if(poisoned_i >= cycle){
+		poisoned_i = 0;
+	}
 }
 
 bool Civilian::Look(World & world){

--- a/clients/silencer/src/actors/npc/civilian.h
+++ b/clients/silencer/src/actors/npc/civilian.h
@@ -12,6 +12,7 @@ public:
 	void Serialize(bool write, Serializer & data, Serializer * old = 0);
 	void Tick(World & world);
 	void HandleHit(World & world, Uint8 x, Uint8 y, Object & projectile);
+	bool Poison(World & world, Uint16 playerid, Uint8 amount);
 	bool AddTract(Uint16 teamid);
 	Uint8 suitcolor;
 	Uint8 speed;
@@ -21,10 +22,14 @@ public:
 private:
 	bool Look(World & world);
 	bool CheckTractVictim(World & world);
+	void TickPoison(World & world);
 	void InitBT();
 	enum {NEW, STANDING, WALKING, RUNNING, DYINGFORWARD, DYINGBACKWARD, DYINGEXPLODE, DEAD};
 	Uint8 state;
 	Uint8 state_i;
+	Uint16 poisonedby;
+	Uint8 poisonedamount;
+	Uint8 poisoned_i;
 	const BehaviorTree* bt_;
 	BTContext btctx_;
 };

--- a/clients/silencer/src/actors/npc/guard.cpp
+++ b/clients/silencer/src/actors/npc/guard.cpp
@@ -42,6 +42,9 @@ Guard::Guard() : Object(ObjectTypes::GUARD){
 	{ const EnemyDef* _gd = GASLoader::Get().GetEnemyDef("guard-blaster");
 	  snapshotinterval = _gd ? _gd->snapshotInterval : 48; }
 	respawnseconds   = g ? g->respawnSeconds : 30;
+	poisonedby = 0;
+	poisonedamount = 0;
+	poisoned_i = 0;
 	patrol = false;
 	lastspoke = 0;
 	lastshot = 0;
@@ -584,6 +587,9 @@ void Guard::Serialize(bool write, Serializer & data, Serializer * old){
 	data.Serialize(write, patrol, old);
 	data.Serialize(write, originalx, old);
 	data.Serialize(write, originaly, old);
+	data.Serialize(write, poisonedby, old);
+	data.Serialize(write, poisonedamount, old);
+	data.Serialize(write, poisoned_i, old);
 }
 
 void Guard::Tick(World & world){
@@ -599,6 +605,7 @@ void Guard::Tick(World & world){
 	// 197:0-8 ladder shoot down
 	Hittable::Tick(*this, world);
 	Bipedal::Tick(*this, world);
+	TickPoison(world);
 
 	if(!bt_) InitBT();
 
@@ -1132,6 +1139,9 @@ void Guard::Tick(World & world){
 				  state_warp = _gd ? _gd->warpTeleportTick : GASLoader::Get().player.warpTeleportTick; }
 				health = maxhealth;
 				shield = maxshield;
+				poisonedby = 0;
+				poisonedamount = 0;
+				poisoned_i = 0;
 				break;
 			}
 			if(world.tickcount % GASLoader::Get().gameengine.ticksPerSecond != 0){
@@ -1209,24 +1219,7 @@ void Guard::HandleHit(World & world, Uint8 x, Uint8 y, Object & projectile){
 	if(health == 0 && state != DYING && state != DYINGEXPLODE && state != DEAD){
 		state = DYING;
 		state_i = 0;
-		if(weapon != 0){
-			PickUp * pickup = (PickUp *)world.CreateObject(ObjectTypes::PICKUP);
-			if(pickup){
-				if(weapon == 2){
-					pickup->type = PickUp::ROCKETAMMO;
-					{ const EnemyDef* _grd = GASLoader::Get().GetEnemyDef("guard-rocket"); pickup->quantity = _grd ? _grd->ammoDropQuantity : 3; }
-				}else
-				if(weapon == 1){
-					pickup->type = PickUp::LASERAMMO;
-					{ const EnemyDef* _gld = GASLoader::Get().GetEnemyDef("guard-laser"); pickup->quantity = _gld ? _gld->ammoDropQuantity : 5; }
-				}
-				pickup->x = Guard::x;
-				pickup->y = Guard::y - 1;
-				{ const EnemyDef* _gb = GASLoader::Get().GetEnemyDef("guard-blaster");
-				  pickup->xv = (world.Random() % (2 * (_gb ? _gb->deathDropXVRange : 4) + 1)) - (_gb ? _gb->deathDropXVRange : 4);
-				  pickup->yv = -(_gb ? _gb->deathDropYV : 15); }
-			}
-		}
+		DropAmmoPickup(world);
 		Object * owner = world.GetObjectFromId(projectile.ownerid);
 		if(owner && owner->type == ObjectTypes::PLAYER){
 			Player * player = static_cast<Player *>(owner);
@@ -1250,6 +1243,90 @@ void Guard::HandleHit(World & world, Uint8 x, Uint8 y, Object & projectile){
 			state = DYINGEXPLODE;
 			world.Explode(*this, 8, xpcnt);
 		}
+	}
+}
+
+bool Guard::Poison(World & world, Uint16 playerid, Uint8 amount){
+	if(state == DYING || state == DYINGEXPLODE || state == DEAD){
+		return false;
+	}
+	int maxpois = GASLoader::Get().player.maxPoisoned;
+	if(poisonedamount >= maxpois){
+		return false;
+	}
+	poisonedby = playerid;
+	poisonedamount += amount;
+	if(poisonedamount > maxpois){
+		poisonedamount = maxpois;
+	}
+	state_hit = 1 + (3 * 32);
+	hitx = 50;
+	hity = 50;
+	return true;
+}
+
+void Guard::TickPoison(World & world){
+	if(!poisonedby || state == DYING || state == DYINGEXPLODE || state == DEAD){
+		return;
+	}
+	const EnemyDef* gd = GASLoader::Get().GetEnemyDef(ActorDefName(weapon));
+	int cycle = gd ? gd->poisonTickCycle : 24;
+	int damage = gd ? gd->poisonDamagePerTick : 1;
+	if(poisoned_i % (cycle / poisonedamount) == 0){
+		health = health > damage ? health - damage : 0;
+		if(destructible && world.IsAuthority()){
+			GameEvent ev;
+			ev.actor_id = id;
+			if(health == 0){
+				ev.type = EventType::ACTOR_KILLED;
+			}else{
+				ev.type = EventType::ACTOR_DAMAGED;
+				ev.value = damage;
+			}
+			world.triggerGraph.Bus().Emit(ev);
+		}
+		if(health == 0){
+			// Silent death: no HIT state and no chasing update, so the guard
+			// never alerts — fits the Black Rose stealth kill.
+			state = DYING;
+			state_i = 0;
+			DropAmmoPickup(world);
+			Object * owner = world.GetObjectFromId(poisonedby);
+			if(owner && owner->type == ObjectTypes::PLAYER){
+				Peer * peer = static_cast<Player *>(owner)->GetPeer(world);
+				if(peer){
+					peer->stats.guardskilled++;
+				}
+			}
+			poisonedby = 0;
+			poisonedamount = 0;
+		}
+	}
+	poisoned_i++;
+	if(poisoned_i >= cycle){
+		poisoned_i = 0;
+	}
+}
+
+void Guard::DropAmmoPickup(World & world){
+	if(weapon == 0){
+		return;
+	}
+	PickUp * pickup = (PickUp *)world.CreateObject(ObjectTypes::PICKUP);
+	if(pickup){
+		if(weapon == 2){
+			pickup->type = PickUp::ROCKETAMMO;
+			{ const EnemyDef* _grd = GASLoader::Get().GetEnemyDef("guard-rocket"); pickup->quantity = _grd ? _grd->ammoDropQuantity : 3; }
+		}else
+		if(weapon == 1){
+			pickup->type = PickUp::LASERAMMO;
+			{ const EnemyDef* _gld = GASLoader::Get().GetEnemyDef("guard-laser"); pickup->quantity = _gld ? _gld->ammoDropQuantity : 5; }
+		}
+		pickup->x = Guard::x;
+		pickup->y = Guard::y - 1;
+		{ const EnemyDef* _gb = GASLoader::Get().GetEnemyDef("guard-blaster");
+		  pickup->xv = (world.Random() % (2 * (_gb ? _gb->deathDropXVRange : 4) + 1)) - (_gb ? _gb->deathDropXVRange : 4);
+		  pickup->yv = -(_gb ? _gb->deathDropYV : 15); }
 	}
 }
 

--- a/clients/silencer/src/actors/npc/guard.h
+++ b/clients/silencer/src/actors/npc/guard.h
@@ -12,6 +12,7 @@ public:
 	void Serialize(bool write, Serializer & data, Serializer * old = 0);
 	void Tick(World & world);
 	void HandleHit(World & world, Uint8 x, Uint8 y, Object & projectile);
+	bool Poison(World & world, Uint16 playerid, Uint8 amount);
 	Uint8 weapon;
 	bool patrol;
 	Sint16 originalx;
@@ -22,6 +23,8 @@ public:
 private:
 	Object * Look(World & world, Uint8 direction);
 	void Fire(World & world, Uint8 direction);
+	void TickPoison(World & world);
+	void DropAmmoPickup(World & world);
 	bool CooledDown(World & world);
 	bool ShouldTarget(Object & object, World & world);
 	void InitBT();
@@ -35,6 +38,9 @@ private:
 	Uint16 maxhealth;
 	Uint16 maxshield;
 	Uint8 respawnseconds;
+	Uint16 poisonedby;
+	Uint8 poisonedamount;
+	Uint8 poisoned_i;
 	Uint32 lastspoke;
 	Uint32 lastshot;
 	const BehaviorTree* bt_;

--- a/clients/silencer/src/actors/player/player.cpp
+++ b/clients/silencer/src/actors/player/player.cpp
@@ -4,6 +4,7 @@
 #include "frameevents.h"
 #include "plume.h"
 #include "civilian.h"
+#include "guard.h"
 #include "EventBus.h"
 #include "robot.h"
 #include "terminal.h"
@@ -788,27 +789,39 @@ void Player::Tick(World & world){
 					if(world.IsAuthority()){
 						std::vector<Uint8> types;
 						types.push_back(ObjectTypes::PLAYER);
+						types.push_back(ObjectTypes::GUARD);
+						types.push_back(ObjectTypes::CIVILIAN);
 						int x1, y1, x2, y2;
 						GetAABB(world.resources, &x1, &y1, &x2, &y2);
 						std::vector<Object *> objects = world.TestAABB(x1, y1, x2, y2, types, id);
 						bool found = false;
+						const ItemDef* poisondef = GASLoader::Get().GetItemDef("poison");
+						int dose = poisondef ? poisondef->poisonDose : 3;
 						for(std::vector<Object *>::iterator it = objects.begin(); it != objects.end(); it++){
 							found = true;
-							Player * player = static_cast<Player *>(*it);
-							const ItemDef* poisondef = GASLoader::Get().GetItemDef("poison");
-							int dose = poisondef ? poisondef->poisonDose : 3;
-							if(player->Poison(world, id, dose)){
+							bool poisoned = false;
+							switch((*it)->type){
+								case ObjectTypes::PLAYER:{
+									Player * player = static_cast<Player *>(*it);
+									poisoned = player->Poison(world, id, dose);
+									if(!poisoned && player->poisonedamount == GASLoader::Get().player.maxPoisoned){
+										world.ShowStatus("Victim maximally poisoned", 208, true, GetPeer(world));
+									}
+								}break;
+								case ObjectTypes::GUARD:{
+									poisoned = static_cast<Guard *>(*it)->Poison(world, id, dose);
+								}break;
+								case ObjectTypes::CIVILIAN:{
+									poisoned = static_cast<Civilian *>(*it)->Poison(world, id, dose);
+								}break;
+							}
+							if(poisoned){
 								Peer * peer = GetPeer(world);
 								if(peer){
 									peer->stats.poisons++;
 								}
 								RemoveInventoryItem(INV_POISON);
 								break;
-							}else{
-								int maxpois = GASLoader::Get().player.maxPoisoned;
-								if(player->poisonedamount == maxpois){
-									world.ShowStatus("Victim maximally poisoned", 208, true, GetPeer(world));
-								}
 							}
 						}
 						if(!found){

--- a/clients/silencer/src/gas/gasloader.cpp
+++ b/clients/silencer/src/gas/gasloader.cpp
@@ -427,6 +427,8 @@ static void LoadEnemies(const std::string& dir, std::vector<EnemyDef>& out,
             e.deathDropXVRange      = ej.value("deathDropXVRange",      e.deathDropXVRange);
             e.meleeHitDuration      = ej.value("meleeHitDuration",      e.meleeHitDuration);
             e.ammoDropQuantity      = ej.value("ammoDropQuantity",      e.ammoDropQuantity);
+            e.poisonTickCycle       = ej.value("poisonTickCycle",       e.poisonTickCycle);
+            e.poisonDamagePerTick   = ej.value("poisonDamagePerTick",   e.poisonDamagePerTick);
             e.lookDefaultMinX       = ej.value("lookDefaultMinX",       e.lookDefaultMinX);
             e.lookDefaultMaxX       = ej.value("lookDefaultMaxX",       e.lookDefaultMaxX);
             e.lookDefaultY          = ej.value("lookDefaultY",          e.lookDefaultY);

--- a/clients/silencer/src/gas/gasloader.h
+++ b/clients/silencer/src/gas/gasloader.h
@@ -435,6 +435,9 @@ struct EnemyDef {
     int warpTeleportTick  = 12;   // state_warp value at which warp completes
     int runDurationTicks  = 150;  // civilian: ticks in RUNNING state before reverting
     int deadRespawnTicks  = 100;  // civilian: ticks in DEAD state before respawning
+    // ---- Poison (Black Rose) -----------------------------------------------------
+    int poisonTickCycle     = 24; // ticks per poison damage cycle (more doses = faster ticks)
+    int poisonDamagePerTick = 1;  // health lost per poison damage event
     int activationTicks   = 7200; // magistrate: ticks after level start before becoming active (default 2 min @ 60fps)
     std::map<int, GuardLookBox> lookBoxes; // guard: vision AABB per direction index
     std::string behaviorTree = "";         // override BT asset ID (empty = use class default)

--- a/shared/assets/gas/enemies.json
+++ b/shared/assets/gas/enemies.json
@@ -12,6 +12,8 @@
       "chaseRangeStop": 80,
       "chaseRangeMax": 90,
       "respawnSeconds": 30,
+      "poisonTickCycle": 24,
+      "poisonDamagePerTick": 1,
       "ladderCooldown": 120,
       "meleeCycleTicks": 32,
       "meleeDelayTicks": 10,
@@ -104,6 +106,8 @@
       "chaseRangeStop": 80,
       "chaseRangeMax": 90,
       "respawnSeconds": 30,
+      "poisonTickCycle": 24,
+      "poisonDamagePerTick": 1,
       "ladderCooldown": 120,
       "meleeCycleTicks": 32,
       "meleeDelayTicks": 10,
@@ -195,6 +199,8 @@
       "chaseRangeStop": 80,
       "chaseRangeMax": 90,
       "respawnSeconds": 30,
+      "poisonTickCycle": 24,
+      "poisonDamagePerTick": 1,
       "ladderCooldown": 120,
       "meleeCycleTicks": 32,
       "meleeDelayTicks": 10,
@@ -311,7 +317,7 @@
     },
     {
       "id": "civilian",
-      "health": 0,
+      "health": 10,
       "shield": 0,
       "speed": 4,
       "speedAlt": 5,
@@ -326,7 +332,9 @@
       "warpTeleportTick": 12,
       "runDurationTicks": 150,
       "deadRespawnTicks": 100,
-      "_note": "Civilian health is not set in constructor \u2014 Object base default applies."
+      "poisonTickCycle": 24,
+      "poisonDamagePerTick": 1,
+      "_note": "Civilian health is only drained by poison \u2014 any direct hit still kills instantly via the state machine."
     },
     {
       "id": "magistrate",

--- a/shared/gas-validation/schemas.ts
+++ b/shared/gas-validation/schemas.ts
@@ -173,6 +173,8 @@ const enemyDef = {
     lookDirMaxX:          int('Robot directional look AABB: far X edge', 200),
     lookDirY1:            int('Robot directional look AABB: top Y offset', -10),
     lookDirY2:            int('Robot directional look AABB: bottom Y offset', -100),
+    poisonTickCycle:      int('Ticks per poison damage cycle (more doses = faster ticks)', 24),
+    poisonDamagePerTick:  int('Health lost per poison damage event', 1),
     _note:               { type: 'string', description: 'Optional dev note (ignored by game)' },
   },
 };


### PR DESCRIPTION
Closes #135

## Summary

Black Rose's poison item (`agencyRestriction 4`) now works on guards and civilians, not just enemy players. Poisoned NPCs take damage over time and die silently — no alarm, no knockback — fitting the agency's stealth identity.

## Changes

- **Guard**: `poisonedby`/`poisonamount`/`poisoned_i` fields (serialized), `Poison()` application, DoT ticker mirroring the player poison cadence, reset on respawn. Poison death drops ammo (extracted `DropAmmoPickup`, shared with `HandleHit`) and credits the poisoner's `guardskilled` stat.
- **Civilian**: same poison fields + ticker; poison death collapses in place (`DYINGFORWARD`, no knockback) and credits `civilianskilled`. Civilians receive a real health pool from GAS (only drained by poison — direct hits still one-shot via the state machine).
- **Player**: `INV_POISON` proximity use now also targets guards and civilians.
- **GAS**: `EnemyDef` gains `poisonTickCycle` + `poisonDamagePerTick` in gasloader, `schemas.ts`, and `enemies.json` seed data.
- **Triggers**: `ACTOR_DAMAGED` / `ACTOR_KILLED` fire on poison ticks and deaths for destructible NPCs, matching the Hittable pipeline.

## Verification

- Build: ✅ `clients/silencer/build.sh` → clean compile, no warnings added
- Types: ✅ `shared/gas-validation` `tsc --noEmit` passes

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>