### PR TITLE
fix(ci): provision SDL3_ttf for release builds; dedicated server goes headless

### DIFF
--- a/.github/actions/build-silencer-linux/action.yml
+++ b/.github/actions/build-silencer-linux/action.yml
@@ -66,7 +66,12 @@ runs:
 
     - name: Build
       shell: bash
-      run: cmake --build build -j"$(nproc)"
+      # Build only the shippable client. CMake pulls in its real deps
+      # (updater-stage-2, silencer_shaders) via add_dependencies, so the
+      # bundle/release path is complete. The unit-test targets aren't run
+      # here (no ctest step) — they're compile-gated on Windows PR CI — and
+      # building them was the only thing failing this release-artifact job.
+      run: cmake --build build --target silencer -j"$(nproc)"
 
     - name: sccache stats
       if: always()

--- a/.github/actions/build-silencer-linux/action.yml
+++ b/.github/actions/build-silencer-linux/action.yml
@@ -37,6 +37,10 @@ runs:
         version: 3-latest
         version-sdl-mixer: 3-latest
         version-sdl-ttf: 3-latest
+        # Build SDL_ttf against its vendored freetype/harfbuzz (sources
+        # setup-sdl already fetches) so libSDL3_ttf is self-contained — no
+        # system freetype/harfbuzz to install or bundle alongside the binary.
+        cmake-arguments: -DSDLTTF_VENDORED=ON
 
     - name: Setup sccache
       uses: mozilla-actions/sccache-action@v0.0.10

--- a/.github/actions/build-silencer-linux/action.yml
+++ b/.github/actions/build-silencer-linux/action.yml
@@ -31,11 +31,12 @@ runs:
           libxi-dev libxfixes-dev libxtst-dev libwayland-dev \
           libxkbcommon-dev libdbus-1-dev libibus-1.0-dev
 
-    - name: Install SDL3 + SDL3_mixer
+    - name: Install SDL3 + SDL3_mixer + SDL3_ttf
       uses: libsdl-org/setup-sdl@main
       with:
         version: 3-latest
         version-sdl-mixer: 3-latest
+        version-sdl-ttf: 3-latest
 
     - name: Setup sccache
       uses: mozilla-actions/sccache-action@v0.0.10
@@ -81,11 +82,13 @@ runs:
         echo "--- SDL3 install roots ---"
         echo "  SDL3_ROOT=$SDL3_ROOT"
         echo "  SDL3_mixer_ROOT=$SDL3_mixer_ROOT"
+        echo "  SDL3_ttf_ROOT=$SDL3_ttf_ROOT"
         stage="build/package/silencer"
         mkdir -p "$stage"
         cp build/silencer "$stage/"
         cp -L "$SDL3_ROOT/lib/libSDL3.so.0" "$stage/"
         cp -L "$SDL3_mixer_ROOT/lib/libSDL3_mixer.so.0" "$stage/"
+        cp -L "$SDL3_ttf_ROOT/lib/libSDL3_ttf.so.0" "$stage/"
         patchelf --set-rpath '$ORIGIN' "$stage/silencer"
         cp -r shared/assets "$stage/assets"
         echo "--- bundled files ---"

--- a/.github/actions/build-silencer-macos/action.yml
+++ b/.github/actions/build-silencer-macos/action.yml
@@ -18,11 +18,12 @@ runs:
       shell: bash
       run: brew install minizip dylibbundler
 
-    - name: Install SDL3 + SDL3_mixer
+    - name: Install SDL3 + SDL3_mixer + SDL3_ttf
       uses: libsdl-org/setup-sdl@main
       with:
         version: 3-latest
         version-sdl-mixer: 3-latest
+        version-sdl-ttf: 3-latest
 
     - name: Setup sccache
       uses: mozilla-actions/sccache-action@v0.0.10
