### PR TITLE
Release v00060

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to Silencer are documented here.
 
 ## [Unreleased]
 
+## [v00060] — 2026-06-17
+
+### Game client
+
+- Migrated the entire client UI from the Clay layout engine to the cppx
+  retained-mode UI engine (#267). Every screen was rebuilt on the new engine:
+  the main menu, lobby connect, the lobby, character create, options, and the
+  in-game HUD.
+
 ## [v00059] — 2026-06-11
 
 ### Game client


### PR DESCRIPTION
Closes #279

Cut release v00060.

Changelog entry for the cppx UI engine migration (#267): migrated the entire client UI from the Clay layout engine to the cppx retained-mode UI engine. Every screen was rebuilt on the new engine — main menu, lobby connect, the lobby, character create, options, and the in-game HUD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)