### PR TITLE
Release v00061

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to Silencer are documented here.
 
 ## [Unreleased]
 
+## [v00061] — 2026-06-17
+
+### Lobby
+
+- Re-baselined the wire-protocol fingerprint guard (#282). An incidental no-op
+  edit to `lobby.cpp` in v00060 tripped `TestWireProtocolFingerprint`; the wire
+  protocol is unchanged, so only the stored fingerprint was updated.
+
 ## [v00060] — 2026-06-17
 
 ### Game client


### PR DESCRIPTION
Closes #283

Cut release v00061. Captures the one commit on `main` past the v00060 tag: the lobby wire-protocol fingerprint re-baseline (#282).

No user-facing or runtime change — an internal CI/test-guard fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)