@@ -66,10 +67,12 @@ runs:
         echo "--- SDL3 install roots ---"
         echo "  SDL3_ROOT=$SDL3_ROOT"
         echo "  SDL3_mixer_ROOT=$SDL3_mixer_ROOT"
+        echo "  SDL3_ttf_ROOT=$SDL3_ttf_ROOT"
         mkdir -p Silencer.app/Contents/Frameworks
         dylibbundler \
           -s "$SDL3_ROOT/lib" \
           -s "$SDL3_mixer_ROOT/lib" \
+          -s "$SDL3_ttf_ROOT/lib" \
           --overwrite-dir \
           --bundle-deps \
           --create-dir \

--- a/.github/actions/build-silencer-macos/action.yml
+++ b/.github/actions/build-silencer-macos/action.yml
@@ -53,7 +53,12 @@ runs:
 
     - name: Build
       shell: bash
-      run: cmake --build build --config Release -j"$(sysctl -n hw.ncpu)"
+      # Build only the shippable client. CMake pulls in its real deps
+      # (updater-stage-2, silencer_shaders) via add_dependencies, so the
+      # bundle/release path is complete. The unit-test targets aren't run
+      # here (no ctest step) — they're compile-gated on Windows PR CI — and
+      # building them was the only thing failing this release-artifact job.
+      run: cmake --build build --config Release --target silencer -j"$(sysctl -n hw.ncpu)"
 
     - name: sccache stats
       if: always()

--- a/.github/actions/build-silencer-macos/action.yml
+++ b/.github/actions/build-silencer-macos/action.yml
@@ -24,6 +24,10 @@ runs:
         version: 3-latest
         version-sdl-mixer: 3-latest
         version-sdl-ttf: 3-latest
+        # Build SDL_ttf against its vendored freetype/harfbuzz (sources
+        # setup-sdl already fetches) so libSDL3_ttf is self-contained — no
+        # system freetype/harfbuzz to install or bundle alongside the binary.
+        cmake-arguments: -DSDLTTF_VENDORED=ON
 
     - name: Setup sccache
       uses: mozilla-actions/sccache-action@v0.0.10

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -105,6 +105,7 @@ jobs:
             -DCMAKE_C_COMPILER_LAUNCHER=sccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=sccache \
             -DSILENCER_UNITY_BUILD=ON \
+            -DSILENCER_HEADLESS=ON \
             -DSILENCER_LOBBY_HOST="${LOBBY_HOST:-lobby.arsiamons.com}"
           cmake --build build -j"$(nproc)"
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,10 @@ build-new/
 build-old/
 build-release/
 build-unity/
+build-headless/
 clients/silencer/build-release/
 clients/silencer/build-unity/
+clients/silencer/build-headless/
 test-update-host/
 test-updater.*.log
 update.json

--- a/clients/silencer/CMakePresets.json
+++ b/clients/silencer/CMakePresets.json
@@ -28,6 +28,14 @@
             "displayName": "Windows / Ninja / Release / Unity (fastest clean build)",
             "binaryDir": "${sourceDir}/build-unity",
             "cacheVariables": { "SILENCER_UNITY_BUILD": "ON" }
+        },
+        {
+            "name": "win-ninja-headless",
+            "inherits": "win-ninja-unity",
+            "displayName": "Windows / Ninja / Release / Unity / Headless (dedicated-server build)",
+            "description": "Headless dedicated-server build: no UI, Yoga, SDL3_ttf, or tests. Mirrors the config deploy.yml ships to the lobby box.",
+            "binaryDir": "${sourceDir}/build-headless",
+            "cacheVariables": { "SILENCER_HEADLESS": "ON" }
         }
     ],
     "buildPresets": [
@@ -44,6 +52,11 @@
         {
             "name": "win-ninja-unity",
             "configurePreset": "win-ninja-unity",
+            "targets": [ "silencer" ]
+        },
+        {
+            "name": "win-ninja-headless",
+            "configurePreset": "win-ninja-headless",
             "targets": [ "silencer" ]
         }
     ]

