### PR TITLE
fix(ci): stage cppx UI fonts in Windows release package

### DIFF
--- a/.github/actions/build-silencer-windows/action.yml
+++ b/.github/actions/build-silencer-windows/action.yml
@@ -98,5 +98,12 @@ runs:
         $vcpkgBin = "build/vcpkg_installed/x64-windows/bin"
         Copy-Item "$vcpkgBin/*.dll" $stage/
         Copy-Item -Recurse shared/assets $stage/assets
+        # Stage the cppx UI .otf fonts at assets/fonts/ (mirrors the Linux
+        # action + macOS bundle). The runtime resolver (ResolveFontDir in
+        # game_ui_pipeline.cpp → GetResDir()+"fonts" = <exe-dir>\assets\fonts)
+        # needs them here; without them PipelineHost::ensure() fails every
+        # frame and the release build launches to a black screen (#289).
+        New-Item -ItemType Directory -Force -Path "$stage/assets/fonts" | Out-Null
+        Copy-Item shared/fonts/*.otf "$stage/assets/fonts/"
         Write-Host "--- packaged files ---"
         Get-ChildItem $stage


### PR DESCRIPTION
Closes #292. Follow-up to #289 / #291.

## Problem

PR #291 fixed the release black screen for macOS and Linux by shipping the cppx UI `.otf` fonts next to the binary and resolving the font dir at runtime (`ResolveFontDir`). The **Windows** packaging step was never updated, so Windows release builds still launch to a black screen with dead input — `PipelineHost::ensure()` fails every frame when it can't find the fonts.

## Root cause

`.github/actions/build-silencer-windows/action.yml`'s `Package` step stages `shared/assets` but never `shared/fonts`. On Windows `GetResDir()` returns `<exe-dir>\assets\`, so `ResolveFontDir()` resolves to `<exe-dir>\assets\fonts` — which doesn't exist in the package.

## Fix

Stage `shared/fonts/*.otf` under `assets/fonts/` in the Package step, mirroring the Linux action and macOS bundle layout.

- The portable zip is the staged dir → covered.
- The Inno Setup installer already copies `assets\*` recursively (`recursesubdirs`) → covered, no `.iss` change needed.
- `SDL3_ttf.dll` is already bundled via the existing vcpkg `*.dll` copy (`sdl3-ttf` is in `vcpkg.json`) → no change needed.

## Testing

CI-config-only change. Verified end-to-end by tracing the resolver: `GetResDir()` Windows branch (`src/platform/os.cpp`) → `<exe-dir>\assets\`, `ResolveFontDir()` non-Apple path (`game_ui_pipeline.cpp`) → `GetResDir()+"fonts"`. The macOS prerelease build from this same chain was confirmed working by the user; this brings Windows to parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)