### PR TITLE
fix(client): name UiInputFrame type in reset for GCC portability

### DIFF
--- a/clients/silencer/src/game/ui/game_ui_pipeline.cpp
+++ b/clients/silencer/src/game/ui/game_ui_pipeline.cpp
@@ -2110,7 +2110,9 @@ void GameUiPipeline::RenderCppxClientUiFrame(Surface &surface) {
     }
 
     // One-frame edges are consumed; reset for the next accumulation window.
-    uiInput_ = {};
+    // Name the type rather than `= {}`: GCC won't form the assignment RHS
+    // from a bare braced-init-list here (clang/MSVC accept it).
+    uiInput_ = ::ui::UiInputFrame{};
     injectedPointer_ = false;
 #else
     (void)surface;


### PR DESCRIPTION
Follow-up to #286.

#286 narrowed the Linux/macOS artifact builds to `cmake --build --target silencer`, so the Linux (GCC) job now compiles the client for real. GCC rejects `uiInput_ = {}` in `game_ui_pipeline.cpp` ("no match for `operator=`" from a brace-enclosed initializer list) where clang/MSVC accept it — this is why the Linux build on the merged PR was still red.

Fix: assign an explicit `::ui::UiInputFrame{}` temporary instead.

This change merged into #286 a moment too late (PR squash-merged before the final push landed), so it's split out here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)