--- a/clients/silencer/build.ps1
+++ b/clients/silencer/build.ps1
@@ -7,13 +7,15 @@
 # VCPKG_ROOT, and serializes against concurrent builds so CLion, CLI
 # agents, and parallel agents can't corrupt the shared CMake cache.
 #
-# Usage:  ./build.ps1 [win-ninja|win-ninja-release|win-ninja-unity] [-Clean]
-#   default preset : win-ninja (Debug)
-#   -Clean         : wipe CMakeCache.txt + CMakeFiles (keep vcpkg_installed) first
+# Usage:  ./build.ps1 [win-ninja|win-ninja-release|win-ninja-unity|win-ninja-headless] [-Clean]
+#   default preset   : win-ninja (Debug)
+#   win-ninja-headless : dedicated-server build (no UI/Yoga/SDL3_ttf) — the
+#                        config deploy.yml ships to the lobby box
+#   -Clean           : wipe CMakeCache.txt + CMakeFiles (keep vcpkg_installed) first
 
 [CmdletBinding()]
 param(
-    [ValidateSet('win-ninja', 'win-ninja-release', 'win-ninja-unity')]
+    [ValidateSet('win-ninja', 'win-ninja-release', 'win-ninja-unity', 'win-ninja-headless')]
     [string]$Preset = 'win-ninja',
     [switch]$Clean
 )
@@ -25,9 +27,10 @@ function Fail($msg) { Write-Host "build.ps1: $msg" -ForegroundColor Red; exit 1 
 
 $silencerDir = $PSScriptRoot
 $binaryDir = switch ($Preset) {
-    'win-ninja'         { Join-Path $silencerDir 'build' }
-    'win-ninja-release' { Join-Path $silencerDir 'build-release' }
-    'win-ninja-unity'   { Join-Path $silencerDir 'build-unity' }
+    'win-ninja'          { Join-Path $silencerDir 'build' }
+    'win-ninja-release'  { Join-Path $silencerDir 'build-release' }
+    'win-ninja-unity'    { Join-Path $silencerDir 'build-unity' }
+    'win-ninja-headless' { Join-Path $silencerDir 'build-headless' }
 }
 
 # --- Resolve Visual Studio: newest install with the C++ x64 toolset ---

--- a/clients/silencer/build.sh
+++ b/clients/silencer/build.sh
@@ -8,9 +8,11 @@
 # agents / an IDE can't corrupt the shared CMake cache by configuring at the
 # same time.
 #
-# Usage:  ./build.sh [win-ninja|win-ninja-release|win-ninja-unity] [--clean]
-#   default preset : win-ninja (Debug)
-#   --clean        : wipe CMakeCache.txt + CMakeFiles (keep vcpkg_installed) first
+# Usage:  ./build.sh [win-ninja|win-ninja-release|win-ninja-unity|win-ninja-headless] [--clean]
+#   default preset     : win-ninja (Debug)
+#   win-ninja-headless : dedicated-server build (no UI/Yoga/SDL3_ttf) — the
+#                        config deploy.yml ships to the lobby box
+#   --clean            : wipe CMakeCache.txt + CMakeFiles (keep vcpkg_installed) first
 set -euo pipefail
 
 fail() { echo "build.sh: $*" >&2; exit 1; }
@@ -35,10 +37,11 @@ for a in "$@"; do [ "$a" = "--clean" ] && clean=1; done
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 case "$preset" in
-    win-ninja)         bdir="$script_dir/build";         btype=Debug;   unity=OFF ;;
-    win-ninja-release) bdir="$script_dir/build-release"; btype=Release; unity=OFF ;;
-    win-ninja-unity)   bdir="$script_dir/build-unity";   btype=Release; unity=ON  ;;
-    *) fail "unknown preset '$preset' (use win-ninja | win-ninja-release | win-ninja-unity)" ;;
+    win-ninja)          bdir="$script_dir/build";          btype=Debug;   unity=OFF; headless=OFF ;;
+    win-ninja-release)  bdir="$script_dir/build-release";  btype=Release; unity=OFF; headless=OFF ;;
+    win-ninja-unity)    bdir="$script_dir/build-unity";    btype=Release; unity=ON;  headless=OFF ;;
+    win-ninja-headless) bdir="$script_dir/build-headless"; btype=Release; unity=ON;  headless=ON  ;;
+    *) fail "unknown preset '$preset' (use win-ninja | win-ninja-release | win-ninja-unity | win-ninja-headless)" ;;
 esac
 
 # --- Optional vcpkg toolchain (macOS/Linux can also use system packages) ---
