### PR TITLE
fix(silencer): null platform pointer crash in Bipedal::FollowGround

### DIFF
--- a/clients/silencer/src/actors/core/bipedal.cpp
+++ b/clients/silencer/src/actors/core/bipedal.cpp
@@ -41,8 +41,13 @@ bool Bipedal::FollowGround(Object & object, World & world, Sint8 velocity){
 	if(velocity == 0 || currentplatformid == 0){
 		return true;
 	}
+	auto it = world.map.platformids.find(currentplatformid);
+	if(it == world.map.platformids.end() || !it->second){
+		currentplatformid = 0;
+		return false;
+	}
 	object.x += velocity;
-	Platform * currentplatform = world.map.platformids[currentplatformid];
+	Platform * currentplatform = it->second;
 	Platform * oldplatform = currentplatform;
 	object.y = currentplatform->XtoY(object.x);
 	if(object.x > currentplatform->x2){
@@ -87,7 +92,9 @@ bool Bipedal::FindCurrentPlatform(Object & object, World & world){
 
 int Bipedal::DistanceToEnd(Object & object, World & world){
 	if(currentplatformid){
-		Platform * platform = world.map.platformids[currentplatformid];
+		auto it = world.map.platformids.find(currentplatformid);
+		Platform * platform = (it != world.map.platformids.end()) ? it->second : nullptr;
+		if(!platform){ return -1; }
 		if(object.mirrored){
 			Platform & leftmost = world.map.GetLeftmostPlatform(*platform);
 			return object.x - leftmost.x1;


### PR DESCRIPTION
Closes #276

## Root cause
`world.map.platformids[currentplatformid]` (std::map::operator[]) inserts a null entry for unknown keys and returns nullptr, which was immediately dereferenced in `XtoY`.

## Fix
- `FollowGround`: use `find()`, guard null → reset `currentplatformid` and return false (player falls)
- `DistanceToEnd`: same, returns -1 on missing platform

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>