### PR TITLE
fix(silencer): updater hangs at "Installing update" — re-home the stage-2 launch

### DIFF
--- a/clients/silencer/src/game/loop/game_loop.cpp
+++ b/clients/silencer/src/game/loop/game_loop.cpp
@@ -152,13 +152,14 @@ bool ViewedPlayerChatActive(Game & game){
 
 
 bool Game::Loop(void){
-	// Self-update stage-2 handoff. When the updater worker reaches STAGING it has
-	// a verified build staged but can't fork itself — the spawn must run here on
-	// the main thread while we still own SDL. PumpStage2() spawns the child once
-	// and latches IsStage2Spawned(); we then unwind so ~Game() releases the audio/
-	// video device before the replacement client opens it (the child blocks on our
-	// PID until we exit).
-	updater.PumpStage2();
+	// Self-update stage-2 handoff (windowed client only — a dedicated server is
+	// updated out-of-band and must never fork a GUI client). When the updater
+	// worker reaches STAGING it has a verified build staged but can't fork itself
+	// — the spawn must run here on the main thread while we still own SDL.
+	// PumpStage2() spawns the child once and latches IsStage2Spawned(); we then
+	// unwind so ~Game() releases the audio/video device before the replacement
+	// client opens it (the child blocks on our PID until we exit).
+	if(!headless) updater.PumpStage2();
 	if(updater.IsStage2Spawned()){
 		return false;
 	}

--- a/clients/silencer/src/game/loop/game_loop.cpp
+++ b/clients/silencer/src/game/loop/game_loop.cpp
@@ -152,8 +152,14 @@ bool ViewedPlayerChatActive(Game & game){
 
 
 bool Game::Loop(void){
+	// Self-update stage-2 handoff. When the updater worker reaches STAGING it has
+	// a verified build staged but can't fork itself — the spawn must run here on
+	// the main thread while we still own SDL. PumpStage2() spawns the child once
+	// and latches IsStage2Spawned(); we then unwind so ~Game() releases the audio/
+	// video device before the replacement client opens it (the child blocks on our
+	// PID until we exit).
+	updater.PumpStage2();
 	if(updater.IsStage2Spawned()){
-		// Stage-2 child is waiting on our PID to exit; unwind so ~Game() tears down cleanly.
 		return false;
 	}
 	if(quitRequested) return false;

--- a/clients/silencer/src/updater/CLAUDE.md
+++ b/clients/silencer/src/updater/CLAUDE.md
@@ -20,7 +20,7 @@ IDLE → PROMPTING → DOWNLOADING → VERIFYING → STAGING → DONE
 ```
 
 - `PROMPTING` — lobby rejected connection and sent an update URL; waiting for user consent.
-- `STAGING` — `UpdaterStage2::Launch` was called; UI must tear down SDL before main returns.
+- `STAGING` — worker finished download + verify. `Game::Loop` drives `Updater::PumpStage2()`, which spawns the stage-2 child on the main thread (the worker can't fork itself) and tears SDL down before main returns.
 - `DONE` — stage-2 is running; `Game::Loop` should return `false` so `~Game()` runs and releases audio/video before the new client opens the device.
 
 ## Key APIs
@@ -39,8 +39,10 @@ updater.GetState();
 updater.GetProgress();      // 0.0 – 1.0
 updater.GetErrorMessage();
 
-// Called by the game loop after stage-2 spawned:
-if (updater.IsStage2Spawned()) return false; // exits Game::Loop
+// Called every frame by the game loop (main thread). At STAGING it spawns
+// stage-2 once, then latches IsStage2Spawned():
+updater.PumpStage2();
+if (updater.IsStage2Spawned()) return false; // exits Game::Loop → ~Game() teardown
 ```
 
 ## Security
@@ -50,7 +52,7 @@ if (updater.IsStage2Spawned()) return false; // exits Game::Loop
 
 ## Stage-2 flow
 
-1. Normal client (`--self-update-stage2` absent): reaches STAGING, calls `UpdaterStage2::Launch(zippath)`, marks spawned, returns from game loop so `~Game()` tears down SDL cleanly.
+1. Normal client (`--self-update-stage2` absent): reaches STAGING; `Game::Loop` calls `Updater::PumpStage2()`, which calls `UpdaterStage2::Launch(zippath)` (one-shot) and latches `IsStage2Spawned()`; the loop then returns so `~Game()` tears down SDL cleanly. A failed spawn transitions the state machine to FAILED.
 2. Stage-2 process (invoked with `--self-update-stage2`): `UpdaterStage2::Run` overwrites the binary, then `exec`-replaces itself with the new client.
    - macOS launches the nested signed helper at `Silencer.app/Contents/Helpers/updater-stage-2`. Do not recreate a temporary `.app` bundle at runtime.
    - Windows/Linux still copy the current executable to a temp path for the handoff.

--- a/clients/silencer/src/updater/updater.cpp
+++ b/clients/silencer/src/updater/updater.cpp
@@ -1,6 +1,7 @@
 #include "updater.h"
 #include "updaterdownload.h"
 #include "updatersha256.h"
+#include "updaterstage2.h"
 #include "updaterzip.h"
 
 #include <cstdio>
@@ -30,7 +31,28 @@ Updater::~Updater() {
     if (worker.joinable()) worker.join();
 }
 
-void Updater::MarkStage2Spawned() { stage2spawned = true; }
+void Updater::PumpStage2() {
+    // stage2spawned/stage2attempted are touched only on the main thread (this
+    // function), so the post-handoff steady state needs no lock.
+    if (stage2spawned || stage2attempted) return;
+    std::string zip;
+    {
+        std::lock_guard<std::mutex> lk(mu);
+        if (state != STAGING) return;
+        stage2attempted = true;  // one-shot, even if the spawn below fails
+        zip = stage2zip;
+    }
+    fprintf(stderr, "[updater] launching stage-2 with zip=%s\n", zip.c_str());
+    if (UpdaterStage2::Launch(zip)) {
+        stage2spawned = true;  // Game::Loop sees this next and unwinds
+    } else {
+        std::lock_guard<std::mutex> lk(mu);
+        state = FAILED;
+        error = "Could not launch the updater";
+        fprintf(stderr, "[updater] stage-2 launch failed\n");
+    }
+}
+
 bool Updater::IsStage2Spawned() const { return stage2spawned; }
 
 void Updater::PresentUpdate(const std::string &u, const uint8_t s[32]) {
@@ -51,6 +73,7 @@ void Updater::Consent() {
         bytes_got = 0;
         bytes_total = 0;
         cancel_flag = false;  // reset under the lock, before worker starts
+        stage2attempted = false;  // let a fresh STAGING re-arm PumpStage2 (retry path)
         error.clear();
     }
     worker = std::thread(&Updater::Run, this);
@@ -177,11 +200,13 @@ void Updater::Run() {
         return;
     }
 
-    // 3. Hand off to stage-2. Caller (main loop) sees state=STAGING and
-    //    performs the exec + exit. We don't fork from the worker thread —
-    //    that needs to happen after SDL is torn down.
+    // 3. Hand off to stage-2. The main loop (Updater::PumpStage2) sees
+    //    state=STAGING and spawns the child + exits. We don't fork from the
+    //    worker thread — that needs to happen on the main thread, while SDL is
+    //    still owned, so ~Game can tear it down cleanly afterwards.
     {
         std::lock_guard<std::mutex> lk(mu);
+        stage2zip = zippath;
         state = STAGING;
     }
     fprintf(stderr, "[updater] download + verify ok, handing off to stage-2\n");

--- a/clients/silencer/src/updater/updater.h
+++ b/clients/silencer/src/updater/updater.h
@@ -83,9 +83,9 @@ private:
     std::atomic<bool> cancel_flag;
     std::thread worker;
     int retries;
-    std::string stage2zip;          // verified update zip, set when entering STAGING
-    bool stage2spawned = false;     // stage-2 child launched; Game::Loop unwinds
-    bool stage2attempted = false;   // launch tried (one-shot; success or failure)
+    std::string stage2zip;                     // verified update zip, set when entering STAGING
+    std::atomic<bool> stage2spawned{false};    // stage-2 child launched; Game::Loop unwinds
+    std::atomic<bool> stage2attempted{false};  // launch tried (one-shot; success or failure)
 };
 
 void UpdaterSetProgress(Updater &u, uint64_t got, uint64_t total);

--- a/clients/silencer/src/updater/updater.h
+++ b/clients/silencer/src/updater/updater.h
@@ -55,11 +55,15 @@ public:
     // for the static phases the modal renders (Prompting/Downloading/Failed).
     void ForceState(State s);
 
-    // Set by UpdateScreen after a successful UpdaterStage2::Launch. Game::Loop
-    // reads this and returns false so main() unwinds and ~Game tears down
-    // SDL/audio cleanly before the new client process opens the device —
-    // skipping that teardown produces an audible pop on the restarted client.
-    void MarkStage2Spawned();
+    // Called every frame by Game::Loop on the main thread. When the worker has
+    // reached STAGING (download + verify complete), spawns the stage-2 child via
+    // UpdaterStage2::Launch — once. The worker can't do this itself: the spawn
+    // must run on the main thread while we still own SDL. On success
+    // IsStage2Spawned() latches true, so Game::Loop returns false and main()
+    // unwinds, letting ~Game tear down SDL/audio before the replacement client
+    // opens the device (skipping that teardown pops the audio device). On a
+    // spawn failure the state machine transitions to FAILED. No-op otherwise.
+    void PumpStage2();
     bool IsStage2Spawned() const;
 
     // Trampolines into the private atomic state from the progress callback.
@@ -79,7 +83,9 @@ private:
     std::atomic<bool> cancel_flag;
     std::thread worker;
     int retries;
-    bool stage2spawned = false;
+    std::string stage2zip;          // verified update zip, set when entering STAGING
+    bool stage2spawned = false;     // stage-2 child launched; Game::Loop unwinds
+    bool stage2attempted = false;   // launch tried (one-shot; success or failure)
 };
 
 void UpdaterSetProgress(Updater &u, uint64_t got, uint64_t total);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ set(TEST_SRC
     ${CMAKE_SOURCE_DIR}/src/updater/updatersha256.cpp
     ${CMAKE_SOURCE_DIR}/src/updater/updaterdownload.cpp
     ${CMAKE_SOURCE_DIR}/src/updater/updaterzip.cpp
+    ${CMAKE_SOURCE_DIR}/src/updater/updaterstage2.cpp
     ${CMAKE_SOURCE_DIR}/src/updater/updater.cpp
 )
 

--- a/tests/updater_sm_test.cpp
+++ b/tests/updater_sm_test.cpp
@@ -31,3 +31,19 @@ TEST_CASE("VerifyOnly catches sha mismatch") {
     CHECK(Updater::VerifyFile(path, correct));
     CHECK_FALSE(Updater::VerifyFile(path, wrong));
 }
+
+// PumpStage2 (driven every frame from Game::Loop) must stay a no-op until the
+// worker actually reaches STAGING — otherwise it would spawn stage-2 mid-flight
+// or in steady state. The STAGING→spawn path itself runs a real process and is
+// covered by manual/e2e verification, not here.
+TEST_CASE("PumpStage2 does nothing before STAGING") {
+    Updater u;
+    u.PumpStage2();  // fresh updater is IDLE
+    CHECK(u.GetState() == Updater::IDLE);
+    CHECK_FALSE(u.IsStage2Spawned());
+
+    u.ForceState(Updater::DOWNLOADING);
+    u.PumpStage2();
+    CHECK(u.GetState() == Updater::DOWNLOADING);
+    CHECK_FALSE(u.IsStage2Spawned());
+}


### PR DESCRIPTION
Closes #301

## Symptom
The auto-update flow hangs forever at **"Installing update"** (the `STAGING` phase). Download + verify complete, then the client never restarts into the new build. Regression in the latest release.

## Root cause
The cppx UI migration (#267, `b2e4edb0`) dropped the side-effect that actually spawns the stage-2 helper.

- The updater worker downloads + verifies, then sets `state = STAGING`. It deliberately does **not** fork — the spawn must happen on the main thread while SDL is still owned.
- Pre-migration, the Clay `UpdateScreen::Update()` saw `STAGING`, called `UpdaterStage2::Launch(zippath)` + `MarkStage2Spawned()`; `Game::Loop` then saw `IsStage2Spawned()` and unwound so `~Game()` tore down SDL before the new client opened the device.
- The cppx port replaced that screen with `update_screen.cppx`, a **pure view function** that only renders the "Installing update" label. Nothing calls `UpdaterStage2::Launch` anymore — confirmed: **zero call sites** in the live tree, only stale comments. So `STAGING` is terminal, `IsStage2Spawned()` stays false, the loop never exits → permanent hang.

## Fix
Re-home the handoff into the updater module as **`Updater::PumpStage2()`**, driven every frame from `Game::Loop` on the main thread (the one place that can spawn while SDL is still owned):

- Owns the staged zip path (stored under the mutex in the same block that sets `STAGING`, so the worker→main handoff is race-free).
- One-shot latch (`stage2attempted`) so it spawns exactly once; **re-armed in `Consent()`** so a Retry after a launch failure can spawn again.
- Transitions to `FAILED` on spawn failure (surfaces the failure modal instead of hanging).
- Removes the now-orphaned `MarkStage2Spawned`.

Doc + test updates: `src/updater/CLAUDE.md` reflects the new flow; `updaterstage2.cpp` added to the test target; a guard test asserts `PumpStage2` is a no-op before `STAGING`.

## Verification
- ✅ macOS client + `silencer_tests` build clean (`build.sh`).
- ✅ `silencer_tests`: 13/13 cases, 31/31 assertions pass.
- ✅ Confirmed no headless control-socket op can force `STAGING` (`show_update_screen` rejects all but prompting/downloading/failed), so the new `PumpStage2` can't trigger a spurious real launch in CI.
- ⚠️ The **real cross-platform self-replace** (STAGING → spawn → exec → restart) still needs manual/e2e verification on macOS/Windows/Linux against a live update payload — the migration's coverage clearly never exercised a live STAGING→restart, which is how this regression shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)