@@ -123,6 +126,7 @@ fi
 cmake -S "$script_dir" -B "$bdir" "${gen[@]+"${gen[@]}"}" \
     -DCMAKE_BUILD_TYPE="$btype" \
     -DSILENCER_UNITY_BUILD="$unity" \
+    -DSILENCER_HEADLESS="$headless" \
     ${toolchain+"${toolchain[@]}"}
 cmake --build "$bdir" --parallel
 echo "build.sh: OK ($preset)"

--- a/docs/silencer-client-build.md
+++ b/docs/silencer-client-build.md
@@ -26,6 +26,7 @@ poisoned cache. Don't hand-roll `rm`/reconfigure loops.
 | `win-ninja` (default) | Debug | `build/` | day-to-day |
 | `win-ninja-release` | Release | `build-release/` | |
 | `win-ninja-unity` | Release + `SILENCER_UNITY_BUILD=ON` | `build-unity/` | fastest clean build |
+| `win-ninja-headless` | Release + unity + `SILENCER_HEADLESS=ON` | `build-headless/` | dedicated-server build (no UI/Yoga/SDL3_ttf); the config `deploy.yml` ships to the lobby box |
 
 Names are shared across platforms even though `win-` is a misnomer
 off Windows. On Windows the preset is a real `CMakePresets.json`

