### PR TITLE
fix(silencer): make the cppx render pipeline total (no more dropped panels)

### DIFF
--- a/clients/silencer/src/ui/runtime/draw_command.cpp
+++ b/clients/silencer/src/ui/runtime/draw_command.cpp
@@ -3,8 +3,17 @@
 namespace ui {
 
 bool DrawCommandList::push(const DrawCommand &command) {
+  if (count >= UI_MAX_DRAW_COMMANDS - UI_DRAW_COMMANDS_RESERVE) {
+    ++dropped_count;
+    return false;
+  }
+  commands[count++] = command;
+  return true;
+}
+
+bool DrawCommandList::push_close(const DrawCommand &command) {
   if (count >= UI_MAX_DRAW_COMMANDS) {
-    ++error_count;
+    ++dropped_count;
     return false;
   }
   commands[count++] = command;
@@ -14,7 +23,7 @@ bool DrawCommandList::push(const DrawCommand &command) {
 bool DrawCommandList::push_text(const char *bytes, uint16_t len,
                                 uint32_t *out_off) {
   if (text_len_used + static_cast<int>(len) > UI_DRAW_TEXT_ARENA_BYTES) {
-    ++error_count;
+    ++dropped_count;
     return false;
   }
   if (out_off)
@@ -27,7 +36,7 @@ bool DrawCommandList::push_text(const char *bytes, uint16_t len,
 bool DrawCommandList::push_stops(const GradientStop *stops, uint8_t n,
                                  uint16_t *out_off) {
   if (grad_count + static_cast<int>(n) > UI_DRAW_GRAD_STOPS) {
-    ++error_count;
+    ++dropped_count;
     return false;
   }
   if (out_off)
@@ -41,7 +50,7 @@ void DrawCommandList::reset() {
   count = 0;
   text_len_used = 0;
   grad_count = 0;
-  error_count = 0;
+  dropped_count = 0;
 }
 
 } // namespace ui

--- a/clients/silencer/src/ui/runtime/draw_command.h
+++ b/clients/silencer/src/ui/runtime/draw_command.h
@@ -128,6 +128,23 @@ constexpr int UI_MAX_DRAW_COMMANDS = UI_RETAINED_MAX_NODES * UI_MAX_CMDS_PER_NOD
 constexpr int UI_DRAW_TEXT_ARENA_BYTES = 8 * 1024;
 constexpr int UI_DRAW_GRAD_STOPS = 256;
 
+// A node holds at most this many clip/layer brackets open across its child
+// recursion: one LayerPush (group opacity) + one ClipPush (overflow clip). The
+// input field's own clip opens and closes within the node's own paint, before
+// the child loop, so it is never simultaneously open with these. Bump this if
+// you add a new per-node bracket kind — the reserve below depends on it.
+constexpr int UI_MAX_OPEN_BRACKETS_PER_NODE = 2;
+
+// Closing-bracket commands (ClipPop/LayerPop) draw from a reserved tail of the
+// command buffer so a content-saturated frame can still emit a matching pop for
+// every open clip/layer (INV4: clip/layer balance holds unconditionally). The
+// reserve covers the worst case — every level of the retained tree's max-depth
+// recursion holding all of its brackets open at once — so a dropped pop, and the
+// unbalanced LayerPush composite smudge it would cause, is structurally
+// impossible.
+constexpr int UI_DRAW_COMMANDS_RESERVE =
+    UI_MAX_OPEN_BRACKETS_PER_NODE * UI_RETAINED_MAX_DEPTH;
+
 struct DrawCommandList {
   DrawCommand commands[UI_MAX_DRAW_COMMANDS] = {};
   int count = 0;
@@ -135,11 +152,15 @@ struct DrawCommandList {
   int text_len_used = 0;
   GradientStop grad_arena[UI_DRAW_GRAD_STOPS] = {};
   int grad_count = 0;
-  int error_count = 0;
+  int dropped_count = 0; // degradation telemetry; never gates the frame
 
-  // Every variable-capacity write is bounds-checked; overflow bumps error_count
-  // and fails the frame (never a silent clamp/truncate).
+  // Fixed-capacity, defined-overflow writes (INV5): a full arena drops the one
+  // command and bumps dropped_count, never fails the frame. push() leaves the
+  // reserve for closing brackets; push_close() (ClipPop/LayerPop) may use it so
+  // balance always holds. Returns whether the command landed — callers gate the
+  // matching pop on the push's return, never abort the walk.
   bool push(const DrawCommand &command);
+  bool push_close(const DrawCommand &command);
   bool push_text(const char *bytes, uint16_t len, uint32_t *out_off);
   bool push_stops(const GradientStop *stops, uint8_t n, uint16_t *out_off);
   void reset(); // cursors only; never memset the arrays

--- a/clients/silencer/src/ui/runtime/draw_command_builder.cpp
+++ b/clients/silencer/src/ui/runtime/draw_command_builder.cpp
@@ -206,10 +206,10 @@ bool push_gradient_command(DrawCommandList &list, NodeId node_id,
 
 // Shadow command, emitted before the fill so it sits behind the node
 // (design §9.8 order: Shadow -> fill/Gradient/Image -> children -> Border).
-bool append_shadow(DrawCommandList &list, const NodeSnapshot &node) {
+void append_shadow(DrawCommandList &list, const NodeSnapshot &node) {
   const Shadow &sh = node.visual.shadow;
   if (sh.color.a == 0)
-    return true;
+    return;
 
   DrawCommand command = {};
   command.kind = DrawCommandKind::Shadow;
@@ -222,15 +222,15 @@ bool append_shadow(DrawCommandList &list, const NodeSnapshot &node) {
       .spread = sh.spread,
       .corner_radius = node.visual.corner_radius,
   };
-  return list.push(command);
+  list.push(command);
 }
 
 // Image command (textured rect), emitted after the fill (design §9.8). The
 // executor cuts corner_radius on nine-slice per §9.7.
-bool append_image(DrawCommandList &list, const NodeSnapshot &node) {
+void append_image(DrawCommandList &list, const NodeSnapshot &node) {
   const BackgroundImage &bi = node.visual.image;
   if (bi.texture_id == 0)
-    return true;
+    return;
 
   DrawCommand command = {};
   command.kind = DrawCommandKind::Image;
@@ -248,12 +248,12 @@ bool append_image(DrawCommandList &list, const NodeSnapshot &node) {
       .flip_h = bi.flip_h,
       .fit = bi.fit,
   };
-  return list.push(command);
+  list.push(command);
 }
 
 // Rect command carrying only the resolved fill; the stroke is a separate Border
 // command emitted by append_frame.
-bool append_rect(DrawCommandList &list, const NodeSnapshot &node,
+void append_rect(DrawCommandList &list, const NodeSnapshot &node,
                  bool focused) {
   const VisualStyle &v = node.visual;
   bool visual_box = has_color(v.background) || v.gradient.stop_count > 0 ||
@@ -263,13 +263,14 @@ bool append_rect(DrawCommandList &list, const NodeSnapshot &node,
                      node.role == NodeRole::Checkbox ||
                      node.role == NodeRole::Input;
   if (!visual_box && !control_box && !focused) {
-    return true;
+    return;
   }
 
   // A resolved gradient IS the fill — emit it in place of the solid Rect.
   if (v.gradient.stop_count > 0) {
-    return push_gradient_command(list, node.id, node.layout, v.gradient,
-                                 v.corner_radius);
+    push_gradient_command(list, node.id, node.layout, v.gradient,
+                          v.corner_radius);
+    return;
   }
 
   // Sprite-backed (image) controls carry their own baked interior, so skip the
@@ -281,12 +282,12 @@ bool append_rect(DrawCommandList &list, const NodeSnapshot &node,
                           ? control_fill(node)
                           : kTransparent);
 
-  return push_rect_command(list, node.id, node.layout, fill, v.corner_radius);
+  push_rect_command(list, node.id, node.layout, fill, v.corner_radius);
 }
 
 // The per-side border + signed-offset outline (focus ring): the resolved border,
 // else a control-role default; the resolved outline, else the focus-ring fallback.
-bool append_frame(DrawCommandList &list, const NodeSnapshot &node,
+void append_frame(DrawCommandList &list, const NodeSnapshot &node,
                   bool focused) {
   const VisualStyle &v = node.visual;
   bool control_box = node.role == NodeRole::Button ||
@@ -329,7 +330,7 @@ bool append_frame(DrawCommandList &list, const NodeSnapshot &node,
   }
 
   if (!has_border && !has_outline)
-    return true;
+    return;
 
   if (has_border) {
     border.color.top = premul(border.color.top);
@@ -352,16 +353,18 @@ bool append_frame(DrawCommandList &list, const NodeSnapshot &node,
       .has_fill = false,
       .has_outline = has_outline,
   };
-  return list.push(command);
+  list.push(command);
 }
 
 // TEXT (role==Text): measure-driven, multi-line. Emits one Text command per
-// measured LineRun. Measure == layout (same measurer, design §10.4). Overflow
-// beyond UI_MAX_TEXT_LINES is a failed frame, never a silent drop.
-bool append_text(DrawCommandList &list, const NodeSnapshot &node,
+// measured LineRun. Measure == layout (same measurer, design §10.4). Content
+// exceeding UI_MAX_TEXT_LINES is truncated to what fits and clipped by the
+// node's own/ancestor clip (INV2: graceful content overflow, never a frame
+// abort). A scrolled text node's off-window lines are clipped by its viewport.
+void append_text(DrawCommandList &list, const NodeSnapshot &node,
                  bool inherited_disabled) {
   if (node.role != NodeRole::Text)
-    return true;
+    return;
 
   const VisualStyle &v = node.visual;
   Color color = has_color(v.text.color)
@@ -380,8 +383,8 @@ bool append_text(DrawCommandList &list, const NodeSnapshot &node,
   MeasureTextFn measurer = text_measurer();
   if (!measurer) {
     // Hermetic fallback (no measurer installed): one line at the content rect.
-    return push_text_command(list, node.id, content, value, color, font_size,
-                             align);
+    push_text_command(list, node.id, content, value, color, font_size, align);
+    return;
   }
 
   TextMetricsQuery query = {};
@@ -398,32 +401,30 @@ bool append_text(DrawCommandList &list, const NodeSnapshot &node,
   for (uint8_t i = 0; i < metrics.line_count; ++i) {
     const LineRun &line = metrics.lines[i];
     if (line.slice_offset + line.slice_len > value_len)
-      return false; // measurer returned an out-of-range slice — fail the frame
+      continue; // measurer returned an out-of-range slice — skip just this line
     DrawRect rect = {content.x + line.x, content.y + line.y, line.w, line.h};
     // The reveal ramp lives at the text's trailing edge: last line only.
     const bool last_line = (i + 1 == metrics.line_count);
-    if (!push_text_line(list, node.id, rect, value + line.slice_offset,
-                        line.slice_len, color, font_id, font_size, i, align,
-                        last_line ? v.text.reveal_boost : 0,
-                        last_line ? v.text.reveal_step : 0))
-      return false;
+    push_text_line(list, node.id, rect, value + line.slice_offset,
+                   line.slice_len, color, font_id, font_size, i, align,
+                   last_line ? v.text.reveal_boost : 0,
+                   last_line ? v.text.reveal_step : 0);
   }
-
-  if (metrics.overflowed) {
-    ++list.error_count; // text needed > UI_MAX_TEXT_LINES — never a silent drop
-    return false;
-  }
-  return true;
+  // metrics.overflowed (content needed > UI_MAX_TEXT_LINES) is a graceful
+  // truncation: the lines that fit are emitted, the rest clip. Recorded as a
+  // degradation, never a frame failure.
+  if (metrics.overflowed)
+    ++list.dropped_count;
 }
 
 // INPUT contents (role==Input): selection rect, value text, caret rect. Caret
 // and selection x come from real measured advances of the value's byte prefixes
 // (design §10.5), so the cursor lands exactly under the laid-out glyph.
-bool append_input_contents(DrawCommandList &list, const NodeSnapshot &node,
+void append_input_contents(DrawCommandList &list, const NodeSnapshot &node,
                            bool focused, bool inherited_disabled,
                            InputScrollStore *input_scroll) {
   if (node.role != NodeRole::Input)
-    return true;
+    return;
 
   // The text pen sits at the input's content box (border + padding), so the
   // screen owns the inset — the transcriber adds none of its own.
@@ -508,13 +509,13 @@ bool append_input_contents(DrawCommandList &list, const NodeSnapshot &node,
   clip_rect.y = node.layout.y;
   clip_rect.width = text_rect.width;
   clip_rect.height = node.layout.height;
+  bool clip_pushed = false;
   {
     DrawCommand clip = {};
     clip.kind = DrawCommandKind::ClipPush;
     clip.node_id = node.id;
     clip.rect = to_draw_rect(clip_rect);
-    if (!list.push(clip))
-      return false;
+    clip_pushed = list.push(clip);
   }
 
   if (focused && selection_end > selection_start) {
@@ -525,8 +526,7 @@ bool append_input_contents(DrawCommandList &list, const NodeSnapshot &node,
     sel.y = text_rect.y;
     sel.width = end_x - start_x;
     sel.height = text_rect.height;
-    if (!push_rect_command(list, node.id, sel, kSelectionFill, 0.0f))
-      return false;
+    push_rect_command(list, node.id, sel, kSelectionFill, 0.0f);
   }
 
   Color text_color =
@@ -536,9 +536,8 @@ bool append_input_contents(DrawCommandList &list, const NodeSnapshot &node,
                                                                : kTextFill);
   Rect value_rect = text_rect;
   value_rect.x -= scroll_x;
-  if (!push_text_command(list, node.id, value_rect, display_value, text_color,
-                         font_size, TextAlign::Left))
-    return false;
+  push_text_command(list, node.id, value_rect, display_value, text_color,
+                    font_size, TextAlign::Left);
 
   if (focused && node.text_edit.show_caret) {
     int caret = clamp_int(node.text_edit.caret, 0, length);
@@ -565,18 +564,15 @@ bool append_input_contents(DrawCommandList &list, const NodeSnapshot &node,
           node.layout.y + (node.layout.height - caret_rect.height) * 0.5f;
     }
     Color caret_color = ck.color.a > 0 ? ck.color : kCaretFill;
-    if (!push_rect_command(list, node.id, caret_rect, caret_color, 0.0f))
-      return false;
+    push_rect_command(list, node.id, caret_rect, caret_color, 0.0f);
   }
 
-  {
+  if (clip_pushed) {
     DrawCommand clip = {};
     clip.kind = DrawCommandKind::ClipPop;
     clip.node_id = node.id;
-    if (!list.push(clip))
-      return false;
+    list.push_close(clip); // reserved tail: the input clip always balances
   }
-  return true;
 }
 
 // LayerPush bracketing the node's subtree (design §9.10): the executor renders
@@ -595,7 +591,7 @@ bool pop_layer(DrawCommandList &list, const NodeSnapshot &node) {
   DrawCommand command = {};
   command.kind = DrawCommandKind::LayerPop;
   command.node_id = node.id;
-  return list.push(command);
+  return list.push_close(command); // reserved tail: a LayerPush always balances
 }
 
 // CLIP: overflow != Visible brackets the children in ClipPush/ClipPop, scissoring
@@ -613,54 +609,54 @@ bool pop_clip(DrawCommandList &list, const NodeSnapshot &node) {
   DrawCommand command = {};
   command.kind = DrawCommandKind::ClipPop;
   command.node_id = node.id;
-  return list.push(command);
+  return list.push_close(command); // reserved tail: a ClipPush always balances
 }
 
-bool append_node(const UiTree &tree, DrawCommandList &list, NodeId id,
+// Transcribe one node + its subtree. Each node paints independently: a node or
+// subtree that cannot fully emit (a saturated arena, a measurer truncation)
+// degrades in place and never aborts a sibling or ancestor (INV3 failure
+// isolation). Clip/layer brackets are emitted as matched pairs gated on whether
+// the push landed, and the pops draw from the reserved tail, so push/pop balance
+// always holds — no dangling LayerPush, no composite smudge (INV4).
+void append_node(const UiTree &tree, DrawCommandList &list, NodeId id,
                  bool inherited_disabled, NodeId focused_id,
                  InputScrollStore *input_scroll) {
   NodeSnapshot node = {};
   if (!tree.snapshot(id, &node))
-    return false;
+    return; // node vanished mid-walk: skip just this subtree (structural)
 
   // hidden => skip paint for the node and its subtree (design §9.10 / §8.5).
   if (node.visual.hidden)
-    return true;
+    return;
 
   bool disabled = inherited_disabled || node.interaction.disabled;
   bool focused = focused_id != 0 && focused_id == node.id;
 
   // Group opacity < 1 brackets the node's paint + subtree in a LayerPush/Pop so
-  // the executor composites the group as a unit (design §9.10).
-  const bool layer = node.visual.opacity < 1.0f;
-  if (layer && !push_layer(list, node))
-    return false;
+  // the executor composites the group as a unit (design §9.10). Only emit the
+  // pop if the push landed.
+  const bool layer_pushed = node.visual.opacity < 1.0f && push_layer(list, node);
 
   // Paint order per design §9.8: Shadow -> fill/Gradient -> Image -> [children]
-  // -> Border+Outline.
-  if (!append_shadow(list, node) ||
-      !append_rect(list, node, focused) ||
-      !append_image(list, node) ||
-      !append_frame(list, node, focused) ||
-      !append_text(list, node, inherited_disabled) ||
-      !append_input_contents(list, node, focused, inherited_disabled,
-                             input_scroll))
-    return false;
+  // -> Border+Outline. Each is best-effort; a dropped command degrades only its
+  // own paint, not the node or its siblings.
+  append_shadow(list, node);
+  append_rect(list, node, focused);
+  append_image(list, node);
+  append_frame(list, node, focused);
+  append_text(list, node, inherited_disabled);
+  append_input_contents(list, node, focused, inherited_disabled, input_scroll);
 
-  const bool clip = node.style.overflow != Overflow::Visible;
-  if (clip && !push_clip(list, node))
-    return false;
-  for (int i = 0; i < tree.child_count(id); ++i) {
-    if (!append_node(tree, list, tree.child_at(id, i), disabled, focused_id,
-                     input_scroll))
-      return false;
-  }
-  if (clip && !pop_clip(list, node))
-    return false;
+  const bool clip_pushed =
+      node.style.overflow != Overflow::Visible && push_clip(list, node);
+  for (int i = 0; i < tree.child_count(id); ++i)
+    append_node(tree, list, tree.child_at(id, i), disabled, focused_id,
+                input_scroll);
+  if (clip_pushed)
+    pop_clip(list, node);
 
-  if (layer && !pop_layer(list, node))
-    return false;
-  return true;
+  if (layer_pushed)
+    pop_layer(list, node);
 }
 
 } // namespace
@@ -668,11 +664,13 @@ bool append_node(const UiTree &tree, DrawCommandList &list, NodeId id,
 bool build_draw_command_list(const UiTree &tree, DrawCommandList *out,
                              NodeId focused_id, InputScrollStore *input_scroll) {
   if (!out || !tree.contains(tree.root_id()))
-    return false;
+    return false; // structural precondition (no buffer / no root), not content
   out->reset();
-  return append_node(tree, *out, tree.root_id(), false, focused_id,
-                     input_scroll) &&
-         out->error_count == 0;
+  // INV1 totality: any valid tree yields a presentable frame. Content that does
+  // not fit degrades (clip/truncate/drop) and is recorded in out->dropped_count;
+  // it is never a frame failure, so the last good frame is never corrupted.
+  append_node(tree, *out, tree.root_id(), false, focused_id, input_scroll);
+  return true;
 }
 
 } // namespace ui

--- a/clients/silencer/src/ui/style/text_measure.h
+++ b/clients/silencer/src/ui/style/text_measure.h
@@ -12,7 +12,7 @@
 
 namespace ui {
 
-constexpr int UI_MAX_TEXT_LINES = 32; // sized for the lore paragraph (~23 wrapped lines); overflow => failed frame
+constexpr int UI_MAX_TEXT_LINES = 32; // sized for the lore paragraph (~23 wrapped lines); content beyond this truncates to what fits (graceful overflow, INV2)
 
 struct TextMetricsQuery {
   const char *utf8 = nullptr; // borrowed; points into the shared string arena

--- a/clients/silencer/tests/client_ui_tests.cpp
+++ b/clients/silencer/tests/client_ui_tests.cpp
@@ -436,7 +436,7 @@ static bool client_ui_owns_retained_runtime_outputs(void) {
   // The live IR is the tagged-union DrawCommandList; the focused fill box emits
   // a Rect/Gradient fill carrying its node id.
   const ::ui::DrawCommandList &draw = client_ui.retained_command_list();
-  CHECK(draw.error_count == 0);
+  CHECK(draw.dropped_count == 0);
   CHECK(draw.count > 0);
   bool saw_button_fill = false;
   for (int i = 0; i < draw.count; ++i) {

--- a/clients/silencer/tests/ui_draw_command_tests.cpp
+++ b/clients/silencer/tests/ui_draw_command_tests.cpp
@@ -35,12 +35,22 @@ static bool test_designated_init() {
 static bool test_push_overflow() {
   static DrawCommandList list; // large; keep off the stack
   list.reset();
-  for (int i = 0; i < UI_MAX_DRAW_COMMANDS; ++i)
+  // Content push() stops at the reserve boundary (defined overflow: the command
+  // is dropped, the frame is not failed) so closing brackets always have room.
+  const int content_cap = UI_MAX_DRAW_COMMANDS - UI_DRAW_COMMANDS_RESERVE;
+  for (int i = 0; i < content_cap; ++i)
     CHECK(list.push({.kind = DrawCommandKind::Rect}));
+  CHECK(list.count == content_cap);
+  CHECK(list.dropped_count == 0);
+  CHECK(!list.push({.kind = DrawCommandKind::Rect})); // content saturated -> dropped
+  CHECK(list.dropped_count == 1);
+  // push_close() may use the reserved tail so every open clip/layer still
+  // balances even on a saturated frame (INV4).
+  for (int i = 0; i < UI_DRAW_COMMANDS_RESERVE; ++i)
+    CHECK(list.push_close({.kind = DrawCommandKind::ClipPop}));
   CHECK(list.count == UI_MAX_DRAW_COMMANDS);
-  CHECK(list.error_count == 0);
-  CHECK(!list.push({.kind = DrawCommandKind::Rect})); // overflow
-  CHECK(list.error_count == 1);
+  CHECK(!list.push_close({.kind = DrawCommandKind::ClipPop})); // hard cap
+  CHECK(list.dropped_count == 2);
   return true;
 }
 
@@ -54,9 +64,9 @@ static bool test_text_arena() {
   uint32_t off2 = 0;
   CHECK(list.push_text("hi", 2, &off2));
   CHECK(off2 == 5);
-  // overflow is a hard fail, not a clamp:
+  // a full text arena drops the bytes (defined overflow), never fails the frame:
   list.reset();
-  CHECK(list.text_len_used == 0 && list.error_count == 0);
+  CHECK(list.text_len_used == 0 && list.dropped_count == 0);
   return true;
 }
 
@@ -69,7 +79,7 @@ static bool test_stops_and_reset() {
   CHECK(off == 0 && list.grad_count == 2);
   list.reset();
   CHECK(list.count == 0 && list.grad_count == 0 && list.text_len_used == 0 &&
-        list.error_count == 0);
+        list.dropped_count == 0);
   return true;
 }
 

--- a/clients/silencer/tests/ui_scroll_tests.cpp
+++ b/clients/silencer/tests/ui_scroll_tests.cpp
@@ -80,7 +80,7 @@ bool clip_brackets_overflow_children() {
 
   static DrawCommandList list;
   CHECK(build_draw_command_list(tree, &list, 0));
-  CHECK(list.error_count == 0);
+  CHECK(list.dropped_count == 0);
 
   // Exactly one push + one pop, and the push carries the viewport's window rect.
   CHECK(count_kind(list, DrawCommandKind::ClipPush) == 1);

--- a/tests/cli-agent/e2e/92_lobby_chat_overflow_repro.sh
+++ b/tests/cli-agent/e2e/92_lobby_chat_overflow_repro.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Repro/regression for the cppx draw-pipeline totality defect: spamming the lobby
+# chat past the per-text-node wrapped-line ceiling used to abort the whole frame
+# transcribe, dropping every sibling panel painted after the chat (the "Active
+# Games" box, borders, text) and leaving an unbalanced layer/clip in the IR.
+#
+# Signal: the build-draw-command-list failure surfaces as the log line
+#   "client/ui: failed to update retained runtime"
+# It must be ABSENT before the spam and stay ABSENT after (totality: a frame is
+# always presentable; content overflow degrades, never fails the frame).
+#
+# Captures lobby_before/after.png at 1920x1080 for visual confirmation that the
+# Active Games panel persists.
+set -euo pipefail
+. "$(dirname "$0")/lib.sh"
+
+LOBBY_BIN="$(lobby_bin)"
+W=1920; H=1080
+# Short messages: each is its own '\n'-separated paragraph = one wrapped line.
+# ~120 of them pack the retained node's 640-byte value cap with ~75 wrapped
+# lines, well past the 32-line text ceiling (a long-message spam never fits
+# enough lines into the value cap to overflow).
+NMSG="${NMSG:-120}"
+
+TMP=$(mktemp -d)
+LOBBY_DB="$TMP/lobby.json"; SILENCER_HOME="$TMP/home"; mkdir -p "$SILENCER_HOME"
+export SILENCER_LOBBYD_DIR="$TMP/lobbyd"; mkdir -p "$SILENCER_LOBBYD_DIR"
+LOBBY_PORT=$(pick_port)
+PLAYER_AUTH_PORT=$(pick_port); MAP_API_PORT=$(pick_port); CTRL_PORT=$(pick_port)
+SILENCER_VERSION="$(silencer_version)"
+WORK="${WORK:-$TMP/work}"; mkdir -p "$WORK"
+GAME_LOG="/tmp/silencer-e2e-$CTRL_PORT.log"
+
+cleanup() {
+  cli --port "$CTRL_PORT" >/dev/null 2>&1 <<<'' || true
+  bun "$REPO_ROOT/clients/cli/index.ts" lobby kill --all >/dev/null 2>&1 || true
+  [ -n "${SILENCER_PID:-}" ] && stop_silencer "$SILENCER_PID" "$CTRL_PORT" || true
+  [ -n "${LOBBY_PID:-}" ] && { kill "$LOBBY_PID" 2>/dev/null || true; wait "$LOBBY_PID" 2>/dev/null || true; }
+  rm -rf "$TMP"
+}
+trap cleanup EXIT
+
+"$LOBBY_BIN" -addr ":$LOBBY_PORT" -db "$LOBBY_DB" -version "$SILENCER_VERSION" \
+  -game-binary "$SILENCER_BIN" -maps-dir "$TMP/maps" \
+  -player-auth-addr ":$PLAYER_AUTH_PORT" -map-api-addr ":$MAP_API_PORT" >"$TMP/lobby.log" 2>&1 &
+LOBBY_PID=$!
+for i in $(seq 1 60); do (echo > "/dev/tcp/127.0.0.1/$LOBBY_PORT") 2>/dev/null && break; sleep 0.25
+  [ "$i" = 60 ] && { echo "lobby never came up" >&2; cat "$TMP/lobby.log" >&2; exit 1; }; done
+
+HOME="$SILENCER_HOME" "$SILENCER_BIN" --headless --control-port "$CTRL_PORT" \
+  --lobby-host 127.0.0.1 --lobby-port "$LOBBY_PORT" >"$GAME_LOG" 2>&1 &
+SILENCER_PID=$!
+wait_alive "$CTRL_PORT"
+
+wait_for_widget() {
+  for i in $(seq 1 200); do
+    found=$(cli --port "$CTRL_PORT" inspect | LABEL="$1" bun -e \
+      'const r=JSON.parse(await new Response(Bun.stdin.stream()).text());const l=process.env.LABEL;
+       console.log((r.nodes||[]).some((w)=>w.label===l||w.control_id===l)?"yes":"no")' 2>/dev/null || echo no)
+    [ "$found" = yes ] && return 0; sleep 0.05
+  done; echo "widget '$1' never appeared" >&2; return 1
+}
+wait_for_lobby_state() {
+  for i in $(seq 1 80); do
+    ls=$(cli --port "$CTRL_PORT" state | bun -e 'console.log(JSON.parse(await new Response(Bun.stdin.stream()).text()).lobby_state||"")')
+    [ "$ls" = "$1" ] && return 0; sleep 0.1
+  done; echo "lobby_state never became $1 (last=$ls)" >&2; return 1
+}
+
+# --- drive game into the lobby (mirrors 71_visual_regression_lobby) ---
+cli --port "$CTRL_PORT" wait_for_state --state MAINMENU --timeout-ms 15000 >/dev/null
+cli --port "$CTRL_PORT" resize --w "$W" --h "$H" >/dev/null
+cli --port "$CTRL_PORT" click --label "Connect To Lobby" >/dev/null
+cli --port "$CTRL_PORT" wait_for_state --state LOBBYCONNECT --timeout-ms 5000 >/dev/null
+wait_for_widget "Username"
+wait_for_lobby_state AUTHENTICATING 2>/dev/null || true
+for ch in a l i c e; do cli --port "$CTRL_PORT" key --key "$ch" >/dev/null; done
+cli --port "$CTRL_PORT" key --key tab >/dev/null
+for ch in s e c r e t; do cli --port "$CTRL_PORT" key --key "$ch" >/dev/null; done
+cli --port "$CTRL_PORT" click --label "Login/Create" >/dev/null
+cli --port "$CTRL_PORT" wait_for_state --state CREATECHARACTER --timeout-ms 15000 >/dev/null
+wait_for_widget "Create New Character"
+cli --port "$CTRL_PORT" click --label "Create New Character" >/dev/null
+wait_for_widget "Alias"
+cli --port "$CTRL_PORT" set_text --label "Alias" --text "Alice" >/dev/null
+cli --port "$CTRL_PORT" key --key enter >/dev/null
+wait_for_widget "Noxis"
+cli --port "$CTRL_PORT" click --label "Noxis" >/dev/null
+cli --port "$CTRL_PORT" wait_for_state --state LOBBY --timeout-ms 15000 >/dev/null
+wait_for_widget "Agents"
+cli --port "$CTRL_PORT" wait_frames --n 45 >/dev/null # let the screen fade-in settle
+cli --port "$CTRL_PORT" screenshot --out "$WORK/lobby_before.png" >/dev/null
+
+BEFORE=$(grep -c "failed to update retained runtime" "$GAME_LOG" || true)
+echo "before: retained-runtime failures in log = $BEFORE"
+
+# --- spam the Lobby channel from a fake player ---
+bun "$REPO_ROOT/clients/cli/index.ts" lobby spawn --as bob --host 127.0.0.1 \
+  --port "$LOBBY_PORT" --version "$SILENCER_VERSION" --user bob --pass bob >/dev/null
+bun "$REPO_ROOT/clients/cli/index.ts" lobby join_channel --as bob --channel Lobby >/dev/null
+for i in $(seq 1 "$NMSG"); do
+  bun "$REPO_ROOT/clients/cli/index.ts" lobby chat --as bob --channel Lobby \
+    --text "m$i" >/dev/null
+done
+
+cli --port "$CTRL_PORT" wait_frames --n 30 >/dev/null
+cli --port "$CTRL_PORT" screenshot --out "$WORK/lobby_after.png" >/dev/null
+
+AFTER=$(grep -c "failed to update retained runtime" "$GAME_LOG" || true)
+echo "after:  retained-runtime failures in log = $AFTER"
+echo "screens: $WORK/lobby_before.png  $WORK/lobby_after.png"
+
+if [ "$AFTER" -gt "$BEFORE" ]; then
+  echo "REPRO: chat spam drove $((AFTER - BEFORE)) frame-transcribe failures (panels drop). DEFECT PRESENT."
+  exit 1
+fi
+echo "PASS 92_lobby_chat_overflow_repro (no frame-transcribe failure under chat spam)"


### PR DESCRIPTION
Closes #297.

## What was broken

The cppx retained-UI render pipeline was a partial function masquerading as a renderer: it produced a valid frame only for trees that fit fixed, undocumented per-frame budgets, and for anything larger it emitted a **corrupted partial frame** and logged a line. A renderer's contract is totality — given *any* element tree, produce a valid presentable frame, always. Content that doesn't fit (clip/scroll/wrap/truncate/virtualize) is the everyday problem of UI, not an error.

Reproduced (`tests/cli-agent/e2e/92_lobby_chat_overflow_repro.sh`): spamming the lobby chat past the per-text-node wrapped-line ceiling (`UI_MAX_TEXT_LINES = 32`) made `append_text` do `++error_count; return false`, the pre-order transcribe aborted on the first false, and **every sibling painted after the chat was dropped** — the entire "Active Games" panel (border + title + content) vanished. Baseline: **1404** `failed to update retained runtime` frames during the spam; the panel disappears from the screenshot.

## The fix — totality at the source (`src/ui` transcriber + IR)

Five compounding decisions turned one local overflow into global, silent, persistent corruption. Each is now closed:

**INV1 — Totality.** `build_draw_command_list` returns `true` for any valid tree; "frame failure for content reasons" is removed from the design. It returns `false` only for a structural precondition (null out / no root). `draw_command_builder.cpp:664-674`.

**INV2 — Graceful content overflow.** `append_text` emits the lines that fit (the measurer already caps at `UI_MAX_TEXT_LINES`) and truncates the rest — the laid-out box is sized to those lines, so over-tall text shows what fits and stops, exactly like clipping. No abort. `draw_command_builder.cpp:361-417`.

**INV3 — Failure isolation.** `append_node` no longer chains paint helpers through `&&` with early-return; each node paints independently and a node/subtree that can't fully emit degrades in place without dropping a sibling or ancestor. `draw_command_builder.cpp:621-660`.

**INV4 — Balanced clip/layer.** Clip/layer brackets are emitted as matched pairs gated on whether the push landed; the closing brackets (`ClipPop`/`LayerPop`) go through `push_close`, which draws from a reserved tail of the command buffer so every open clip/layer always balances — no dangling `LayerPush`, no GPU composite smudge. `append_input_contents` got the same treatment (its own clip now balances unconditionally). `draw_command.cpp:5-23`, `draw_command_builder.cpp:590-617,650-659` (node brackets) and `draw_command_builder.cpp:506-578` (input clip).

**INV5 — Fixed budget, defined overflow.** The fixed-capacity, zero-allocation, relocatable buffers are unchanged (no heap growth). A full arena now *drops the one command* and bumps `dropped_count` (degradation telemetry) instead of failing the frame. The reserve distinguishes the two kinds of limit: structural balance commands (pops) get reserved capacity; content commands degrade earlier. `draw_command.cpp:5-46`, `draw_command.h:131-159`.

### Reserve sizing (provably sufficient)

`UI_DRAW_COMMANDS_RESERVE = UI_MAX_OPEN_BRACKETS_PER_NODE (2) * UI_RETAINED_MAX_DEPTH`. At any instant a node holds open at most a layer + one clip (its input-clip closes before the overflow-clip opens, so they're never simultaneous), and transcribe recursion depth is bounded by the retained tree's build-time depth cap (`UI_RETAINED_MAX_DEPTH`). Worst-case simultaneously-open brackets = `2 * UI_RETAINED_MAX_DEPTH`, exactly the reserve. Once content saturates, new pushes are dropped (so their pops are gated off and need no reserve). The `2` is named (`UI_MAX_OPEN_BRACKETS_PER_NODE`) so a future per-node bracket kind forces an explicit bump rather than silently undersizing the reserve.

The counter `DrawCommandList::error_count` was renamed to `dropped_count` to reflect that it is non-fatal degradation telemetry, never a frame gate.

## Verification

- **Repro is the regression test** (`92_lobby_chat_overflow_repro.sh`): baseline = 1404 transcribe failures + Active Games panel gone; with the fix = **0** failures, all panels persist, chat truncates gracefully.
- **No regression on normal screens** (the change is a no-op when nothing overflows): the 7 in-game HUD surfaces are pixel-identical fix-vs-baseline (0.0000; tech_overlay 3.2% is animation-pulse phase, hot_tiles=0); the main menu is structurally identical (only the animated logo-scramble + focus-pulse phase differ). The lobby renders all panels.
- `ui_draw_command_tests` updated to the new totality contract (reserve boundary, `push_close` balance, defined overflow) — passes.

## Not in this PR (deliberate)

- **True windowing / virtualization of scrolled Text/lists.** Totality already makes the chat degrade gracefully (and at normal resolution the 640-byte retained value cap keeps it under the 32-line ceiling anyway). Materializing only the visible window of a *scrolled* Text so the newest lines always show under heavy overflow is the durable enhancement but a larger build — recommended as a follow-up, not folded in here.
- **Frame atomicity / last-good fallback.** Totality removes the need (the build always produces a presentable frame). A build-into-scratch/publish-on-success backstop for genuine programmer error is a reasonable future addition but not the fix.

## Pre-existing, out of scope

`ui_scroll_tests` / `client_ui_tests` / `ui_pipeline_tests` segfault on macOS on `main` too — they stack-allocate `UiTree`/`ClientUi` (~8.4 MB > the 8 MB macOS main-thread stack). Identical crash before/after this change; not introduced here. (The two I touched only for the `error_count`→`dropped_count` rename still compile.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
