### PR TITLE
WIP: feat(silencer): export perf tracing (OTLP) to OpenObserve

### DIFF
--- a/clients/silencer/CLAUDE.md
+++ b/clients/silencer/CLAUDE.md
@@ -280,6 +280,21 @@ windowed = vsync-bound real numbers (`present` ≈ vsync wait); `--headless`
 free-runs at 640×480 = pure CPU, no vsync/throttle. Drive menus via the
 CLI and `grep '\[perf\]'` the run log.
 
+### OTLP export (metrics + traces → OpenObserve)
+
+`SILENCER_PERF_OTLP=<base-url>` turns on a second, independent output:
+Layer-1 **metrics** (fps + frame-ms p50/p95/p99 + per-section avg, one
+OTLP-metrics flush/sec) and Layer-2 **operation traces** (`startup`,
+`level_load`, tail-sampled over-budget `frame`) as flame graphs. The same
+`PERF_SCOPE`s nest under a `perf::Operation` trace root via a thread-local
+scope stack; identity/device live in the OTLP **Resource** (set once,
+batched once per POST — never stamped per span). Export runs on a
+background curl thread (bounded queue, drops on overflow, never stalls a
+frame). `SILENCER_PERF` (stdout) and `SILENCER_PERF_OTLP` are independent.
+Code: `src/platform/perf_trace.{h,cpp}` + `perf_otlp.{h,cpp}`. Local
+Docker + dashboard + Traces-filter how-to:
+[`../../docs/silencer-perf-otlp.md`](../../docs/silencer-perf-otlp.md).
+
 ## Gotchas
 
 - **Build-time config is baked at configure.** Lobby host/port and