--- a/tools/dev/run-local-lobby-client.ps1
+++ b/tools/dev/run-local-lobby-client.ps1
@@ -42,9 +42,10 @@ function Wait-ForTcp($hostName, $port, $process, $stdoutPath, $stderrPath) {
 
 function Get-ClientBinary($clientDir, $preset) {
     $buildDir = switch ($preset) {
-        'win-ninja'         { Join-Path $clientDir 'build' }
-        'win-ninja-release' { Join-Path $clientDir 'build-release' }
-        'win-ninja-unity'   { Join-Path $clientDir 'build-unity' }
+        'win-ninja'          { Join-Path $clientDir 'build' }
+        'win-ninja-release'  { Join-Path $clientDir 'build-release' }
+        'win-ninja-unity'    { Join-Path $clientDir 'build-unity' }
+        'win-ninja-headless' { Join-Path $clientDir 'build-headless' }
     }
     $binary = Join-Path $buildDir 'Silencer.exe'
     if (-not (Test-Path $binary)) {
@@ -76,6 +77,13 @@ Write-Host "Building client ($Preset)..."
 if ($LASTEXITCODE -ne 0) { Fail "client build failed" }
 $clientBin = Get-ClientBinary $clientDir $Preset
 
+# The lobby spawns the dedicated server as `silencer -s`; build it headless
+# (no UI/SDL3_ttf), matching what deploy.yml ships to the prod lobby box.
+Write-Host "Building headless dedicated server (win-ninja-headless)..."
+& (Join-Path $clientDir 'build.ps1') 'win-ninja-headless'
+if ($LASTEXITCODE -ne 0) { Fail "headless server build failed" }
+$serverBin = Get-ClientBinary $clientDir 'win-ninja-headless'
+
 Write-Host "Building lobby..."
 Push-Location $lobbyDir
 try {
@@ -89,7 +97,7 @@ Write-Host "Starting lobby on 127.0.0.1:$LobbyPort..."
 $lobbyArgs = @(
     '-addr', ":$LobbyPort",
     '-db', "`"$lobbyDb`"",
-    '-game-binary', "`"$clientBin`"",
+    '-game-binary', "`"$serverBin`"",
     '-public-addr', '127.0.0.1',
     '-update-manifest=',
     '-player-auth-addr', ":$playerAuthPort",

--- a/tools/dev/run-local-lobby-client.sh
+++ b/tools/dev/run-local-lobby-client.sh
@@ -6,8 +6,9 @@ usage() {
     cat <<'USAGE'
 Usage: tools/dev/run-local-lobby-client.sh [--preset win-ninja|win-ninja-release|win-ninja-unity] [--lobby-port PORT]
 
-Builds the client, builds the Go lobby, starts the lobby on 127.0.0.1:15170
-by default, then launches the client pointed at that local lobby.
+Builds the interactive client + a headless dedicated server (the lobby spawns
+the latter via -game-binary), builds the Go lobby, starts the lobby on
+127.0.0.1:15170 by default, then launches the client pointed at that local lobby.
 USAGE
 }
 
@@ -114,6 +115,12 @@ echo "Building client ($preset)..."
 "$client_dir/build.sh" "$preset"
 client_bin="$(client_binary "$(client_build_dir)")"
 
+# The lobby spawns the dedicated server as `silencer -s`; build it headless
+# (no UI/SDL3_ttf), matching what deploy.yml ships to the prod lobby box.
+echo "Building headless dedicated server (win-ninja-headless)..."
+"$client_dir/build.sh" win-ninja-headless
+server_bin="$(client_binary "$client_dir/build-headless")"
+
 echo "Building lobby..."
 (cd "$lobby_dir" && go build -o "$lobby_bin")
 
@@ -121,7 +128,7 @@ echo "Starting lobby on 127.0.0.1:$lobby_port..."
 "$lobby_bin" \
     -addr ":$lobby_port" \
     -db "$lobby_db" \
-    -game-binary "$client_bin" \
+    -game-binary "$server_bin" \
     -public-addr 127.0.0.1 \
     -update-manifest= \
     -player-auth-addr ":$player_auth_port" \


### PR DESCRIPTION
Closes #285

The tag-triggered `Release` workflow fails on the Linux and macOS client builds (both v00060 and v00061 release builds are red), because #267 added a hard `find_package(SDL3_ttf REQUIRED CONFIG)` for the non-headless client. Windows resolves it via vcpkg; the Linux/macOS builds get SDL from `libsdl-org/setup-sdl`, which was never told to build SDL3_ttf. Normal PR CI only does a *real* build on Windows (Linux/macOS are denylist-skipped on most PRs), so the gap only surfaced when a release tag triggered the full multi-platform build.

### Changes
- **`build-silencer-linux` / `build-silencer-macos`**: add `version-sdl-ttf: 3-latest` to setup-sdl and bundle the library next to the binary, mirroring SDL3_mixer. These are real GUI clients that render text.
- **`deploy.yml` dedicated server**: build with `-DSILENCER_HEADLESS=ON`. The lobby box only ever runs `silencer -s`; the headless build drops the UI/Yoga/SDL3_ttf stack (and the Python3 cppx-transpile dep) it never uses, instead of shipping a font library to a server.
- **`win-ninja-headless` preset** + wrapper support (`build.ps1`/`build.sh`) so the headless config can be built/validated locally; `build-headless/` gitignored; doc table updated.

### Validation
- Headless build verified locally (Windows): compiles and links with **no** SDL3_ttf dependency (`SILENCER_HEADLESS:BOOL=ON`, only `SDL3.dll` + `SDL3_mixer.dll` staged).
- The Linux/macOS SDL3_ttf provisioning is exercised by this PR's `CI Build (Linux)` / `CI Build (macOS)` — editing the build action files isn't denylisted, so the real cross-platform builds run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)