### PR TITLE
fix(lobby): re-baseline wire-protocol fingerprint

### DIFF
--- a/services/lobby/protocol_version_test.go
+++ b/services/lobby/protocol_version_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 const currentProtocolVersion = "00058"
-const currentWireFingerprint = "c16c0106632b187bff8887ecf00fdef413aa9a46434b90a7caaf8d96d8da80eb"
+const currentWireFingerprint = "a7360f375ff6416867ded7cdb463b8288fa97fa976ad2f8e70b1f0d4b7eb233d"
 
 var wireFingerprintPaths = []string{
 	"shared/lobby-protocol/protocol.md",


### PR DESCRIPTION
Closes #281

Fixes red `main`: `TestWireProtocolFingerprint` has been failing since #267 (cppx UI migration).

#267 made one incidental edit to a guarded file, `clients/silencer/src/net/lobby.cpp`:

```
-void Lobby::SendMessage(const char msg[256], Uint8 size){
+void Lobby::SendMessage(const char msg[0xFF], Uint8 size){
```

A function-parameter array extent is ignored by the compiler — both declare `const char*` — and the function body is unchanged, so the wire protocol is byte-for-byte identical. This only tripped the file-hash guard.

Fix: re-baseline `currentWireFingerprint` only. No `currentProtocolVersion` bump — `TestProtocolVersionDefaults` still passes at 00058, and there is no actual protocol change requiring a client-compat version.

Verified locally: `go test ./... -count=1` in `services/lobby/` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)