--- a/clients/silencer/CMakeLists.txt
+++ b/clients/silencer/CMakeLists.txt
@@ -623,6 +623,7 @@ add_executable(pipeline_host_tests
 	src/render/cppx_ui/pipeline_host.cpp
 	src/render/cppx_ui/ui_draw_program.cpp
 	src/platform/perf_trace.cpp
+	src/platform/perf_otlp.cpp
 	src/render/cppx_ui/ui_surface.cpp
 	src/render/cppx_ui/draw_executor.cpp
 	src/render/cppx_ui/ui_draw_geometry.cpp
@@ -648,7 +649,7 @@ target_compile_features(pipeline_host_tests PRIVATE cxx_std_20)
 target_include_directories(pipeline_host_tests PRIVATE
 	"${CMAKE_CURRENT_SOURCE_DIR}/src" "${CMAKE_CURRENT_SOURCE_DIR}/src/platform"
 	${SILENCER_CPPX_INCLUDE_DIRS})
-target_link_libraries(pipeline_host_tests PRIVATE SDL3::SDL3 SDL3_ttf::SDL3_ttf yogacore)
+target_link_libraries(pipeline_host_tests PRIVATE SDL3::SDL3 SDL3_ttf::SDL3_ttf yogacore CURL::libcurl)
 target_compile_definitions(pipeline_host_tests PRIVATE
 	SILENCER_TEST_FONT_DIR="${SILENCER_SHARED_DIR}/fonts")
 if(MSVC)

--- a/clients/silencer/src/game/init/game_init.cpp
+++ b/clients/silencer/src/game/init/game_init.cpp
@@ -1,6 +1,8 @@
 #include "game.h"
 #include "config.h"
 #include "objecttypes.h"
+#include "perf_otlp.h"
+#include "perf_trace.h"
 #include "state.h"
 #include "sdl3gpubackend.h"
 #include "tuibackend.h"
@@ -56,6 +58,7 @@ Game::Game()
 }
 
 Game::~Game(){
+	perf::Shutdown(); // flush + stop the telemetry exporter thread
 	gameSession.MapDownloaderRef().JoinAndShutdown();
 	controlserver.Stop();
 	inputserver.Stop();
@@ -78,6 +81,10 @@ Game::~Game(){
 }
 
 bool Game::Load(char * cmdline){
+	// Anchor the perf clock + start the OTLP exporter (no-ops unless the env
+	// switches are set) before opening the startup trace.
+	perf::Init();
+	perf::Operation _startup("startup", perf::Sampling::Always);
 	// CLI overrides for the lobby host / port — applied AFTER Config::Load
 	// below so the on-disk config doesn't clobber them. Empty strings / 0
 	// mean "no override; use the config value".
@@ -202,7 +209,9 @@ bool Game::Load(char * cmdline){
 		}
 		if(!headless && !tui) gameInput.OpenFirstGamepad();
 		printf("Loading palette...\n");
-		if(!renderer.palette.SetPalette(0)){
+		bool paletteOk;
+		{ PERF_SCOPE("startup.palette"); paletteOk = renderer.palette.SetPalette(0); }
+		if(!paletteOk){
 			return false;
 		}
 		if(tui){
@@ -250,7 +259,9 @@ bool Game::Load(char * cmdline){
 		// so the palette is always populated by the time a screenshot is captured.
 	}
 	printf("Loading resources...\n");
-	if(!world.resources.Load(this, world.dedicatedserver.active)){
+	bool resourcesOk;
+	{ PERF_SCOPE("startup.resources"); resourcesOk = world.resources.Load(this, world.dedicatedserver.active); }
+	if(!resourcesOk){
 		printf("Could not load resources\n");
 		return false;
 	}
@@ -258,6 +269,42 @@ bool Game::Load(char * cmdline){
 	// GASLoader::Get().items is populated (World constructor ran too early).
 	world.LoadBuyableItems();
 	printf("Resources loaded\n");
+
+	// Publish the session-constant identity/device block into the OTLP Resource
+	// (no-op unless SILENCER_PERF_OTLP is set). Per-span data stays off spans.
+	if(perf::g_trace_enabled){
+		perf::otlp::ResourceInfo ri;
+		ri.service_name = "silencer";
+		ri.build_version = SILENCER_VERSION;
+		ri.os = SDL_GetPlatform();
+		ri.cpu_cores = SDL_GetNumLogicalCPUCores();
+		ri.ram_mb = SDL_GetSystemRAM();
+		RenderDevice * dev = gameRenderer.GetRenderDevice();
+		if(dev){
+			ri.gpu_driver = dev->GpuDriverName();
+			ri.gpu = ri.gpu_driver; // SDL3 GPU exposes the driver, not the adapter name
+		}
+		const char * gpuUiEnv = SDL_getenv("SILENCER_GPU_UI");
+		bool gpuUi = !headless && !tui && dev && dev->SupportsUiGeometry() &&
+		             (!gpuUiEnv || strcmp(gpuUiEnv, "0") != 0);
+		ri.ui_path = gpuUi ? "gpu" : "cpu";
+		ri.fullscreen = Config::GetInstance().fullscreen;
+		ri.vsync = true; // windowed GPU swapchain presents vsynced by default
+		SDL_Window * win = gameRenderer.GetWindow();
+		if(win){
+			int vw = 0, vh = 0;
+			if(!SDL_GetWindowSizeInPixels(win, &vw, &vh) || vw < 1)
+				SDL_GetWindowSize(win, &vw, &vh);
+			ri.viewport_w = vw; ri.viewport_h = vh;
+			SDL_DisplayID disp = SDL_GetDisplayForWindow(win);
+			const SDL_DisplayMode * dm = SDL_GetCurrentDisplayMode(disp);
+			if(dm){
+				ri.disp_w = dm->w; ri.disp_h = dm->h;
+				ri.refresh = (int)(dm->refresh_rate + 0.5f);
+			}
+		}
+		perf::otlp::SetResource(ri);
+	}
 	lasttick = SDL_GetTicks();
 	gameRenderer.RestartPaletteFade();
 	if(controlPort > 0){

--- a/clients/silencer/src/game/loop/game_loop.cpp
+++ b/clients/silencer/src/game/loop/game_loop.cpp
@@ -5,6 +5,7 @@
 #include "gasloader.h"
 #include "lobbygame.h"
 #include "objecttypes.h"
+#include "perf_otlp.h"
 #include "perf_trace.h"
 #include "player.h"
 #include "state.h"
@@ -161,6 +162,29 @@ bool Game::Loop(void){
 
 	// Goodbye, Mr. Anderson.
 	if(quitRequested) return false;
+
+	// Open the per-frame trace root: every PERF_SCOPE below (game.tick, sim,
+	// world.draw, ui, present) nests under it. Tail-sampled — only over-budget
+	// frames (plus a 1-in-N baseline) are emitted. Dedicated servers don't
+	// render, so they never open a frame trace.
+	perf::Operation _frame("frame", perf::Sampling::FrameBudget, !world.dedicatedserver.active);
+
+	// Reflect mid-session identity/display changes into the OTLP Resource
+	// (account becomes known after lobby auth; viewport/fullscreen on resize).
+	// Each setter bumps session.epoch only on an actual change.
+	if(perf::g_trace_enabled && !world.dedicatedserver.active){
+		if(world.lobby.accountid != 0) perf::otlp::SetAccountId(world.lobby.accountid);
+		if(SDL_Window * win = gameRenderer.GetWindow()){
+			int vw = 0, vh = 0;
+			if(!SDL_GetWindowSizeInPixels(win, &vw, &vh) || vw < 1)
+				SDL_GetWindowSize(win, &vw, &vh);
+			bool fs = (SDL_GetWindowFlags(win) & SDL_WINDOW_FULLSCREEN) != 0;
+			const char * gpuUiEnv = SDL_getenv("SILENCER_GPU_UI");
+			RenderDevice * dev = gameRenderer.GetRenderDevice();
+			bool gpuUi = dev && dev->SupportsUiGeometry() && (!gpuUiEnv || strcmp(gpuUiEnv, "0") != 0);
+			perf::otlp::SetDisplay(vw, vh, fs, true, gpuUi ? "gpu" : "cpu");
+		}
+	}
 
 	// Process commands from CLI
 	DrainControlQueue();

--- a/clients/silencer/src/game/session/game_session.cpp
+++ b/clients/silencer/src/game/session/game_session.cpp
@@ -12,6 +12,7 @@
 #include "team.h"
 #include "user.h"
 #include "world.h"
+#include "perf_trace.h"
 #include <cstring>
 #include <vector>
 
@@ -22,10 +23,16 @@ GameSession::GameSession(Game & g)
 }
 
 bool GameSession::LoadMap(const char * name){
-if(!game.world.map.Load(name, game.world)){
+// A level load is one logical operation → one trace (always emitted). The
+// scopes below light up as children for the flame graph.
+perf::Operation _levelLoad("level_load", perf::Sampling::Always, "map", name ? name : "");
+bool mapOk;
+{ PERF_SCOPE("level.map_parse"); mapOk = game.world.map.Load(name, game.world); }
+if(!mapOk){
 return false;
 }
 if(!game.world.dedicatedserver.active){
+PERF_SCOPE("level.ambience");
 ambienceMixer.CreateAmbienceChannels();
 game.renderer.palette.SetParallaxColors(game.world.map.parallax);
 // Restart the transition fade clock now that the (slow, synchronous) map load

--- a/clients/silencer/src/platform/perf_otlp.cpp
+++ b/clients/silencer/src/platform/perf_otlp.cpp
@@ -1,0 +1,440 @@
+#include "perf_otlp.h"
+
+#include <SDL3/SDL.h>
+#include <curl/curl.h>
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstdio>
+#include <cstring>
+#include <deque>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+
+namespace perf {
+namespace otlp {
+
+namespace {
+
+// ---- config + lifecycle --------------------------------------------------
+std::string g_tracesUrl;
+std::string g_metricsUrl;
+std::string g_authHeader; // full "Authorization: ..." line, or empty
+std::string g_sessionId;
+std::atomic<bool> g_running{false};
+
+// ---- resource (constant per session.epoch) -------------------------------
+std::mutex g_resMutex;
+ResourceInfo g_res;
+uint64_t g_epoch = 0;
+std::shared_ptr<const std::string> g_resJson; // cached "{\"attributes\":[...]}"
+
+// ---- export queue --------------------------------------------------------
+struct Item {
+	bool is_metric;
+	Trace trace;
+	Metrics metric;
+	std::shared_ptr<const std::string> res;
+};
+constexpr size_t kMaxQueue = 4096;
+std::mutex g_qMutex;
+std::condition_variable g_qCv;
+std::deque<Item> g_queue;
+bool g_stop = false;
+uint64_t g_dropped = 0;
+std::thread g_thread;
+
+// ---- string helpers ------------------------------------------------------
+void AppendEscaped(std::string & out, const std::string & s) {
+	for (char c : s) {
+		switch (c) {
+		case '"': out += "\\\""; break;
+		case '\\': out += "\\\\"; break;
+		case '\n': out += "\\n"; break;
+		case '\r': out += "\\r"; break;
+		case '\t': out += "\\t"; break;
+		default:
+			if ((unsigned char)c < 0x20) {
+				char buf[8];
+				snprintf(buf, sizeof(buf), "\\u%04x", (unsigned char)c);
+				out += buf;
+			} else {
+				out += c;
+			}
+		}
+	}
+}
+
+void AppendHex64(std::string & out, uint64_t v) {
+	char buf[17];
+	snprintf(buf, sizeof(buf), "%016llx", (unsigned long long)v);
+	out += buf;
+}
+
+void AppendU64(std::string & out, uint64_t v) {
+	char buf[24];
+	snprintf(buf, sizeof(buf), "%llu", (unsigned long long)v);
+	out += buf;
+}
+
+void AppendDouble(std::string & out, double v) {
+	char buf[40];
+	snprintf(buf, sizeof(buf), "%.6g", v);
+	out += buf;
+}
+
+std::string Base64(const std::string & in) {
+	static const char * tbl =
+	    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+	std::string out;
+	int val = 0, bits = -6;
+	for (unsigned char c : in) {
+		val = (val << 8) + c;
+		bits += 8;
+		while (bits >= 0) {
+			out += tbl[(val >> bits) & 0x3F];
+			bits -= 6;
+		}
+	}
+	if (bits > -6) out += tbl[((val << 8) >> (bits + 8)) & 0x3F];
+	while (out.size() % 4) out += '=';
+	return out;
+}
+
+void AppendAttr(std::string & out, const Attr & a) {
+	out += "{\"key\":\"";
+	out += a.key;
+	out += "\",\"value\":{";
+	switch (a.type) {
+	case Attr::Str:
+		out += "\"stringValue\":\"";
+		AppendEscaped(out, a.s);
+		out += "\"";
+		break;
+	case Attr::Int:
+		out += "\"intValue\":\"";
+		{ char b[24]; snprintf(b, sizeof(b), "%lld", a.i); out += b; }
+		out += "\"";
+		break;
+	case Attr::Dbl:
+		out += "\"doubleValue\":";
+		AppendDouble(out, a.d);
+		break;
+	case Attr::Bool:
+		out += a.b ? "\"boolValue\":true" : "\"boolValue\":false";
+		break;
+	}
+	out += "}}";
+}
+
+// Build the resource "{\"attributes\":[...]}" block from the current info.
+std::shared_ptr<const std::string> BuildResJsonLocked() {
+	std::vector<Attr> attrs;
+	attrs.push_back(SA("service.name", g_res.service_name.empty() ? "silencer" : g_res.service_name));
+	attrs.push_back(SA("session.id", g_sessionId));
+	attrs.push_back(IA("session.epoch", (long long)g_epoch));
+	if (!g_res.build_version.empty()) attrs.push_back(SA("build.version", g_res.build_version));
+	if (!g_res.account_id.empty()) attrs.push_back(SA("account.id", g_res.account_id));
+	if (!g_res.os.empty()) attrs.push_back(SA("device.os", g_res.os));
+	if (!g_res.gpu.empty()) attrs.push_back(SA("device.gpu", g_res.gpu));
+	if (!g_res.gpu_driver.empty()) attrs.push_back(SA("device.gpu_driver", g_res.gpu_driver));
+	if (!g_res.cpu.empty()) attrs.push_back(SA("device.cpu", g_res.cpu));
+	if (g_res.cpu_cores > 0) attrs.push_back(IA("device.cpu_cores", g_res.cpu_cores));
+	if (g_res.ram_mb > 0) attrs.push_back(IA("device.ram_mb", g_res.ram_mb));
+	if (g_res.disp_w > 0) {
+		char b[32]; snprintf(b, sizeof(b), "%dx%d", g_res.disp_w, g_res.disp_h);
+		attrs.push_back(SA("display.resolution", b));
+	}
+	if (g_res.viewport_w > 0) {
+		char b[32]; snprintf(b, sizeof(b), "%dx%d", g_res.viewport_w, g_res.viewport_h);
+		attrs.push_back(SA("display.viewport", b));
+	}
+	if (g_res.refresh > 0) attrs.push_back(IA("display.refresh", g_res.refresh));
+	attrs.push_back(BA("render.vsync", g_res.vsync));
+	attrs.push_back(BA("render.fullscreen", g_res.fullscreen));
+	if (!g_res.ui_path.empty()) attrs.push_back(SA("render.ui_path", g_res.ui_path));
+
+	auto s = std::make_shared<std::string>();
+	*s += "{\"attributes\":[";
+	for (size_t i = 0; i < attrs.size(); ++i) {
+		if (i) *s += ",";
+		AppendAttr(*s, attrs[i]);
+	}
+	*s += "]}";
+	return s;
+}
+
+std::shared_ptr<const std::string> CurrentResJson() {
+	std::lock_guard<std::mutex> lk(g_resMutex);
+	if (!g_resJson) g_resJson = BuildResJsonLocked();
+	return g_resJson;
+}
+
+// ---- sender thread -------------------------------------------------------
+void AppendSpan(std::string & out, const Trace & t, const Span & s) {
+	out += "{\"traceId\":\"";
+	AppendHex64(out, t.trace_hi);
+	AppendHex64(out, t.trace_lo);
+	out += "\",\"spanId\":\"";
+	AppendHex64(out, s.id);
+	out += "\",";
+	if (s.parent != 0) {
+		out += "\"parentSpanId\":\"";
+		AppendHex64(out, s.parent);
+		out += "\",";
+	}
+	out += "\"name\":\"";
+	AppendEscaped(out, std::string(s.name ? s.name : ""));
+	out += "\",\"kind\":1,\"startTimeUnixNano\":\"";
+	AppendU64(out, s.start_ns);
+	out += "\",\"endTimeUnixNano\":\"";
+	AppendU64(out, s.end_ns);
+	out += "\"";
+	if (!s.attrs.empty()) {
+		out += ",\"attributes\":[";
+		for (size_t i = 0; i < s.attrs.size(); ++i) {
+			if (i) out += ",";
+			AppendAttr(out, s.attrs[i]);
+		}
+		out += "]";
+	}
+	out += "}";
+}
+
+size_t DiscardBody(char *, size_t sz, size_t nmemb, void *) { return sz * nmemb; }
+
+void Post(CURL * curl, struct curl_slist * headers, const std::string & url,
+          const std::string & body) {
+	curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, DiscardBody);
+	curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+	curl_easy_setopt(curl, CURLOPT_POST, 1L);
+	curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+	curl_easy_setopt(curl, CURLOPT_POSTFIELDS, body.c_str());
+	curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, (long)body.size());
+	curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 2L);
+	curl_easy_setopt(curl, CURLOPT_TIMEOUT, 5L);
+	curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
+	CURLcode rc = curl_easy_perform(curl);
+	if (rc != CURLE_OK) {
+		fprintf(stderr, "[perf-otlp] POST %s failed: %s\n", url.c_str(),
+		        curl_easy_strerror(rc));
+	}
+}
+
+// Flush accumulated trace spans (all sharing one resource) as one request.
+void FlushTraceBatch(CURL * curl, struct curl_slist * headers,
+                     const std::shared_ptr<const std::string> & res,
+                     std::string & spans, int & count) {
+	if (count == 0) return;
+	std::string body = "{\"resourceSpans\":[{\"resource\":";
+	body += *res;
+	body += ",\"scopeSpans\":[{\"scope\":{\"name\":\"silencer.perf\"},\"spans\":[";
+	body += spans;
+	body += "]}]}]}";
+	Post(curl, headers, g_tracesUrl, body);
+	spans.clear();
+	count = 0;
+}
+
+void PostMetrics(CURL * curl, struct curl_slist * headers,
+                 const std::shared_ptr<const std::string> & res, const Metrics & m) {
+	std::string body = "{\"resourceMetrics\":[{\"resource\":";
+	body += *res;
+	body += ",\"scopeMetrics\":[{\"scope\":{\"name\":\"silencer.perf\"},\"metrics\":[";
+	for (size_t i = 0; i < m.gauges.size(); ++i) {
+		if (i) body += ",";
+		body += "{\"name\":\"";
+		AppendEscaped(body, std::string(m.gauges[i].first));
+		body += "\",\"gauge\":{\"dataPoints\":[{\"asDouble\":";
+		AppendDouble(body, m.gauges[i].second);
+		body += ",\"timeUnixNano\":\"";
+		AppendU64(body, m.ts_ns);
+		body += "\"}]}}";
+	}
+	body += "]}]}]}";
+	Post(curl, headers, g_metricsUrl, body);
+}
+
+void SenderLoop() {
+	CURL * curl = curl_easy_init();
+	struct curl_slist * headers = nullptr;
+	headers = curl_slist_append(headers, "Content-Type: application/json");
+	if (!g_authHeader.empty()) headers = curl_slist_append(headers, g_authHeader.c_str());
+
+	constexpr int kBatchSpanCap = 256;
+	while (true) {
+		std::deque<Item> batch;
+		{
+			std::unique_lock<std::mutex> lk(g_qMutex);
+			g_qCv.wait_for(lk, std::chrono::milliseconds(500),
+			               [] { return g_stop || !g_queue.empty(); });
+			batch.swap(g_queue);
+			bool stop = g_stop;
+			lk.unlock();
+			if (batch.empty() && stop) break;
+		}
+
+		// Accumulate trace spans sharing a resource into batched POSTs.
+		std::shared_ptr<const std::string> curRes;
+		std::string spanBuf;
+		int spanCount = 0;
+		for (Item & it : batch) {
+			if (it.is_metric) {
+				if (curl) PostMetrics(curl, headers, it.res, it.metric);
+				continue;
+			}
+			if (curRes && it.res != curRes && spanCount > 0)
+				FlushTraceBatch(curl, headers, curRes, spanBuf, spanCount);
+			curRes = it.res;
+			for (const Span & s : it.trace.spans) {
+				if (spanCount > 0) spanBuf += ",";
+				AppendSpan(spanBuf, it.trace, s);
+				if (++spanCount >= kBatchSpanCap)
+					FlushTraceBatch(curl, headers, curRes, spanBuf, spanCount);
+			}
+		}
+		if (curl && spanCount > 0) FlushTraceBatch(curl, headers, curRes, spanBuf, spanCount);
+
+		{
+			std::lock_guard<std::mutex> lk(g_qMutex);
+			if (g_stop && g_queue.empty()) break;
+		}
+	}
+
+	if (headers) curl_slist_free_all(headers);
+	if (curl) curl_easy_cleanup(curl);
+}
+
+std::string MakeUuid() {
+	// 122-bit random v4 UUID from two SDL_GetPerformanceCounter()-seeded draws.
+	uint64_t s = (uint64_t)SDL_GetPerformanceCounter() ^ 0x9e3779b97f4a7c15ull;
+	auto next = [&]() {
+		uint64_t z = (s += 0x9e3779b97f4a7c15ull);
+		z = (z ^ (z >> 30)) * 0xbf58476d1ce4e5b9ull;
+		z = (z ^ (z >> 27)) * 0x94d049bb133111ebull;
+		return z ^ (z >> 31);
+	};
+	uint64_t hi = next(), lo = next();
+	hi = (hi & 0xFFFFFFFFFFFF0FFFull) | 0x0000000000004000ull; // version 4
+	lo = (lo & 0x3FFFFFFFFFFFFFFFull) | 0x8000000000000000ull; // variant
+	char buf[40];
+	snprintf(buf, sizeof(buf), "%08x-%04x-%04x-%04x-%012llx",
+	         (unsigned)(hi >> 32), (unsigned)((hi >> 16) & 0xFFFF),
+	         (unsigned)(hi & 0xFFFF), (unsigned)((lo >> 48) & 0xFFFF),
+	         (unsigned long long)(lo & 0xFFFFFFFFFFFFull));
+	return buf;
+}
+
+} // namespace
+
+bool Init(const char * endpoint) {
+	if (g_running.load()) return true;
+	if (!endpoint || !*endpoint) return false;
+
+	std::string base = endpoint;
+	while (!base.empty() && base.back() == '/') base.pop_back();
+	g_tracesUrl = base + "/v1/traces";
+	g_metricsUrl = base + "/v1/metrics";
+
+	const char * rawAuth = SDL_getenv("SILENCER_PERF_OTLP_AUTH");
+	if (rawAuth && *rawAuth) {
+		g_authHeader = std::string("Authorization: ") + rawAuth;
+	} else {
+		const char * user = SDL_getenv("SILENCER_PERF_OTLP_USER");
+		const char * pass = SDL_getenv("SILENCER_PERF_OTLP_PASS");
+		if (user && pass) {
+			g_authHeader = "Authorization: Basic " +
+			               Base64(std::string(user) + ":" + pass);
+		}
+	}
+
+	// curl global init on the main thread before the sender thread spins up
+	// (curl_easy_init's lazy global init is not thread-safe).
+	curl_global_init(CURL_GLOBAL_DEFAULT);
+
+	g_sessionId = MakeUuid();
+	g_stop = false;
+	g_running.store(true);
+	g_thread = std::thread(SenderLoop);
+	return true;
+}
+
+void Shutdown() {
+	if (!g_running.load()) return;
+	{
+		std::lock_guard<std::mutex> lk(g_qMutex);
+		g_stop = true;
+	}
+	g_qCv.notify_all();
+	if (g_thread.joinable()) g_thread.join();
+	g_running.store(false);
+	if (g_dropped) fprintf(stderr, "[perf-otlp] dropped %llu telemetry items (queue overflow)\n",
+	                       (unsigned long long)g_dropped);
+}
+
+bool Active() { return g_running.load(); }
+
+const std::string & SessionId() { return g_sessionId; }
+
+void SetResource(const ResourceInfo & r) {
+	std::lock_guard<std::mutex> lk(g_resMutex);
+	g_res = r;
+	g_resJson = BuildResJsonLocked();
+}
+
+void SetAccountId(uint64_t account_id) {
+	std::lock_guard<std::mutex> lk(g_resMutex);
+	std::string s = std::to_string(account_id);
+	if (g_res.account_id == s) return;
+	g_res.account_id = s;
+	++g_epoch;
+	g_resJson = BuildResJsonLocked();
+}
+
+void SetDisplay(int viewport_w, int viewport_h, bool fullscreen, bool vsync,
+                const char * ui_path) {
+	std::lock_guard<std::mutex> lk(g_resMutex);
+	std::string up = ui_path ? ui_path : "";
+	if (g_res.viewport_w == viewport_w && g_res.viewport_h == viewport_h &&
+	    g_res.fullscreen == fullscreen && g_res.vsync == vsync && g_res.ui_path == up)
+		return;
+	g_res.viewport_w = viewport_w;
+	g_res.viewport_h = viewport_h;
+	g_res.fullscreen = fullscreen;
+	g_res.vsync = vsync;
+	g_res.ui_path = up;
+	++g_epoch;
+	g_resJson = BuildResJsonLocked();
+}
+
+void EnqueueTrace(Trace && t) {
+	if (!g_running.load()) return;
+	auto res = CurrentResJson();
+	std::lock_guard<std::mutex> lk(g_qMutex);
+	if (g_queue.size() >= kMaxQueue) { ++g_dropped; return; }
+	Item it;
+	it.is_metric = false;
+	it.trace = std::move(t);
+	it.res = res;
+	g_queue.push_back(std::move(it));
+	g_qCv.notify_one();
+}
+
+void EnqueueMetrics(Metrics && m) {
+	if (!g_running.load()) return;
+	auto res = CurrentResJson();
+	std::lock_guard<std::mutex> lk(g_qMutex);
+	if (g_queue.size() >= kMaxQueue) { ++g_dropped; return; }
+	Item it;
+	it.is_metric = true;
+	it.metric = std::move(m);
+	it.res = res;
+	g_queue.push_back(std::move(it));
+	g_qCv.notify_one();
+}
+
+} // namespace otlp
+} // namespace perf

--- a/clients/silencer/src/platform/perf_otlp.h
+++ b/clients/silencer/src/platform/perf_otlp.h
@@ -1,0 +1,97 @@
+#pragma once
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+// OTLP/HTTP exporter for the perf tracer (Layer 1 metrics + Layer 2 traces).
+//
+// Off unless SILENCER_PERF_OTLP=<base-url> is set, e.g.
+//   SILENCER_PERF_OTLP=http://localhost:5080/api/default
+// Auth (OpenObserve root basic-auth or an ingestion token):
+//   SILENCER_PERF_OTLP_USER + SILENCER_PERF_OTLP_PASS  → Basic <base64(user:pass)>
+//   SILENCER_PERF_OTLP_AUTH=<verbatim Authorization header value>  (overrides)
+//
+// Identity/device live in the OTLP Resource block (set once per session, sent
+// once per export request). Only per-operation-varying data (span name, "map",
+// frame duration) rides on span attributes. The frame thread enqueues completed
+// traces / metric snapshots into a bounded queue; one background thread batches
+// them into curl POSTs. Telemetry never blocks a frame — overflow drops.
+
+namespace perf {
+namespace otlp {
+
+struct Attr {
+	const char * key;
+	enum Type { Str, Int, Dbl, Bool } type;
+	std::string s;
+	long long i = 0;
+	double d = 0.0;
+	bool b = false;
+};
+inline Attr SA(const char * k, std::string v) { Attr a; a.key = k; a.type = Attr::Str; a.s = std::move(v); return a; }
+inline Attr IA(const char * k, long long v)   { Attr a; a.key = k; a.type = Attr::Int; a.i = v; return a; }
+inline Attr DA(const char * k, double v)      { Attr a; a.key = k; a.type = Attr::Dbl; a.d = v; return a; }
+inline Attr BA(const char * k, bool v)        { Attr a; a.key = k; a.type = Attr::Bool; a.b = v; return a; }
+
+struct Span {
+	uint64_t id;
+	uint64_t parent; // 0 == trace root
+	const char * name;
+	uint64_t start_ns;
+	uint64_t end_ns;
+	std::vector<Attr> attrs; // usually empty; only operation roots carry a few
+};
+
+struct Trace {
+	uint64_t trace_hi;
+	uint64_t trace_lo;
+	std::vector<Span> spans;
+};
+
+struct Metrics {
+	uint64_t ts_ns;
+	std::vector<std::pair<const char *, double>> gauges;
+};
+
+// Constant-per-session identity + device data → OTLP Resource attributes.
+struct ResourceInfo {
+	std::string service_name;
+	std::string build_version;
+	std::string account_id; // empty when not yet known
+	std::string os;
+	std::string gpu;
+	std::string gpu_driver;
+	std::string cpu;
+	int cpu_cores = 0;
+	int ram_mb = 0;
+	int disp_w = 0, disp_h = 0, refresh = 0;
+	int viewport_w = 0, viewport_h = 0;
+	bool fullscreen = false;
+	bool vsync = true;
+	std::string ui_path; // "gpu" | "cpu"
+};
+
+// Start the exporter. `endpoint` is the SILENCER_PERF_OTLP base URL. Returns
+// true if a sender thread is running and traces/metrics will be exported.
+bool Init(const char * endpoint);
+void Shutdown();
+bool Active();
+
+// A fresh UUID minted per launch; surfaced so a slow player can report it.
+const std::string & SessionId();
+
+// Resource lifecycle. SetResource installs the full session-constant block
+// (session.id + session.epoch are added internally). The narrow setters below
+// handle the few fields that can change mid-session — each bumps session.epoch
+// so every epoch's Resource is internally constant.
+void SetResource(const ResourceInfo & r);
+void SetAccountId(uint64_t account_id);
+void SetDisplay(int viewport_w, int viewport_h, bool fullscreen, bool vsync,
+                const char * ui_path);
+
+void EnqueueTrace(Trace && t);
+void EnqueueMetrics(Metrics && m);
+
+} // namespace otlp
+} // namespace perf

--- a/clients/silencer/src/platform/perf_trace.cpp
+++ b/clients/silencer/src/platform/perf_trace.cpp
@@ -35,6 +35,7 @@ double g_nsPerTick = 0.0;
 
 // ---- metrics window (Layer-1) --------------------------------------------
 uint64_t g_lastMarkCounter = 0;
+bool g_skipNextFrameMs = true; // first FrameMark period == startup load, not a frame
 std::vector<float> g_frameMs; // per-frame periods since last metrics flush
 constexpr double kWindowMs = 1000.0;
 
@@ -101,12 +102,17 @@ void FlushMetrics(uint64_t now) {
 	m.ts_ns = CounterToWallNs(now);
 	m.gauges.push_back({"frame.fps", elapsedS > 0 ? (double)g_frames / elapsedS : 0.0});
 
-	std::vector<float> sorted = g_frameMs;
-	std::sort(sorted.begin(), sorted.end());
-	m.gauges.push_back({"frame.ms.p50", Percentile(sorted, 50.0)});
-	m.gauges.push_back({"frame.ms.p95", Percentile(sorted, 95.0)});
-	m.gauges.push_back({"frame.ms.p99", Percentile(sorted, 99.0)});
-	m.gauges.push_back({"frame.ms.worst", sorted.empty() ? 0.0 : sorted.back()});
+	// Only emit frame-ms percentiles when the window actually has frame samples.
+	// The startup window's single period is skipped (it's the load, not a frame),
+	// so emitting 0s there would dip the charts misleadingly.
+	if (!g_frameMs.empty()) {
+		std::vector<float> sorted = g_frameMs;
+		std::sort(sorted.begin(), sorted.end());
+		m.gauges.push_back({"frame.ms.p50", Percentile(sorted, 50.0)});
+		m.gauges.push_back({"frame.ms.p95", Percentile(sorted, 95.0)});
+		m.gauges.push_back({"frame.ms.p99", Percentile(sorted, 99.0)});
+		m.gauges.push_back({"frame.ms.worst", sorted.back()});
+	}
 
 	// Per-section avg ms/frame (present/ui/sim/world.draw/...): the same arena
 	// the stdout layer prints, exported as low-cardinality gauges.
@@ -239,8 +245,12 @@ void FrameMark() {
 	uint64_t now = SDL_GetPerformanceCounter();
 
 	if (g_trace_enabled) {
+		// The first period measured here spans Init()→first frame, i.e. the
+		// synchronous startup load (~seconds). That's the `startup` trace, not a
+		// frame — skip it so it can't pin frame-ms p95/worst to a bogus outlier.
 		double ms = (double)(now - g_lastMarkCounter) * g_msPerTick;
-		if (g_frameMs.size() < 4096) g_frameMs.push_back((float)ms);
+		if (g_skipNextFrameMs) g_skipNextFrameMs = false;
+		else if (g_frameMs.size() < 4096) g_frameMs.push_back((float)ms);
 	}
 	g_lastMarkCounter = now;
 

--- a/clients/silencer/src/platform/perf_trace.cpp
+++ b/clients/silencer/src/platform/perf_trace.cpp
@@ -1,12 +1,19 @@
 #include "perf_trace.h"
+#include "perf_otlp.h"
+
+#include <algorithm>
+#include <chrono>
 #include <cstdio>
+#include <vector>
 
 namespace perf {
 
 bool g_enabled = false;
+bool g_trace_enabled = false;
 
 namespace {
 
+// ---- stdout aggregate (Layer-0, unchanged) -------------------------------
 struct Acc {
 	const char * name; // string-literal pointer identity is the key (no strcmp)
 	uint64_t ticks;
@@ -21,59 +28,251 @@ uint64_t g_windowStart = 0;
 double g_msPerTick = 0.0;
 bool g_inited = false;
 
-Acc * Find(const char * name){
-	for(int i = 0; i < g_count; ++i)
-		if(g_acc[i].name == name) return &g_acc[i];
-	if(g_count >= kMaxSections) return nullptr;
+// ---- wall-clock anchor (perf counter is monotonic, not wall time) --------
+uint64_t g_anchorWallNs = 0;
+uint64_t g_anchorCounter = 0;
+double g_nsPerTick = 0.0;
+
+// ---- metrics window (Layer-1) --------------------------------------------
+uint64_t g_lastMarkCounter = 0;
+std::vector<float> g_frameMs; // per-frame periods since last metrics flush
+constexpr double kWindowMs = 1000.0;
+
+// ---- frame-trace sampling (Layer-2) --------------------------------------
+double g_frameBudgetMs = 16.67; // ~60 fps target
+double g_frameOverFactor = 2.0; // emit a frame trace when frame_ms > factor*budget
+uint32_t g_frameBaselineN = 600; // also emit 1-in-N frames as a baseline (0 = off)
+uint64_t g_frameCounter = 0;
+
+// ---- trace builders (a stack of in-flight operations) --------------------
+struct PendingSpan {
+	uint64_t id;
+	uint64_t parent;
+	const char * name;
+	uint64_t start_ns;
+	uint64_t end_ns;
+	std::vector<otlp::Attr> attrs;
+};
+struct Builder {
+	uint64_t trace_hi, trace_lo;
+	Sampling mode;
+	std::vector<PendingSpan> spans;
+	std::vector<int> open; // indices of currently-open spans (parent chain)
+};
+std::vector<Builder> g_ops; // active operations; back() is the current trace
+
+// ---- splitmix64 id generator (per-session seed, main thread only) --------
+uint64_t g_idState = 0;
+uint64_t NextId() {
+	uint64_t z = (g_idState += 0x9e3779b97f4a7c15ull);
+	z = (z ^ (z >> 30)) * 0xbf58476d1ce4e5b9ull;
+	z = (z ^ (z >> 27)) * 0x94d049bb133111ebull;
+	return z ^ (z >> 31);
+}
+
+Acc * Find(const char * name) {
+	for (int i = 0; i < g_count; ++i)
+		if (g_acc[i].name == name) return &g_acc[i];
+	if (g_count >= kMaxSections) return nullptr;
 	g_acc[g_count] = {name, 0, 0};
 	return &g_acc[g_count++];
 }
 
-void EnsureInit(){
-	if(g_inited) return;
-	g_inited = true;
-	g_enabled = SDL_getenv("SILENCER_PERF") != nullptr;
-	g_msPerTick = 1000.0 / (double)SDL_GetPerformanceFrequency();
-	g_windowStart = SDL_GetPerformanceCounter();
+double EnvDouble(const char * key, double fallback) {
+	const char * v = SDL_getenv(key);
+	if (!v || !*v) return fallback;
+	double d = SDL_atof(v);
+	return d > 0.0 ? d : fallback;
+}
+
+double Percentile(std::vector<float> & sorted, double pct) {
+	if (sorted.empty()) return 0.0;
+	size_t idx = (size_t)(pct / 100.0 * (double)(sorted.size() - 1) + 0.5);
+	if (idx >= sorted.size()) idx = sorted.size() - 1;
+	return sorted[idx];
+}
+
+void FlushMetrics(uint64_t now) {
+	if (!g_trace_enabled || g_frames == 0) return;
+	double elapsedMs = (double)(now - g_windowStart) * g_msPerTick;
+	double elapsedS = elapsedMs / 1000.0;
+
+	otlp::Metrics m;
+	m.ts_ns = CounterToWallNs(now);
+	m.gauges.push_back({"frame.fps", elapsedS > 0 ? (double)g_frames / elapsedS : 0.0});
+
+	std::vector<float> sorted = g_frameMs;
+	std::sort(sorted.begin(), sorted.end());
+	m.gauges.push_back({"frame.ms.p50", Percentile(sorted, 50.0)});
+	m.gauges.push_back({"frame.ms.p95", Percentile(sorted, 95.0)});
+	m.gauges.push_back({"frame.ms.p99", Percentile(sorted, 99.0)});
+	m.gauges.push_back({"frame.ms.worst", sorted.empty() ? 0.0 : sorted.back()});
+
+	// Per-section avg ms/frame (present/ui/sim/world.draw/...): the same arena
+	// the stdout layer prints, exported as low-cardinality gauges.
+	for (int i = 0; i < g_count; ++i) {
+		double avgMs = ((double)g_acc[i].ticks * g_msPerTick) / (double)g_frames;
+		m.gauges.push_back({g_acc[i].name, avgMs});
+	}
+	otlp::EnqueueMetrics(std::move(m));
 }
 
 } // namespace
 
-void AddSample(const char * name, uint64_t ticks){
-	if(!g_enabled) return;
-	Acc * a = Find(name);
-	if(a){ a->ticks += ticks; a->calls += 1; }
+uint64_t CounterToWallNs(uint64_t counter) {
+	if (counter < g_anchorCounter) return g_anchorWallNs;
+	return g_anchorWallNs + (uint64_t)((double)(counter - g_anchorCounter) * g_nsPerTick);
 }
 
-void FrameMark(){
-	EnsureInit();
-	if(!g_enabled) return;
+void Init() {
+	if (g_inited) return;
+	g_inited = true;
+	g_enabled = SDL_getenv("SILENCER_PERF") != nullptr;
+	const char * otlp_ep = SDL_getenv("SILENCER_PERF_OTLP");
+
+	g_msPerTick = 1000.0 / (double)SDL_GetPerformanceFrequency();
+	g_nsPerTick = 1.0e9 / (double)SDL_GetPerformanceFrequency();
+	uint64_t counter = SDL_GetPerformanceCounter();
+	g_anchorCounter = counter;
+	g_windowStart = counter;
+	g_lastMarkCounter = counter;
+	g_anchorWallNs = (uint64_t)std::chrono::duration_cast<std::chrono::nanoseconds>(
+	                     std::chrono::system_clock::now().time_since_epoch())
+	                     .count();
+	g_idState = g_anchorWallNs ^ (counter * 0x9e3779b97f4a7c15ull);
+
+	if (otlp_ep && *otlp_ep) {
+		g_frameBudgetMs = EnvDouble("SILENCER_PERF_FRAME_BUDGET_MS", g_frameBudgetMs);
+		g_frameOverFactor = EnvDouble("SILENCER_PERF_FRAME_OVER_FACTOR", g_frameOverFactor);
+		const char * n = SDL_getenv("SILENCER_PERF_FRAME_BASELINE_N");
+		if (n && *n) g_frameBaselineN = (uint32_t)SDL_atoi(n);
+		g_trace_enabled = otlp::Init(otlp_ep);
+		if (g_trace_enabled) {
+			printf("[perf] OTLP export -> %s | session.id=%s\n", otlp_ep,
+			       otlp::SessionId().c_str());
+			fflush(stdout);
+		}
+	}
+}
+
+void Shutdown() {
+	if (g_trace_enabled) otlp::Shutdown();
+	g_trace_enabled = false;
+}
+
+void AddSample(const char * name, uint64_t ticks) {
+	if (!g_enabled && !g_trace_enabled) return;
+	Acc * a = Find(name);
+	if (a) { a->ticks += ticks; a->calls += 1; }
+}
+
+bool ScopeBegin(const char * name, uint64_t start_counter) {
+	if (g_ops.empty()) return false; // no active operation → not traced
+	Builder & b = g_ops.back();
+	uint64_t parent = b.spans[b.open.back()].id;
+	int idx = (int)b.spans.size();
+	b.spans.push_back({NextId(), parent, name, CounterToWallNs(start_counter), 0, {}});
+	b.open.push_back(idx);
+	return true;
+}
+
+void ScopeEnd(uint64_t end_counter) {
+	if (g_ops.empty()) return;
+	Builder & b = g_ops.back();
+	if (b.open.size() <= 1) return; // never pop the root via a scope
+	int idx = b.open.back();
+	b.open.pop_back();
+	b.spans[idx].end_ns = CounterToWallNs(end_counter);
+}
+
+void OperationBegin(const char * name, Sampling mode, const char * attr_key,
+                    const char * attr_val) {
+	Builder b;
+	b.trace_hi = NextId();
+	b.trace_lo = NextId();
+	b.mode = mode;
+	PendingSpan root;
+	root.id = NextId();
+	root.parent = 0;
+	root.name = name;
+	root.start_ns = CounterToWallNs(SDL_GetPerformanceCounter());
+	root.end_ns = 0;
+	if (attr_key && attr_val) root.attrs.push_back(otlp::SA(attr_key, attr_val));
+	b.spans.push_back(std::move(root));
+	b.open.push_back(0);
+	g_ops.push_back(std::move(b));
+}
+
+void OperationEnd() {
+	if (g_ops.empty()) return;
+	Builder b = std::move(g_ops.back());
+	g_ops.pop_back();
+	uint64_t end = CounterToWallNs(SDL_GetPerformanceCounter());
+	b.spans[0].end_ns = end;
+	// Close any scopes the caller left dangling (defensive).
+	for (size_t i = 1; i < b.spans.size(); ++i)
+		if (b.spans[i].end_ns == 0) b.spans[i].end_ns = end;
+
+	bool emit = true;
+	if (b.mode == Sampling::FrameBudget) {
+		double durMs = (double)(b.spans[0].end_ns - b.spans[0].start_ns) / 1.0e6;
+		bool overBudget = durMs > g_frameBudgetMs * g_frameOverFactor;
+		bool baseline = g_frameBaselineN > 0 && (g_frameCounter % g_frameBaselineN == 0);
+		++g_frameCounter;
+		emit = overBudget || baseline;
+	}
+	if (!emit) return;
+
+	otlp::Trace t;
+	t.trace_hi = b.trace_hi;
+	t.trace_lo = b.trace_lo;
+	t.spans.reserve(b.spans.size());
+	for (PendingSpan & ps : b.spans)
+		t.spans.push_back({ps.id, ps.parent, ps.name, ps.start_ns, ps.end_ns, std::move(ps.attrs)});
+	otlp::EnqueueTrace(std::move(t));
+}
+
+void FrameMark() {
+	Init();
+	if (!g_enabled && !g_trace_enabled) return;
 	g_frames += 1;
 	uint64_t now = SDL_GetPerformanceCounter();
-	double elapsedMs = (double)(now - g_windowStart) * g_msPerTick;
-	if(elapsedMs < 1000.0) return;
 
-	// Sort sections by cost (descending) so the priciest reads first.
-	int idx[kMaxSections];
-	for(int i = 0; i < g_count; ++i) idx[i] = i;
-	for(int i = 0; i < g_count; ++i)
-		for(int j = i + 1; j < g_count; ++j)
-			if(g_acc[idx[j]].ticks > g_acc[idx[i]].ticks){ int t = idx[i]; idx[i] = idx[j]; idx[j] = t; }
-
-	char line[640];
-	int o = snprintf(line, sizeof(line), "[perf] %ufps frame %.2fms",
-	                 (unsigned)g_frames, elapsedMs / (double)g_frames);
-	for(int k = 0; k < g_count && o < (int)sizeof(line); ++k){
-		Acc & a = g_acc[idx[k]];
-		double avgMs = ((double)a.ticks * g_msPerTick) / (double)g_frames;
-		o += snprintf(line + o, sizeof(line) - o, " | %s %.2f", a.name, avgMs);
+	if (g_trace_enabled) {
+		double ms = (double)(now - g_lastMarkCounter) * g_msPerTick;
+		if (g_frameMs.size() < 4096) g_frameMs.push_back((float)ms);
 	}
-	printf("%s\n", line);
-	fflush(stdout);
+	g_lastMarkCounter = now;
 
-	for(int i = 0; i < g_count; ++i){ g_acc[i].ticks = 0; g_acc[i].calls = 0; }
+	double elapsedMs = (double)(now - g_windowStart) * g_msPerTick;
+	if (elapsedMs < kWindowMs) return;
+
+	if (g_enabled) {
+		// Sort sections by cost (descending) so the priciest reads first.
+		int idx[kMaxSections];
+		for (int i = 0; i < g_count; ++i) idx[i] = i;
+		for (int i = 0; i < g_count; ++i)
+			for (int j = i + 1; j < g_count; ++j)
+				if (g_acc[idx[j]].ticks > g_acc[idx[i]].ticks) { int t = idx[i]; idx[i] = idx[j]; idx[j] = t; }
+
+		char line[640];
+		int o = snprintf(line, sizeof(line), "[perf] %ufps frame %.2fms",
+		                 (unsigned)g_frames, elapsedMs / (double)g_frames);
+		for (int k = 0; k < g_count && o < (int)sizeof(line); ++k) {
+			Acc & a = g_acc[idx[k]];
+			double avgMs = ((double)a.ticks * g_msPerTick) / (double)g_frames;
+			o += snprintf(line + o, sizeof(line) - o, " | %s %.2f", a.name, avgMs);
+		}
+		printf("%s\n", line);
+		fflush(stdout);
+	}
+
+	FlushMetrics(now);
+
+	for (int i = 0; i < g_count; ++i) { g_acc[i].ticks = 0; g_acc[i].calls = 0; }
 	g_frames = 0;
 	g_windowStart = now;
+	g_frameMs.clear();
 }
 
 } // namespace perf

--- a/clients/silencer/src/platform/perf_trace.h
+++ b/clients/silencer/src/platform/perf_trace.h
@@ -2,29 +2,90 @@
 #include <SDL3/SDL.h>
 #include <cstdint>
 
-// Lightweight frame-time tracer. Enabled at runtime by setting the SILENCER_PERF
-// env var (any value). When off, every hook below early-outs to a single bool
-// test, so the scopes can stay compiled into release builds.
+// Two-layer perf tracer.
 //
-// Usage:
-//   PERF_SCOPE("ui");                 // times the enclosing block
-//   perf::FrameMark();                // call once per rendered frame
+//  PERF_SCOPE("name")   — RAII timer for the enclosing block.
+//  perf::Operation op   — RAII trace root; PERF_SCOPEs running inside nest
+//                         under it via a thread-local scope stack.
+//  perf::FrameMark()    — call once per rendered frame.
 //
-// Once per second the accumulated per-section time is printed to stdout, sorted
-// by cost, as average ms-per-frame over the window, e.g.:
-//   [perf] 60fps frame 16.62ms | present 14.90 | ui 1.31 | ui.raster 0.92 | net 0.02
+// Two independent outputs, each gated by its own env var (set in perf::Init):
+//
+//  SILENCER_PERF        → g_enabled: per-section avg ms printed to stdout once
+//                         per window (unchanged legacy behavior).
+//  SILENCER_PERF_OTLP   → g_trace_enabled: Layer-1 metrics + Layer-2 operation
+//                         traces exported to OpenObserve over OTLP/HTTP.
+//
+// When both are unset every hook below early-outs on a single bool test, so the
+// scopes stay compiled in at no cost.
 namespace perf {
 
-extern bool g_enabled;
+extern bool g_enabled;       // stdout aggregate
+extern bool g_trace_enabled; // OTLP metrics + traces
 
-void AddSample(const char * name, uint64_t ticks);
-void FrameMark();
+// Anchor the monotonic clock to wall time, read the env switches, and start the
+// OTLP exporter if configured. Idempotent; safe to call before any scope.
+void Init();
+void Shutdown();
+
+// Absolute Unix wall-clock nanoseconds for a SDL_GetPerformanceCounter() value,
+// derived from the init-time anchor (perf counter is monotonic, not wall-clock).
+uint64_t CounterToWallNs(uint64_t counter);
+
+void AddSample(const char * name, uint64_t ticks); // stdout aggregate
+void FrameMark();                                   // per-frame stdout + metrics
+
+// --- tracing internals (used by Scope / Operation below) ---
+enum class Sampling { Always, FrameBudget };
+bool ScopeBegin(const char * name, uint64_t start_counter); // true if a span was opened
+void ScopeEnd(uint64_t end_counter);
+void OperationBegin(const char * name, Sampling mode, const char * attr_key,
+                    const char * attr_val);
+void OperationEnd();
+
+// Opens a trace ROOT for one logical operation (frame / startup / level_load).
+// Any PERF_SCOPE running inside nests under it. FrameBudget operations are
+// tail-sampled (emitted only when over budget, plus a 1-in-N baseline); Always
+// operations always emit.
+struct Operation {
+	bool active;
+	Operation(const char * name, Sampling mode)
+	    : active(g_trace_enabled) {
+		if (active) OperationBegin(name, mode, nullptr, nullptr);
+	}
+	Operation(const char * name, Sampling mode, const char * attr_key, const char * attr_val)
+	    : active(g_trace_enabled) {
+		if (active) OperationBegin(name, mode, attr_key, attr_val);
+	}
+	// `enabled` lets a call site keep the RAII span scoping while opting out
+	// (e.g. the dedicated server never opens a frame trace).
+	Operation(const char * name, Sampling mode, bool enabled)
+	    : active(g_trace_enabled && enabled) {
+		if (active) OperationBegin(name, mode, nullptr, nullptr);
+	}
+	~Operation() { if (active) OperationEnd(); }
+	Operation(const Operation &) = delete;
+	Operation & operator=(const Operation &) = delete;
+};
 
 struct Scope {
 	const char * name;
 	uint64_t start;
-	explicit Scope(const char * n) : name(n), start(g_enabled ? SDL_GetPerformanceCounter() : 0) {}
-	~Scope(){ if(g_enabled) AddSample(name, SDL_GetPerformanceCounter() - start); }
+	bool traced;
+	explicit Scope(const char * n)
+	    : name(n),
+	      start((g_enabled || g_trace_enabled) ? SDL_GetPerformanceCounter() : 0),
+	      traced(false) {
+		if (g_trace_enabled) traced = ScopeBegin(n, start);
+	}
+	~Scope() {
+		if (!g_enabled && !g_trace_enabled) return;
+		uint64_t end = SDL_GetPerformanceCounter();
+		// Feed the per-section aggregate (drives both the stdout line and the
+		// Layer-1 metric gauges); close the span only if one was opened.
+		AddSample(name, end - start);
+		if (traced) ScopeEnd(end);
+	}
 };
 
 } // namespace perf

--- a/clients/silencer/src/render/renderdevice.h
+++ b/clients/silencer/src/render/renderdevice.h
@@ -49,6 +49,10 @@ public:
 	// Skips the render pass silently when the window is minimized.
 	virtual void Present() = 0;
 
+	// Backend driver name for telemetry (e.g. "metal", "vulkan", "direct3d12").
+	// Empty when not applicable (TUI). Best-effort device identity.
+	virtual const char * GpuDriverName() const { return ""; }
+
 	virtual void SetScaleFilter(bool linear) = 0;
 
 	virtual void BeginLobbyPanelBorderBlur(int /*virtualWidth*/,

--- a/clients/silencer/src/render/sdl3gpubackend.cpp
+++ b/clients/silencer/src/render/sdl3gpubackend.cpp
@@ -1162,6 +1162,12 @@ void SDL3GPUBackend::DrawParticles(int handle, Uint32 count) {
 }
 
 // Executes all queued work in a single command buffer.
+const char *SDL3GPUBackend::GpuDriverName() const {
+	if (!device) return "";
+	const char *d = SDL_GetGPUDeviceDriver(device);
+	return d ? d : "";
+}
+
 void SDL3GPUBackend::Present() {
 	if (!device || !remap_pipeline || !upscale_pipeline) return;
 

--- a/clients/silencer/src/render/sdl3gpubackend.h
+++ b/clients/silencer/src/render/sdl3gpubackend.h
@@ -34,6 +34,7 @@ public:
 	void RequestCapture() override;
 	bool TakeCapturedFrame(std::vector<Uint8> &rgba, int &w, int &h) override;
 	void Present() override;
+	const char *GpuDriverName() const override;
 	void SetScaleFilter(bool linear) override;
 	void BeginLobbyPanelBorderBlur(int virtualWidth, int virtualHeight, float uiScale) override;
 	void AddLobbyPanelBorderBlurRect(const SDL_Rect & rect) override;

--- a/docs/silencer-perf-otlp.md
+++ b/docs/silencer-perf-otlp.md
@@ -1,0 +1,117 @@
+# Client perf telemetry → OpenObserve (OTLP)
+
+Two-layer telemetry exported from the Silencer client's perf tracer
+(`clients/silencer/src/platform/perf_trace.{h,cpp}` +
+`perf_otlp.{h,cpp}`) over OTLP/HTTP. **Off by default** — only the
+existing `SILENCER_PERF` stdout path runs unless `SILENCER_PERF_OTLP`
+is set. The two paths are independent.
+
+- **Layer 1 — METRICS** (always-on once enabled, low-cardinality, one
+  flush/second): `fps`, frame-ms `p50/p95/p99`, worst-frame, and
+  per-section avg ms (`ui`, `present`, `sim`, `world.draw`, …). Exported
+  as **OTLP metrics**. Each metric name becomes its own OpenObserve
+  metrics stream (`frame_ms_p95`, `frame_fps`, `ui`, …). This is the
+  signal filter: query it to find slow cohorts, then pull their traces.
+- **Layer 2 — TRACES** (sampled flame graphs). A trace = one logical
+  **operation**:
+  - `startup` — process start → first frame ready (palette + resources
+    load as child spans). Always emitted.
+  - `level_load` — each map load; carries a `map` span attribute. Always
+    emitted.
+  - `frame` — every rendered frame; the existing `PERF_SCOPE`s
+    (`game.tick`, `sim`, `world.draw`, `ui`, `present`) nest under it.
+    **Tail-sampled**: emitted only when `frame_ms > budget × factor`
+    (default `16.67 ms × 2`), plus a 1-in-N baseline (default N=600). So
+    every `frame` trace in OpenObserve is already a hitch.
+
+Operations nest via a thread-local scope stack: a new `PERF_SCOPE`'s
+parent is the top of the stack, so the real hierarchy
+(`ui.gpu_build` → `ui` → `frame`) is preserved.
+
+### Identity / device — OTLP Resource
+
+All constant-per-session identity + device data lives in OTLP **Resource**
+attributes, set once and attached to every span *and* every metric, sent
+once per export request (so the metadata cost amortizes to near-zero — it
+is **not** stamped on every span): `service.name`, `session.id` (fresh
+UUID per launch, also printed to stdout), `account.id` (once lobby auth
+completes), `build.version`, `device.os/gpu/gpu_driver/cpu_cores/ram_mb`,
+`display.resolution/viewport/refresh`, `render.ui_path/vsync/fullscreen`.
+A few of these can change mid-session (viewport/fullscreen/ui_path on
+resize, `account.id` on login) — those bump `session.epoch` so each
+epoch's Resource is internally constant.
+
+Because identity/device live in the Resource, the **same** `session.id`
+filter narrows both the metrics dashboard and the Traces tab.
+
+### Transport
+
+Export runs off the frame thread: a bounded queue + one background curl
+sender doing batched POSTs. Overflow **drops** rather than back-pressuring
+the game — telemetry never stalls a frame.
+
+## Run it locally
+
+### 1. OpenObserve in Docker
+
+```bash
+docker run -d --name openobserve -p 5080:5080 \
+  -e ZO_ROOT_USER_EMAIL="root@example.com" \
+  -e ZO_ROOT_USER_PASSWORD="Complexpass#123" \
+  -v "$HOME/.openobserve-data:/data" -e ZO_DATA_DIR="/data" \
+  public.ecr.aws/zinclabs/openobserve:latest
+```
+
+UI: http://localhost:5080 (login `root@example.com` / `Complexpass#123`).
+OTLP/HTTP endpoints (OpenObserve v0.91, OTLP/JSON, basic auth):
+`POST /api/default/v1/traces` and `/api/default/v1/metrics`.
+
+### 2. Build
+
+```bash
+bash clients/silencer/build.sh        # macOS/Linux, default win-ninja → build/
+```
+
+### 3. Run with export on
+
+```bash
+export SILENCER_PERF_OTLP=http://localhost:5080/api/default
+export SILENCER_PERF_OTLP_USER='root@example.com'
+export SILENCER_PERF_OTLP_PASS='Complexpass#123'
+
+# windowed (real vsync-bound frame times + GPU/display Resource fields):
+clients/silencer/build/Silencer.app/Contents/MacOS/Silencer
+
+# headless, driven to a level_load via the Tutorial:
+BIN=clients/silencer/build/Silencer.app/Contents/MacOS/Silencer
+"$BIN" --headless --control-port 5170 &
+bun clients/cli/index.ts --port 5170 wait_for_state --state MAINMENU --timeout-ms 20000
+bun clients/cli/index.ts --port 5170 click --label Tutorial
+bun clients/cli/index.ts --port 5170 wait_for_state --state SINGLEPLAYERGAME --timeout-ms 20000
+```
+
+The session id is printed at startup:
+`[perf] OTLP export -> … | session.id=<uuid>`.
+
+Optional tuning env: `SILENCER_PERF_FRAME_BUDGET_MS` (default 16.67),
+`SILENCER_PERF_FRAME_OVER_FACTOR` (default 2.0),
+`SILENCER_PERF_FRAME_BASELINE_N` (default 600). Auth alternative to
+USER/PASS: `SILENCER_PERF_OTLP_AUTH=<verbatim Authorization header>`.
+
+### 4. View both layers
+
+Streams auto-appear once data arrives.
+
+- **Layer 1 — Dashboards.** A starter dashboard "Silencer Client Perf
+  (Layer 1)" ships two panels: `frame_ms_p95` over time, and avg p95
+  grouped by `device.gpu` / `device.os`. To rebuild by hand, add a panel
+  on the `frame_ms_p95` **metrics** stream with X = `histogram(_timestamp)`,
+  Y = `avg(value)`; group the second by `concat(device_gpu,' / ',device_os)`.
+- **Layer 2 — Traces tab.** Filter by resource attributes + duration,
+  e.g. `operation_name='frame' AND service_device_gpu='metal' AND
+  duration > 33000` (duration is µs). Click a trace → flame graph with the
+  nested scopes. Roots are `startup`, `level_load`, and over-budget
+  `frame`.
+- **One session across both layers.** Metrics filter field is
+  `session_id`; traces filter field is `service_session_id` (OpenObserve
+  prefixes trace Resource attrs with `service_`). Same UUID, both layers.


### PR DESCRIPTION
**Status: WIP / draft.** Exports the client perf tracer to OpenObserve over OTLP/HTTP — two layers, off by default behind `SILENCER_PERF_OTLP`, independent of the existing `SILENCER_PERF` stdout path. The pipeline works end to end locally, but the telemetry *content* is not yet validated (see "Not done").

Closes #308.

## What works
- **Transport**: opt-in `SILENCER_PERF_OTLP=<base-url>`; off by default (single bool test, no overhead). Export off the frame thread — bounded queue + one background curl sender, drops on overflow, never stalls a frame.
- **Layer 1 — metrics** (OTLP metrics, one flush/sec): fps, frame-ms p50/p95/p99, worst-frame, per-section avg ms. The startup load is excluded from frame-ms (it's the `startup` trace, not a frame).
- **Layer 2 — traces** (operation = trace): `perf::Operation` opens a trace root; existing `PERF_SCOPE`s nest under it via a thread-local scope stack. Operations: `startup`, `level_load` (always emitted; carries a `map` attr), `frame` (tail-sampled — over-budget + 1-in-N baseline). Absolute Unix-ns timestamps via a wall-clock anchor over the monotonic perf counter.
- **Identity/device** in the OTLP **Resource** (set once, batched once per POST, never per-span); `session.epoch` bumps on viewport/fullscreen/ui_path/account change. `session.id` logged at startup.
- Verified the data *lands and is queryable/filterable*: metrics streams + traces stream populate; a single `session.id` narrows both layers; windowed run fills `device.gpu`/`display.*`; windowed steady-state reads ~7.6 ms p50 @ ~120 Hz after the startup-skew fix.

## Files
`perf_trace.{h,cpp}` (operation/scope-stack/metrics engine), new `perf_otlp.{h,cpp}` (Resource, queue, sender, OTLP/JSON), `game_init.cpp` / `game_loop.cpp` / `game_session.cpp` (instrumentation), `renderdevice.h` + `sdl3gpubackend.*` (`GpuDriverName()`), `CMakeLists.txt`. How-to-run: `docs/silencer-perf-otlp.md`.

## Not done (before un-drafting)
- [ ] **Actual useful dashboards.** A starter dashboard exists (FPS, p50/p95/p99, worst-frame, per-section, with a `session.id` picker) but the panel set / layout / defaults still need a real design pass — what's worth watching, sensible time ranges, cohort comparison. Not yet considered "good".
- [ ] **Validate the spans are actually useful.** The chosen scope set (`startup.palette`/`startup.resources`, `level.map_parse`/`level.ambience`, the existing frame scopes) was picked structurally, not from real debugging need. Need to confirm the flame graphs answer real questions and add/remove/re-nest scopes where they don't (e.g. resource load is one opaque ~1.5 s span — probably wants breaking down).

## Known caveats
- Headless free-runs uncapped (no vsync) — only windowed runs give real frame times.
- `device.cpu` (model) left empty; `device.gpu`/`gpu_driver` report the SDL GPU driver (e.g. `metal`), not the adapter name.
- Frame-budget threshold default 16.67 ms × 2; tunable via env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)